### PR TITLE
feat(ui): full UI with landing page, scanner, and end-to-end wiring

### DIFF
--- a/src/lib/components/landing/Features.svelte
+++ b/src/lib/components/landing/Features.svelte
@@ -1,0 +1,183 @@
+<script lang="ts">
+	const features = [
+		{
+			icon: '🎯',
+			title: 'real ATS simulation',
+			description:
+				'scores your resume against 6 actual ATS systems used by Fortune 500 companies. not a generic algorithm.'
+		},
+		{
+			icon: '🔍',
+			title: 'keyword intelligence',
+			description:
+				'exact, fuzzy, and semantic matching strategies that mirror how each system actually filters resumes.'
+		},
+		{
+			icon: '📊',
+			title: 'detailed breakdown',
+			description:
+				'see exactly why each system scores you the way it does. formatting, keywords, sections, experience, education.'
+		},
+		{
+			icon: '🤖',
+			title: 'AI-powered suggestions',
+			description:
+				'Gemini-powered analysis gives you specific, actionable tips. falls back to rule-based when offline.'
+		},
+		{
+			icon: '🌍',
+			title: 'any industry',
+			description:
+				'works for tech, finance, healthcare, marketing, legal, operations, education, and more. not just software.'
+		},
+		{
+			icon: '💰',
+			title: 'actually free',
+			description:
+				'no sign-up, no paywall, no "premium tier". everything runs client-side or on free infrastructure.'
+		}
+	];
+
+	// per-card mouse position for independent spotlight effects
+	let mousePositions = $state<Record<number, { x: number; y: number }>>({});
+
+	function handleCardMouseMove(e: MouseEvent, index: number) {
+		const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+		mousePositions[index] = {
+			x: e.clientX - rect.left,
+			y: e.clientY - rect.top
+		};
+	}
+</script>
+
+<section class="features" id="features">
+	<div class="features-header">
+		<h2 class="section-title">not another fake ATS score</h2>
+		<p class="section-description">
+			most ATS screeners use arbitrary algorithms with no connection to real systems. this one
+			simulates what actually happens to your resume.
+		</p>
+	</div>
+
+	<div class="features-grid">
+		{#each features as feature, i}
+			<!-- svelte-ignore a11y_no_static_element_interactions -->
+			<div
+				class="feature-card"
+				onmousemove={(e) => handleCardMouseMove(e, i)}
+				style="--spotlight-x: {mousePositions[i]?.x ?? 0}px; --spotlight-y: {mousePositions[i]?.y ??
+					0}px;"
+			>
+				<div class="feature-spotlight"></div>
+				<div class="feature-content">
+					<span class="feature-icon">{feature.icon}</span>
+					<h3>{feature.title}</h3>
+					<p>{feature.description}</p>
+				</div>
+			</div>
+		{/each}
+	</div>
+</section>
+
+<style>
+	.features {
+		padding: 6rem 2rem;
+		max-width: 1200px;
+		margin: 0 auto;
+	}
+
+	.features-header {
+		text-align: center;
+		margin-bottom: 4rem;
+	}
+
+	.section-title {
+		font-size: clamp(1.75rem, 4vw, 2.5rem);
+		font-weight: 700;
+		color: var(--text-primary);
+		margin-bottom: 1rem;
+	}
+
+	.section-description {
+		font-size: 1.1rem;
+		color: var(--text-secondary);
+		max-width: 600px;
+		margin: 0 auto;
+		line-height: 1.6;
+	}
+
+	.features-grid {
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+		gap: 1.5rem;
+	}
+
+	.feature-card {
+		position: relative;
+		padding: 2rem;
+		background: var(--glass-bg);
+		border: 1px solid var(--glass-border);
+		border-radius: var(--radius-xl);
+		backdrop-filter: blur(var(--glass-blur));
+		overflow: hidden;
+		transition:
+			border-color 0.3s ease,
+			transform 0.2s ease;
+	}
+
+	.feature-card:hover {
+		border-color: rgba(6, 182, 212, 0.2);
+		transform: translateY(-2px);
+	}
+
+	.feature-spotlight {
+		position: absolute;
+		inset: 0;
+		background: radial-gradient(
+			300px circle at var(--spotlight-x) var(--spotlight-y),
+			rgba(6, 182, 212, 0.06),
+			transparent 60%
+		);
+		pointer-events: none;
+		opacity: 0;
+		transition: opacity 0.3s ease;
+	}
+
+	.feature-card:hover .feature-spotlight {
+		opacity: 1;
+	}
+
+	.feature-content {
+		position: relative;
+		z-index: 1;
+	}
+
+	.feature-icon {
+		font-size: 2rem;
+		display: block;
+		margin-bottom: 1rem;
+	}
+
+	.feature-content h3 {
+		font-size: 1.15rem;
+		font-weight: 600;
+		color: var(--text-primary);
+		margin-bottom: 0.5rem;
+	}
+
+	.feature-content p {
+		font-size: 0.95rem;
+		color: var(--text-secondary);
+		line-height: 1.5;
+	}
+
+	@media (max-width: 640px) {
+		.features {
+			padding: 4rem 1.5rem;
+		}
+
+		.features-grid {
+			grid-template-columns: 1fr;
+		}
+	}
+</style>

--- a/src/lib/components/landing/Footer.svelte
+++ b/src/lib/components/landing/Footer.svelte
@@ -1,0 +1,89 @@
+<section class="footer">
+	<div class="footer-content">
+		<div class="footer-brand">
+			<span class="gradient-text">ATS Screener</span>
+			<p>free ATS resume screener. built by a student, for students.</p>
+		</div>
+		<div class="footer-links">
+			<a href="https://github.com/sunnypatell/ats-screener" target="_blank" rel="noopener">
+				GitHub
+			</a>
+			<a href="/scanner">Scanner</a>
+		</div>
+	</div>
+	<div class="footer-bottom">
+		<p>&copy; {new Date().getFullYear()} Sunny Patel. MIT License.</p>
+	</div>
+</section>
+
+<style>
+	.footer {
+		padding: 4rem 2rem 2rem;
+		border-top: 1px solid var(--glass-border);
+	}
+
+	.footer-content {
+		max-width: 1200px;
+		margin: 0 auto;
+		display: flex;
+		justify-content: space-between;
+		align-items: flex-start;
+		gap: 2rem;
+		margin-bottom: 2rem;
+	}
+
+	.footer-brand {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+	}
+
+	.gradient-text {
+		font-size: 1.25rem;
+		font-weight: 700;
+		background: var(--gradient-primary);
+		-webkit-background-clip: text;
+		-webkit-text-fill-color: transparent;
+		background-clip: text;
+	}
+
+	.footer-brand p {
+		font-size: 0.9rem;
+		color: var(--text-tertiary);
+	}
+
+	.footer-links {
+		display: flex;
+		gap: 1.5rem;
+	}
+
+	.footer-links a {
+		color: var(--text-secondary);
+		text-decoration: none;
+		font-size: 0.9rem;
+		transition: color 0.2s ease;
+	}
+
+	.footer-links a:hover {
+		color: var(--accent-cyan);
+	}
+
+	.footer-bottom {
+		max-width: 1200px;
+		margin: 0 auto;
+		padding-top: 1.5rem;
+		border-top: 1px solid var(--glass-border);
+	}
+
+	.footer-bottom p {
+		font-size: 0.8rem;
+		color: var(--text-tertiary);
+		text-align: center;
+	}
+
+	@media (max-width: 640px) {
+		.footer-content {
+			flex-direction: column;
+		}
+	}
+</style>

--- a/src/lib/components/landing/Hero.svelte
+++ b/src/lib/components/landing/Hero.svelte
@@ -1,0 +1,265 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+
+	// delays fade-in until hydrated to prevent flash
+	let mounted = $state(false);
+	// mouse position as % for the radial glow gradient
+	let mouseX = $state(0);
+	let mouseY = $state(0);
+
+	onMount(() => {
+		mounted = true;
+	});
+
+	// converts pixel coords to percentage of hero bounds for the glow
+	function handleMouseMove(e: MouseEvent) {
+		const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+		mouseX = ((e.clientX - rect.left) / rect.width) * 100;
+		mouseY = ((e.clientY - rect.top) / rect.height) * 100;
+	}
+</script>
+
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<section class="hero" class:mounted onmousemove={handleMouseMove}>
+	<div class="hero-glow" style="--mx: {mouseX}%; --my: {mouseY}%;"></div>
+
+	<div class="hero-content">
+		<div class="badge">
+			<span class="badge-dot"></span>
+			free forever. no sign-up. no limits.
+		</div>
+
+		<h1 class="hero-title">
+			<span class="gradient-text">Beat the ATS.</span>
+			<br />
+			Get Interviewed.
+		</h1>
+
+		<p class="hero-description">
+			simulate how Workday, Taleo, iCIMS, Greenhouse, Lever, and SuccessFactors actually parse your
+			resume. get a real score, not a made-up number.
+		</p>
+
+		<div class="hero-actions">
+			<a href="/scanner" class="btn-primary">
+				<span class="btn-shimmer"></span>
+				scan your resume
+			</a>
+		</div>
+
+		<div class="hero-stats">
+			<div class="stat">
+				<span class="stat-number">6</span>
+				<span class="stat-label">ATS systems</span>
+			</div>
+			<div class="stat-divider"></div>
+			<div class="stat">
+				<span class="stat-number">100%</span>
+				<span class="stat-label">free</span>
+			</div>
+			<div class="stat-divider"></div>
+			<div class="stat">
+				<span class="stat-number">any</span>
+				<span class="stat-label">industry</span>
+			</div>
+		</div>
+	</div>
+</section>
+
+<style>
+	.hero {
+		position: relative;
+		min-height: 100vh;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		padding: 6rem 2rem 4rem;
+		overflow: hidden;
+	}
+
+	.hero-glow {
+		position: absolute;
+		inset: 0;
+		background: radial-gradient(
+			600px circle at var(--mx, 50%) var(--my, 50%),
+			rgba(6, 182, 212, 0.08),
+			transparent 60%
+		);
+		transition: background 0.3s ease;
+		pointer-events: none;
+	}
+
+	.hero-content {
+		position: relative;
+		max-width: 800px;
+		text-align: center;
+		opacity: 0;
+		transform: translateY(30px);
+		transition:
+			opacity 0.8s ease,
+			transform 0.8s ease;
+	}
+
+	.mounted .hero-content {
+		opacity: 1;
+		transform: translateY(0);
+	}
+
+	.badge {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.5rem;
+		padding: 0.5rem 1rem;
+		background: var(--glass-bg);
+		border: 1px solid var(--glass-border);
+		border-radius: 999px;
+		font-size: 0.85rem;
+		color: var(--text-secondary);
+		margin-bottom: 2rem;
+		backdrop-filter: blur(12px);
+	}
+
+	.badge-dot {
+		width: 6px;
+		height: 6px;
+		border-radius: 50%;
+		background: var(--accent-cyan);
+		animation: pulse 2s ease-in-out infinite;
+	}
+
+	@keyframes pulse {
+		0%,
+		100% {
+			opacity: 1;
+			box-shadow: 0 0 0 0 rgba(6, 182, 212, 0.4);
+		}
+		50% {
+			opacity: 0.8;
+			box-shadow: 0 0 0 6px rgba(6, 182, 212, 0);
+		}
+	}
+
+	.hero-title {
+		font-size: clamp(2.5rem, 8vw, 5rem);
+		font-weight: 800;
+		line-height: 1.1;
+		margin-bottom: 1.5rem;
+		letter-spacing: -0.03em;
+		color: var(--text-primary);
+	}
+
+	.gradient-text {
+		background: var(--gradient-primary);
+		-webkit-background-clip: text;
+		-webkit-text-fill-color: transparent;
+		background-clip: text;
+	}
+
+	.hero-description {
+		font-size: clamp(1rem, 2vw, 1.25rem);
+		color: var(--text-secondary);
+		max-width: 600px;
+		margin: 0 auto 2.5rem;
+		line-height: 1.6;
+	}
+
+	.hero-actions {
+		margin-bottom: 3rem;
+	}
+
+	.btn-primary {
+		position: relative;
+		display: inline-flex;
+		align-items: center;
+		padding: 1rem 2.5rem;
+		font-size: 1.1rem;
+		font-weight: 600;
+		color: var(--color-bg-primary);
+		background: var(--gradient-primary);
+		border: none;
+		border-radius: var(--radius-lg);
+		cursor: pointer;
+		text-decoration: none;
+		overflow: hidden;
+		transition:
+			transform 0.2s ease,
+			box-shadow 0.2s ease;
+	}
+
+	.btn-primary:hover {
+		transform: translateY(-2px);
+		box-shadow:
+			0 0 30px rgba(6, 182, 212, 0.3),
+			0 0 60px rgba(59, 130, 246, 0.15);
+	}
+
+	.btn-shimmer {
+		position: absolute;
+		inset: 0;
+		background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.2), transparent);
+		animation: shimmer 3s ease-in-out infinite;
+	}
+
+	@keyframes shimmer {
+		0% {
+			transform: translateX(-100%);
+		}
+		100% {
+			transform: translateX(100%);
+		}
+	}
+
+	.hero-stats {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		gap: 2rem;
+		padding: 1.5rem 2rem;
+		background: var(--glass-bg);
+		border: 1px solid var(--glass-border);
+		border-radius: var(--radius-xl);
+		backdrop-filter: blur(var(--glass-blur));
+	}
+
+	.stat {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 0.25rem;
+	}
+
+	.stat-number {
+		font-size: 1.5rem;
+		font-weight: 700;
+		color: var(--accent-cyan);
+	}
+
+	.stat-label {
+		font-size: 0.8rem;
+		color: var(--text-tertiary);
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+	}
+
+	.stat-divider {
+		width: 1px;
+		height: 2.5rem;
+		background: var(--glass-border);
+	}
+
+	@media (max-width: 640px) {
+		.hero {
+			padding: 4rem 1.5rem 3rem;
+		}
+
+		.hero-stats {
+			flex-direction: column;
+			gap: 1rem;
+		}
+
+		.stat-divider {
+			width: 3rem;
+			height: 1px;
+		}
+	}
+</style>

--- a/src/lib/components/landing/HowItWorks.svelte
+++ b/src/lib/components/landing/HowItWorks.svelte
@@ -1,0 +1,124 @@
+<script lang="ts">
+	const steps = [
+		{
+			number: '01',
+			title: 'upload your resume',
+			description:
+				'PDF or DOCX. everything is parsed client-side. your file never leaves your browser.'
+		},
+		{
+			number: '02',
+			title: 'optionally add a job description',
+			description:
+				'paste the JD for targeted scoring. without it, you get a general ATS-readiness score.'
+		},
+		{
+			number: '03',
+			title: 'get scored by 6 systems',
+			description:
+				'Workday, Taleo, iCIMS, Greenhouse, Lever, SuccessFactors. each with different weights and strategies.'
+		},
+		{
+			number: '04',
+			title: 'see what to fix',
+			description:
+				'detailed breakdown per system: formatting, keywords, sections, experience, education. plus actionable suggestions.'
+		}
+	];
+</script>
+
+<section class="how-it-works">
+	<div class="section-header">
+		<h2 class="section-title">how it works</h2>
+	</div>
+
+	<div class="steps">
+		{#each steps as step, i}
+			<div class="step" style="--delay: {i * 0.1}s">
+				<div class="step-number">{step.number}</div>
+				<div class="step-content">
+					<h3>{step.title}</h3>
+					<p>{step.description}</p>
+				</div>
+				{#if i < steps.length - 1}
+					<div class="step-connector"></div>
+				{/if}
+			</div>
+		{/each}
+	</div>
+</section>
+
+<style>
+	.how-it-works {
+		padding: 6rem 2rem;
+		max-width: 800px;
+		margin: 0 auto;
+	}
+
+	.section-header {
+		text-align: center;
+		margin-bottom: 4rem;
+	}
+
+	.section-title {
+		font-size: clamp(1.75rem, 4vw, 2.5rem);
+		font-weight: 700;
+		color: var(--text-primary);
+	}
+
+	.steps {
+		display: flex;
+		flex-direction: column;
+		gap: 0;
+	}
+
+	.step {
+		position: relative;
+		display: flex;
+		gap: 1.5rem;
+		padding: 2rem 0;
+	}
+
+	.step-number {
+		flex-shrink: 0;
+		width: 3rem;
+		height: 3rem;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		font-size: 1rem;
+		font-weight: 700;
+		color: var(--accent-cyan);
+		background: rgba(6, 182, 212, 0.1);
+		border: 1px solid rgba(6, 182, 212, 0.2);
+		border-radius: var(--radius-md);
+	}
+
+	.step-content h3 {
+		font-size: 1.2rem;
+		font-weight: 600;
+		color: var(--text-primary);
+		margin-bottom: 0.5rem;
+	}
+
+	.step-content p {
+		font-size: 0.95rem;
+		color: var(--text-secondary);
+		line-height: 1.5;
+	}
+
+	.step-connector {
+		position: absolute;
+		left: 1.5rem;
+		top: 5rem;
+		width: 1px;
+		height: calc(100% - 5rem + 2rem);
+		background: linear-gradient(to bottom, rgba(6, 182, 212, 0.3), transparent);
+	}
+
+	@media (max-width: 640px) {
+		.how-it-works {
+			padding: 4rem 1.5rem;
+		}
+	}
+</style>

--- a/src/lib/components/scoring/ScoreCard.svelte
+++ b/src/lib/components/scoring/ScoreCard.svelte
@@ -1,0 +1,291 @@
+<script lang="ts">
+	import type { ScoreResult } from '$engine/scorer/types';
+
+	let { result }: { result: ScoreResult } = $props();
+
+	// mouse position in px for the spotlight hover effect
+	let mouseX = $state(0);
+	let mouseY = $state(0);
+
+	function handleMouseMove(e: MouseEvent) {
+		const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+		mouseX = e.clientX - rect.left;
+		mouseY = e.clientY - rect.top;
+	}
+
+	// maps score ranges to colors: green/yellow/orange/red
+	function getScoreColor(score: number): string {
+		if (score >= 80) return '#22c55e';
+		if (score >= 60) return '#eab308';
+		if (score >= 40) return '#f97316';
+		return '#ef4444';
+	}
+
+	const scoreColor = $derived(getScoreColor(result.overallScore));
+	// svg circle math: circumference and dash offset for the ring progress
+	const circumference = 2 * Math.PI * 42;
+	const offset = $derived(circumference - (result.overallScore / 100) * circumference);
+</script>
+
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div
+	class="score-card"
+	class:passing={result.passesFilter}
+	class:failing={!result.passesFilter}
+	onmousemove={handleMouseMove}
+	style="--spotlight-x: {mouseX}px; --spotlight-y: {mouseY}px;"
+>
+	<div class="card-spotlight"></div>
+
+	<div class="card-header">
+		<div>
+			<h3 class="system-name">{result.system}</h3>
+			<p class="system-vendor">{result.vendor}</p>
+		</div>
+		<div class="score-ring">
+			<svg viewBox="0 0 100 100" width="72" height="72">
+				<circle cx="50" cy="50" r="42" fill="none" stroke="var(--glass-border)" stroke-width="6" />
+				<circle
+					cx="50"
+					cy="50"
+					r="42"
+					fill="none"
+					stroke={scoreColor}
+					stroke-width="6"
+					stroke-dasharray={circumference}
+					stroke-dashoffset={offset}
+					stroke-linecap="round"
+					transform="rotate(-90 50 50)"
+					class="score-progress"
+				/>
+			</svg>
+			<span class="score-value" style="color: {scoreColor}">
+				{result.overallScore}
+			</span>
+		</div>
+	</div>
+
+	<div class="card-status">
+		{#if result.passesFilter}
+			<span class="status-badge pass">likely to pass</span>
+		{:else}
+			<span class="status-badge fail">may be filtered</span>
+		{/if}
+	</div>
+
+	<div class="card-breakdown">
+		<div class="breakdown-item">
+			<span class="breakdown-label">formatting</span>
+			<div class="breakdown-bar">
+				<div
+					class="breakdown-fill"
+					style="width: {result.breakdown.formatting.score}%; background: {getScoreColor(
+						result.breakdown.formatting.score
+					)}"
+				></div>
+			</div>
+			<span class="breakdown-value">{result.breakdown.formatting.score}</span>
+		</div>
+		<div class="breakdown-item">
+			<span class="breakdown-label">keywords</span>
+			<div class="breakdown-bar">
+				<div
+					class="breakdown-fill"
+					style="width: {result.breakdown.keywordMatch.score}%; background: {getScoreColor(
+						result.breakdown.keywordMatch.score
+					)}"
+				></div>
+			</div>
+			<span class="breakdown-value">{result.breakdown.keywordMatch.score}</span>
+		</div>
+		<div class="breakdown-item">
+			<span class="breakdown-label">sections</span>
+			<div class="breakdown-bar">
+				<div
+					class="breakdown-fill"
+					style="width: {result.breakdown.sections.score}%; background: {getScoreColor(
+						result.breakdown.sections.score
+					)}"
+				></div>
+			</div>
+			<span class="breakdown-value">{result.breakdown.sections.score}</span>
+		</div>
+		<div class="breakdown-item">
+			<span class="breakdown-label">experience</span>
+			<div class="breakdown-bar">
+				<div
+					class="breakdown-fill"
+					style="width: {result.breakdown.experience.score}%; background: {getScoreColor(
+						result.breakdown.experience.score
+					)}"
+				></div>
+			</div>
+			<span class="breakdown-value">{result.breakdown.experience.score}</span>
+		</div>
+		<div class="breakdown-item">
+			<span class="breakdown-label">education</span>
+			<div class="breakdown-bar">
+				<div
+					class="breakdown-fill"
+					style="width: {result.breakdown.education.score}%; background: {getScoreColor(
+						result.breakdown.education.score
+					)}"
+				></div>
+			</div>
+			<span class="breakdown-value">{result.breakdown.education.score}</span>
+		</div>
+	</div>
+</div>
+
+<style>
+	.score-card {
+		position: relative;
+		padding: 1.5rem;
+		background: var(--glass-bg);
+		border: 1px solid var(--glass-border);
+		border-radius: var(--radius-xl);
+		backdrop-filter: blur(var(--glass-blur));
+		overflow: hidden;
+		transition:
+			border-color 0.3s ease,
+			transform 0.2s ease;
+	}
+
+	.score-card:hover {
+		transform: translateY(-2px);
+	}
+
+	.score-card.passing:hover {
+		border-color: rgba(34, 197, 94, 0.3);
+	}
+
+	.score-card.failing:hover {
+		border-color: rgba(239, 68, 68, 0.3);
+	}
+
+	.card-spotlight {
+		position: absolute;
+		inset: 0;
+		background: radial-gradient(
+			250px circle at var(--spotlight-x) var(--spotlight-y),
+			rgba(6, 182, 212, 0.05),
+			transparent 60%
+		);
+		pointer-events: none;
+		opacity: 0;
+		transition: opacity 0.3s ease;
+	}
+
+	.score-card:hover .card-spotlight {
+		opacity: 1;
+	}
+
+	.card-header {
+		display: flex;
+		justify-content: space-between;
+		align-items: flex-start;
+		margin-bottom: 1rem;
+		position: relative;
+		z-index: 1;
+	}
+
+	.system-name {
+		font-size: 1.15rem;
+		font-weight: 600;
+		color: var(--text-primary);
+	}
+
+	.system-vendor {
+		font-size: 0.8rem;
+		color: var(--text-tertiary);
+		margin-top: 0.25rem;
+	}
+
+	.score-ring {
+		position: relative;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+	}
+
+	.score-value {
+		position: absolute;
+		font-size: 1.25rem;
+		font-weight: 700;
+	}
+
+	.score-progress {
+		transition: stroke-dashoffset 1s ease;
+	}
+
+	.card-status {
+		margin-bottom: 1rem;
+		position: relative;
+		z-index: 1;
+	}
+
+	.status-badge {
+		display: inline-block;
+		padding: 0.25rem 0.75rem;
+		border-radius: 999px;
+		font-size: 0.75rem;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.03em;
+	}
+
+	.status-badge.pass {
+		background: rgba(34, 197, 94, 0.1);
+		color: #22c55e;
+		border: 1px solid rgba(34, 197, 94, 0.2);
+	}
+
+	.status-badge.fail {
+		background: rgba(239, 68, 68, 0.1);
+		color: #ef4444;
+		border: 1px solid rgba(239, 68, 68, 0.2);
+	}
+
+	.card-breakdown {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+		position: relative;
+		z-index: 1;
+	}
+
+	.breakdown-item {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+	}
+
+	.breakdown-label {
+		font-size: 0.75rem;
+		color: var(--text-tertiary);
+		width: 80px;
+		flex-shrink: 0;
+	}
+
+	.breakdown-bar {
+		flex: 1;
+		height: 4px;
+		background: rgba(255, 255, 255, 0.05);
+		border-radius: 2px;
+		overflow: hidden;
+	}
+
+	.breakdown-fill {
+		height: 100%;
+		border-radius: 2px;
+		transition: width 1s ease;
+	}
+
+	.breakdown-value {
+		font-size: 0.75rem;
+		color: var(--text-secondary);
+		width: 24px;
+		text-align: right;
+		flex-shrink: 0;
+	}
+</style>

--- a/src/lib/components/scoring/ScoreDashboard.svelte
+++ b/src/lib/components/scoring/ScoreDashboard.svelte
@@ -1,0 +1,200 @@
+<script lang="ts">
+	import { scoresStore } from '$stores/scores.svelte';
+	import ScoreCard from './ScoreCard.svelte';
+
+	// derived stats for the summary card header
+	const avgScore = $derived(scoresStore.averageScore);
+	const passCount = $derived(scoresStore.passingCount);
+	const totalCount = $derived(scoresStore.results.length);
+</script>
+
+{#if scoresStore.hasResults}
+	<div class="dashboard">
+		<div class="dashboard-header">
+			<div class="summary-card">
+				<div class="summary-score">
+					<span class="score-number">{avgScore}</span>
+					<span class="score-label">avg score</span>
+				</div>
+				<div class="summary-stats">
+					<div class="pass-rate">
+						<span class="pass-count">{passCount}/{totalCount}</span>
+						<span class="pass-label">systems passed</span>
+					</div>
+					<div class="mode-badge">
+						{scoresStore.mode === 'targeted' ? 'targeted scoring' : 'general readiness'}
+					</div>
+				</div>
+			</div>
+
+			{#if scoresStore.llmFallback}
+				<p class="fallback-notice">
+					using rule-based analysis (LLM unavailable). results are still accurate but suggestions
+					may be less specific.
+				</p>
+			{/if}
+		</div>
+
+		<div class="scores-grid">
+			{#each scoresStore.results as result (result.system)}
+				<ScoreCard {result} />
+			{/each}
+		</div>
+
+		<!-- deduplicated suggestions from all 6 ATS profiles -->
+		{#if scoresStore.results.some((r) => r.suggestions.length > 0)}
+			<div class="suggestions-section">
+				<h3 class="suggestions-title">suggestions</h3>
+				<div class="suggestions-list">
+					{#each [...new Set(scoresStore.results.flatMap((r) => r.suggestions))] as suggestion}
+						<div class="suggestion-item">
+							<span class="suggestion-bullet">&#8250;</span>
+							{suggestion}
+						</div>
+					{/each}
+				</div>
+			</div>
+		{/if}
+	</div>
+{/if}
+
+<style>
+	.dashboard {
+		margin-top: 2rem;
+	}
+
+	.dashboard-header {
+		margin-bottom: 2rem;
+	}
+
+	.summary-card {
+		display: flex;
+		align-items: center;
+		gap: 2rem;
+		padding: 1.5rem 2rem;
+		background: var(--glass-bg);
+		border: 1px solid var(--glass-border);
+		border-radius: var(--radius-xl);
+		backdrop-filter: blur(var(--glass-blur));
+	}
+
+	.summary-score {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+	}
+
+	.score-number {
+		font-size: 3rem;
+		font-weight: 800;
+		background: var(--gradient-primary);
+		-webkit-background-clip: text;
+		-webkit-text-fill-color: transparent;
+		background-clip: text;
+		line-height: 1;
+	}
+
+	.score-label {
+		font-size: 0.8rem;
+		color: var(--text-tertiary);
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+	}
+
+	.summary-stats {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+	}
+
+	.pass-rate {
+		display: flex;
+		align-items: baseline;
+		gap: 0.5rem;
+	}
+
+	.pass-count {
+		font-size: 1.25rem;
+		font-weight: 600;
+		color: var(--text-primary);
+	}
+
+	.pass-label {
+		font-size: 0.85rem;
+		color: var(--text-tertiary);
+	}
+
+	.mode-badge {
+		display: inline-block;
+		padding: 0.25rem 0.75rem;
+		background: rgba(6, 182, 212, 0.1);
+		border: 1px solid rgba(6, 182, 212, 0.2);
+		border-radius: 999px;
+		font-size: 0.75rem;
+		color: var(--accent-cyan);
+		width: fit-content;
+	}
+
+	.fallback-notice {
+		margin-top: 0.75rem;
+		font-size: 0.85rem;
+		color: var(--text-tertiary);
+		padding: 0.5rem 1rem;
+		background: rgba(234, 179, 8, 0.05);
+		border: 1px solid rgba(234, 179, 8, 0.15);
+		border-radius: var(--radius-md);
+	}
+
+	.scores-grid {
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
+		gap: 1.5rem;
+	}
+
+	.suggestions-section {
+		margin-top: 2rem;
+		padding: 1.5rem;
+		background: var(--glass-bg);
+		border: 1px solid var(--glass-border);
+		border-radius: var(--radius-xl);
+		backdrop-filter: blur(var(--glass-blur));
+	}
+
+	.suggestions-title {
+		font-size: 1.1rem;
+		font-weight: 600;
+		color: var(--text-primary);
+		margin-bottom: 1rem;
+	}
+
+	.suggestions-list {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+	}
+
+	.suggestion-item {
+		display: flex;
+		gap: 0.5rem;
+		font-size: 0.9rem;
+		color: var(--text-secondary);
+		line-height: 1.5;
+	}
+
+	.suggestion-bullet {
+		color: var(--accent-cyan);
+		flex-shrink: 0;
+		font-weight: bold;
+	}
+
+	@media (max-width: 640px) {
+		.summary-card {
+			flex-direction: column;
+			text-align: center;
+		}
+
+		.scores-grid {
+			grid-template-columns: 1fr;
+		}
+	}
+</style>

--- a/src/lib/components/ui/Navbar.svelte
+++ b/src/lib/components/ui/Navbar.svelte
@@ -1,0 +1,150 @@
+<script lang="ts">
+	import { page } from '$app/stores';
+
+	// controls the mobile menu visibility
+	let mobileOpen = $state(false);
+
+	// highlight the active route
+	const currentPath = $derived($page.url.pathname);
+</script>
+
+<nav class="navbar">
+	<div class="nav-inner">
+		<a href="/" class="nav-brand">
+			<span class="gradient-text">ATS Screener</span>
+		</a>
+
+		<div class="nav-links" class:open={mobileOpen}>
+			<a href="/" class="nav-link" class:active={currentPath === '/'}>home</a>
+			<a href="/scanner" class="nav-link" class:active={currentPath === '/scanner'}>scanner</a>
+			<a
+				href="https://github.com/sunnypatell/ats-screener"
+				target="_blank"
+				rel="noopener"
+				class="nav-link"
+			>
+				github
+			</a>
+		</div>
+
+		<!-- mobile hamburger -->
+		<button
+			class="nav-toggle"
+			onclick={() => (mobileOpen = !mobileOpen)}
+			aria-label="toggle navigation"
+		>
+			<span class="bar" class:open={mobileOpen}></span>
+			<span class="bar" class:open={mobileOpen}></span>
+			<span class="bar" class:open={mobileOpen}></span>
+		</button>
+	</div>
+</nav>
+
+<style>
+	.navbar {
+		position: fixed;
+		top: 0;
+		left: 0;
+		right: 0;
+		z-index: 100;
+		padding: 1rem 2rem;
+		background: rgba(10, 10, 20, 0.8);
+		backdrop-filter: blur(20px);
+		border-bottom: 1px solid var(--glass-border);
+	}
+
+	.nav-inner {
+		max-width: 1200px;
+		margin: 0 auto;
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+	}
+
+	.nav-brand {
+		text-decoration: none;
+	}
+
+	.gradient-text {
+		font-size: 1.15rem;
+		font-weight: 700;
+		background: var(--gradient-primary);
+		-webkit-background-clip: text;
+		-webkit-text-fill-color: transparent;
+		background-clip: text;
+	}
+
+	.nav-links {
+		display: flex;
+		gap: 2rem;
+	}
+
+	.nav-link {
+		color: var(--text-secondary);
+		text-decoration: none;
+		font-size: 0.9rem;
+		font-weight: 500;
+		transition: color 0.2s ease;
+	}
+
+	.nav-link:hover,
+	.nav-link.active {
+		color: var(--text-primary);
+	}
+
+	.nav-toggle {
+		display: none;
+		flex-direction: column;
+		gap: 4px;
+		background: none;
+		border: none;
+		cursor: pointer;
+		padding: 4px;
+	}
+
+	.bar {
+		width: 20px;
+		height: 2px;
+		background: var(--text-secondary);
+		border-radius: 1px;
+		transition:
+			transform 0.3s ease,
+			opacity 0.3s ease;
+	}
+
+	/* hamburger → X animation */
+	.bar.open:nth-child(1) {
+		transform: rotate(45deg) translate(4px, 4px);
+	}
+	.bar.open:nth-child(2) {
+		opacity: 0;
+	}
+	.bar.open:nth-child(3) {
+		transform: rotate(-45deg) translate(4px, -4px);
+	}
+
+	@media (max-width: 640px) {
+		.nav-toggle {
+			display: flex;
+		}
+
+		.nav-links {
+			/* slide down on mobile */
+			position: absolute;
+			top: 100%;
+			left: 0;
+			right: 0;
+			flex-direction: column;
+			padding: 1rem 2rem;
+			background: rgba(10, 10, 20, 0.95);
+			backdrop-filter: blur(20px);
+			border-bottom: 1px solid var(--glass-border);
+			gap: 1rem;
+			display: none;
+		}
+
+		.nav-links.open {
+			display: flex;
+		}
+	}
+</style>

--- a/src/lib/components/upload/JobDescriptionInput.svelte
+++ b/src/lib/components/upload/JobDescriptionInput.svelte
@@ -1,0 +1,115 @@
+<script lang="ts">
+	import { scoresStore } from '$stores/scores.svelte';
+
+	let expanded = $state(false);
+</script>
+
+<div class="jd-input">
+	<button class="jd-toggle" onclick={() => (expanded = !expanded)}>
+		<span class="toggle-icon" class:expanded>
+			<svg
+				width="16"
+				height="16"
+				viewBox="0 0 24 24"
+				fill="none"
+				stroke="currentColor"
+				stroke-width="2"
+			>
+				<polyline points="6,9 12,15 18,9" />
+			</svg>
+		</span>
+		{#if expanded}
+			hide job description (optional)
+		{:else}
+			add job description for targeted scoring
+		{/if}
+	</button>
+
+	{#if expanded}
+		<div class="jd-textarea-wrapper">
+			<textarea
+				class="jd-textarea"
+				placeholder="paste the job description here for targeted keyword matching and industry-specific scoring..."
+				rows="8"
+				value={scoresStore.jobDescription}
+				oninput={(e) => scoresStore.setJobDescription((e.target as HTMLTextAreaElement).value)}
+			></textarea>
+			{#if scoresStore.hasJobDescription}
+				<p class="jd-status">
+					targeted mode active. your resume will be scored against this specific job.
+				</p>
+			{/if}
+		</div>
+	{/if}
+</div>
+
+<style>
+	.jd-input {
+		margin-top: 1.5rem;
+	}
+
+	.jd-toggle {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		padding: 0.75rem 1rem;
+		background: none;
+		border: 1px solid var(--glass-border);
+		border-radius: var(--radius-md);
+		color: var(--text-secondary);
+		cursor: pointer;
+		font-size: 0.9rem;
+		width: 100%;
+		transition:
+			border-color 0.2s ease,
+			color 0.2s ease;
+	}
+
+	.jd-toggle:hover {
+		border-color: var(--accent-cyan);
+		color: var(--text-primary);
+	}
+
+	.toggle-icon {
+		transition: transform 0.2s ease;
+		display: inline-flex;
+	}
+
+	.toggle-icon.expanded {
+		transform: rotate(180deg);
+	}
+
+	.jd-textarea-wrapper {
+		margin-top: 1rem;
+	}
+
+	.jd-textarea {
+		width: 100%;
+		padding: 1rem;
+		background: var(--glass-bg);
+		border: 1px solid var(--glass-border);
+		border-radius: var(--radius-lg);
+		color: var(--text-primary);
+		font-family: var(--font-sans);
+		font-size: 0.9rem;
+		line-height: 1.5;
+		resize: vertical;
+		backdrop-filter: blur(var(--glass-blur));
+		transition: border-color 0.2s ease;
+	}
+
+	.jd-textarea:focus {
+		outline: none;
+		border-color: var(--accent-cyan);
+	}
+
+	.jd-textarea::placeholder {
+		color: var(--text-tertiary);
+	}
+
+	.jd-status {
+		margin-top: 0.5rem;
+		font-size: 0.85rem;
+		color: var(--accent-cyan);
+	}
+</style>

--- a/src/lib/components/upload/ResumeUploader.svelte
+++ b/src/lib/components/upload/ResumeUploader.svelte
@@ -1,0 +1,247 @@
+<script lang="ts">
+	import { resumeStore } from '$stores/resume.svelte';
+
+	// visual feedback for the drag-and-drop zone
+	let isDragging = $state(false);
+	// ref to the hidden file input for programmatic click
+	let fileInput: HTMLInputElement;
+
+	// MIME types we accept (PDF and DOCX only)
+	const ACCEPTED_TYPES = [
+		'application/pdf',
+		'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+	];
+
+	function handleDragOver(e: DragEvent) {
+		e.preventDefault();
+		isDragging = true;
+	}
+
+	function handleDragLeave() {
+		isDragging = false;
+	}
+
+	function handleDrop(e: DragEvent) {
+		e.preventDefault();
+		isDragging = false;
+		const file = e.dataTransfer?.files[0];
+		if (file) validateAndSetFile(file);
+	}
+
+	function handleFileSelect(e: Event) {
+		const input = e.target as HTMLInputElement;
+		const file = input.files?.[0];
+		if (file) validateAndSetFile(file);
+	}
+
+	// validates type + size before passing to the store
+	function validateAndSetFile(file: File) {
+		if (!ACCEPTED_TYPES.includes(file.type)) {
+			resumeStore.setError('please upload a PDF or DOCX file');
+			return;
+		}
+		if (file.size > 10 * 1024 * 1024) {
+			resumeStore.setError('file too large (max 10MB)');
+			return;
+		}
+		resumeStore.setFile(file);
+	}
+
+	function openFilePicker() {
+		fileInput.click();
+	}
+</script>
+
+<div
+	class="uploader"
+	class:dragging={isDragging}
+	class:has-file={resumeStore.file !== null}
+	ondragover={handleDragOver}
+	ondragleave={handleDragLeave}
+	ondrop={handleDrop}
+	role="button"
+	tabindex="0"
+	onclick={openFilePicker}
+	onkeydown={(e) => e.key === 'Enter' && openFilePicker()}
+>
+	<input
+		bind:this={fileInput}
+		type="file"
+		accept=".pdf,.docx"
+		onchange={handleFileSelect}
+		class="visually-hidden"
+	/>
+
+	{#if resumeStore.file}
+		<div class="file-info">
+			<div class="file-icon">
+				{#if resumeStore.file.name.endsWith('.pdf')}
+					<svg
+						width="24"
+						height="24"
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						stroke-width="2"
+					>
+						<path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+						<polyline points="14,2 14,8 20,8" />
+						<path d="M10 12l2 2 4-4" />
+					</svg>
+				{:else}
+					<svg
+						width="24"
+						height="24"
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						stroke-width="2"
+					>
+						<path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+						<polyline points="14,2 14,8 20,8" />
+						<line x1="16" y1="13" x2="8" y2="13" />
+						<line x1="16" y1="17" x2="8" y2="17" />
+					</svg>
+				{/if}
+			</div>
+			<div>
+				<p class="file-name">{resumeStore.file.name}</p>
+				<p class="file-size">{(resumeStore.file.size / 1024).toFixed(0)} KB</p>
+			</div>
+		</div>
+	{:else if resumeStore.isParsing}
+		<div class="parsing">
+			<div class="spinner"></div>
+			<p>parsing your resume...</p>
+		</div>
+	{:else}
+		<div class="upload-prompt">
+			<svg
+				class="upload-icon"
+				width="48"
+				height="48"
+				viewBox="0 0 24 24"
+				fill="none"
+				stroke="currentColor"
+				stroke-width="1.5"
+			>
+				<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+				<polyline points="17,8 12,3 7,8" />
+				<line x1="12" y1="3" x2="12" y2="15" />
+			</svg>
+			<p class="upload-text">drag & drop your resume here</p>
+			<p class="upload-hint">or click to browse. PDF or DOCX, max 10MB</p>
+		</div>
+	{/if}
+
+	{#if resumeStore.error}
+		<p class="error">{resumeStore.error}</p>
+	{/if}
+</div>
+
+<style>
+	.uploader {
+		position: relative;
+		padding: 3rem 2rem;
+		background: var(--glass-bg);
+		border: 2px dashed var(--glass-border);
+		border-radius: var(--radius-xl);
+		backdrop-filter: blur(var(--glass-blur));
+		cursor: pointer;
+		transition:
+			border-color 0.3s ease,
+			background 0.3s ease;
+		text-align: center;
+	}
+
+	.uploader:hover,
+	.uploader.dragging {
+		border-color: var(--accent-cyan);
+		background: rgba(6, 182, 212, 0.03);
+	}
+
+	.uploader.has-file {
+		border-style: solid;
+		border-color: rgba(6, 182, 212, 0.3);
+	}
+
+	.visually-hidden {
+		position: absolute;
+		width: 1px;
+		height: 1px;
+		padding: 0;
+		margin: -1px;
+		overflow: hidden;
+		clip: rect(0, 0, 0, 0);
+		border: 0;
+	}
+
+	.upload-icon {
+		color: var(--text-tertiary);
+		margin-bottom: 1rem;
+	}
+
+	.upload-text {
+		font-size: 1.1rem;
+		color: var(--text-secondary);
+		margin-bottom: 0.5rem;
+	}
+
+	.upload-hint {
+		font-size: 0.85rem;
+		color: var(--text-tertiary);
+	}
+
+	.file-info {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		gap: 1rem;
+	}
+
+	.file-icon {
+		color: var(--accent-cyan);
+	}
+
+	.file-name {
+		font-weight: 600;
+		color: var(--text-primary);
+	}
+
+	.file-size {
+		font-size: 0.85rem;
+		color: var(--text-tertiary);
+	}
+
+	.parsing {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 1rem;
+	}
+
+	.spinner {
+		width: 32px;
+		height: 32px;
+		border: 3px solid var(--glass-border);
+		border-top-color: var(--accent-cyan);
+		border-radius: 50%;
+		animation: spin 0.8s linear infinite;
+	}
+
+	@keyframes spin {
+		to {
+			transform: rotate(360deg);
+		}
+	}
+
+	.parsing p {
+		color: var(--text-secondary);
+	}
+
+	.error {
+		margin-top: 1rem;
+		color: #ef4444;
+		font-size: 0.9rem;
+	}
+</style>

--- a/src/lib/engine/job-parser/extractor.ts
+++ b/src/lib/engine/job-parser/extractor.ts
@@ -2,11 +2,7 @@ import type { ParsedJobDescription } from './types';
 import { tokenize, extractNgrams } from '$engine/nlp/tokenizer';
 import { detectIndustry, getIndustrySkills } from '$engine/nlp/skills-taxonomy';
 
-/**
- * extracts structured data from a job description.
- * this is the rule-based extractor. LLM enhancement happens in the server endpoint.
- * works for any industry and role type.
- */
+// rule-based JD extractor. LLM enhancement happens server-side. works for any industry
 export function parseJobDescription(text: string): ParsedJobDescription {
 	const lower = text.toLowerCase();
 

--- a/src/lib/engine/llm/client.ts
+++ b/src/lib/engine/llm/client.ts
@@ -1,11 +1,7 @@
 import type { LLMAnalysis, LLMRequestPayload, LLMResponse } from './types';
 import { generateFallbackAnalysis } from './fallback';
 
-/**
- * client-side LLM caller.
- * sends requests to our SvelteKit server endpoint which proxies to Gemini.
- * falls back to rule-based analysis if the server is unavailable or quota exhausted.
- */
+// proxies to /api/analyze (Gemini). falls back to rule-based if unavailable
 export async function analyzWithLLM(payload: LLMRequestPayload): Promise<LLMResponse> {
 	try {
 		const response = await fetch('/api/analyze', {

--- a/src/lib/engine/llm/fallback.ts
+++ b/src/lib/engine/llm/fallback.ts
@@ -2,11 +2,7 @@ import type { LLMAnalysis, LLMRequestPayload } from './types';
 import { tokenize } from '$engine/nlp/tokenizer';
 import { detectIndustry } from '$engine/nlp/skills-taxonomy';
 
-/**
- * rule-based fallback when LLM is unavailable (quota exhausted, errors, offline).
- * provides reasonable analysis using the NLP engine directly.
- * not as accurate as LLM semantic analysis, but deterministic and free.
- */
+// rule-based fallback when LLM is unavailable. deterministic, uses NLP engine directly
 export function generateFallbackAnalysis(payload: LLMRequestPayload): LLMAnalysis {
 	const { resumeText, jobDescription, resumeSkills } = payload;
 

--- a/src/lib/engine/llm/prompts.ts
+++ b/src/lib/engine/llm/prompts.ts
@@ -1,8 +1,4 @@
-/**
- * prompt templates for Gemini 2.0 Flash.
- * designed to extract structured data from unstructured text.
- * works across any industry and role type.
- */
+// prompt templates for Gemini 2.0 Flash. structured JSON output, any industry
 
 export function buildJDAnalysisPrompt(jobDescription: string): string {
 	return `analyze this job description and extract structured requirements. respond ONLY with valid JSON, no markdown fences.

--- a/src/lib/engine/nlp/skills-taxonomy.ts
+++ b/src/lib/engine/nlp/skills-taxonomy.ts
@@ -1,10 +1,5 @@
-/**
- * categorized skills database organized by industry and domain.
- * used for:
- * 1. identifying which industry a resume/JD belongs to
- * 2. suggesting relevant skills the candidate might be missing
- * 3. weighting keyword matches by relevance to the target role
- */
+// categorized skills database by industry/domain
+// used for industry detection, skill suggestions, and relevance weighting
 
 export interface SkillCategory {
 	domain: string;
@@ -557,10 +552,7 @@ export const SKILLS_TAXONOMY: SkillCategory[] = [
 	}
 ];
 
-/**
- * detects the most likely industry of a text based on skill keyword presence.
- * returns industries sorted by match count.
- */
+// detects the most likely industry based on skill keyword presence, sorted by match count
 export function detectIndustry(text: string): Array<{ industry: string; matchCount: number }> {
 	const lowerText = text.toLowerCase();
 	const industryCounts = new Map<string, number>();
@@ -584,16 +576,12 @@ export function detectIndustry(text: string): Array<{ industry: string; matchCou
 		.sort((a, b) => b.matchCount - a.matchCount);
 }
 
-/**
- * gets all skills for a given industry.
- */
+// gets all skills for a given industry
 export function getIndustrySkills(industry: string): string[] {
 	return SKILLS_TAXONOMY.filter((cat) => cat.industry === industry).flatMap((cat) => cat.skills);
 }
 
-/**
- * gets the domain/category for a given skill.
- */
+// gets the domain/category for a given skill
 export function getSkillDomain(skill: string): string | null {
 	const lower = skill.toLowerCase();
 	for (const category of SKILLS_TAXONOMY) {

--- a/src/lib/engine/nlp/synonyms.ts
+++ b/src/lib/engine/nlp/synonyms.ts
@@ -1,11 +1,5 @@
-/**
- * cross-industry skill synonym map.
- * maps variant names/abbreviations to a canonical form.
- * this enables matching "JS" on a resume to "JavaScript" in a JD,
- * or "PM" to "Project Management".
- *
- * organized by industry cluster for maintainability.
- */
+// cross-industry synonym map: maps variant names/abbreviations to a canonical form
+// organized by industry cluster for maintainability
 const SYNONYM_GROUPS: string[][] = [
 	// === technology / programming ===
 	['javascript', 'js', 'ecmascript', 'es6', 'es2015'],
@@ -206,10 +200,7 @@ const SYNONYM_GROUPS: string[][] = [
 	['power bi', 'powerbi', 'microsoft power bi']
 ];
 
-/**
- * maps every variant to its canonical form (first item in the group).
- * lookups are case-insensitive.
- */
+// maps every variant to its canonical form (first in group), case-insensitive
 const synonymMap = new Map<string, string>();
 
 for (const group of SYNONYM_GROUPS) {
@@ -219,35 +210,26 @@ for (const group of SYNONYM_GROUPS) {
 	}
 }
 
-/**
- * returns the canonical form of a term, or the term itself if no synonym exists.
- */
+// returns the canonical form of a term, or the term itself if no synonym exists
 export function getCanonical(term: string): string {
 	return synonymMap.get(term.toLowerCase()) || term.toLowerCase();
 }
 
-/**
- * checks if two terms are synonymous.
- */
+// checks if two terms are synonymous
 export function areSynonyms(term1: string, term2: string): boolean {
 	const c1 = getCanonical(term1);
 	const c2 = getCanonical(term2);
 	return c1 === c2;
 }
 
-/**
- * finds all known synonyms for a term.
- */
+// finds all known synonyms for a term
 export function getSynonyms(term: string): string[] {
 	const canonical = getCanonical(term);
 	const group = SYNONYM_GROUPS.find((g) => g.some((v) => v.toLowerCase() === canonical));
 	return group ? [...group] : [term];
 }
 
-/**
- * normalizes a list of terms using the synonym map.
- * deduplicates based on canonical form.
- */
+// normalizes a list of terms using the synonym map, deduplicates by canonical form
 export function normalizeTerms(terms: string[]): string[] {
 	const seen = new Set<string>();
 	const result: string[] = [];

--- a/src/lib/engine/nlp/tfidf.ts
+++ b/src/lib/engine/nlp/tfidf.ts
@@ -13,10 +13,7 @@ interface TFIDFScore {
 	idf: number;
 }
 
-/**
- * computes term frequency for a document.
- * TF = (count of term in document) / (total terms in document)
- */
+// computes term frequency: TF = count of term / total terms in doc
 export function computeTF(text: string): TermFrequency[] {
 	const tokens = tokenize(text);
 	const counts = new Map<string, number>();
@@ -39,11 +36,7 @@ export function computeTF(text: string): TermFrequency[] {
 	return frequencies.sort((a, b) => b.tf - a.tf);
 }
 
-/**
- * computes inverse document frequency across a corpus.
- * IDF = log(N / (1 + df)) where N = total docs, df = docs containing term
- * the +1 prevents division by zero.
- */
+// computes inverse document frequency: IDF = log(N / (1 + df)), +1 prevents div by zero
 export function computeIDF(documents: string[]): Map<string, number> {
 	const docCount = documents.length;
 	const termDocCounts = new Map<string, number>();
@@ -65,11 +58,8 @@ export function computeIDF(documents: string[]): Map<string, number> {
 	return idf;
 }
 
-/**
- * computes TF-IDF scores for a target document against a corpus.
- * higher scores indicate terms that are important to the target
- * but not common across all documents.
- */
+// computes TF-IDF scores for a target doc against a corpus
+// higher scores = important to target but uncommon across all docs
 export function computeTFIDF(targetText: string, corpusTexts: string[]): TFIDFScore[] {
 	const allDocs = [targetText, ...corpusTexts];
 	const idfMap = computeIDF(allDocs);
@@ -90,10 +80,7 @@ export function computeTFIDF(targetText: string, corpusTexts: string[]): TFIDFSc
 	return scores.sort((a, b) => b.score - a.score);
 }
 
-/**
- * computes keyword overlap between two texts.
- * returns matched terms, missing terms, and a similarity score.
- */
+// computes keyword overlap between two texts: matched terms, missing terms, similarity score
 export function computeKeywordOverlap(
 	sourceText: string,
 	targetText: string
@@ -124,10 +111,7 @@ export function computeKeywordOverlap(
 	return { matched, missing, score };
 }
 
-/**
- * finds the most important terms in a document using TF-IDF.
- * useful for extracting key skills and requirements from job descriptions.
- */
+// extracts the most important terms in a doc using TF-IDF (key skills/requirements)
 export function extractKeyTerms(text: string, topN: number = 20): string[] {
 	// use the text as both target and a minimal corpus
 	// the IDF won't be meaningful with a single doc, so we rely mainly on TF

--- a/src/lib/engine/nlp/tokenizer.ts
+++ b/src/lib/engine/nlp/tokenizer.ts
@@ -1,8 +1,4 @@
-/**
- * stop words to exclude from keyword analysis.
- * these are common english words that don't carry meaningful
- * semantic weight for resume/job description matching.
- */
+// stop words to exclude from keyword analysis (common english words with no semantic weight)
 const STOP_WORDS = new Set([
 	'a',
 	'an',
@@ -132,10 +128,7 @@ export interface Token {
 	position: number;
 }
 
-/**
- * tokenizes text into individual terms.
- * normalizes to lowercase, removes punctuation, filters stop words.
- */
+// tokenizes text into terms: lowercase, strip punctuation, filter stop words
 export function tokenize(text: string): Token[] {
 	const words = text.split(/[\s,;|]+/);
 	const tokens: Token[] = [];
@@ -156,11 +149,7 @@ export function tokenize(text: string): Token[] {
 	return tokens;
 }
 
-/**
- * extracts n-grams (multi-word phrases) from text.
- * useful for matching compound skills like "machine learning",
- * "project management", "data analysis".
- */
+// extracts n-grams (multi-word phrases) for matching compound skills
 export function extractNgrams(text: string, n: number): string[] {
 	const words = text
 		.toLowerCase()
@@ -181,10 +170,7 @@ export function extractNgrams(text: string, n: number): string[] {
 	return ngrams;
 }
 
-/**
- * extracts unique terms from text, combining unigrams and bigrams.
- * this gives us both individual skills ("python") and compound skills ("machine learning").
- */
+// extracts unique terms combining unigrams, bigrams, and trigrams
 export function extractTerms(text: string): string[] {
 	const tokens = tokenize(text);
 	const unigrams = tokens.map((t) => t.normalized);
@@ -195,9 +181,7 @@ export function extractTerms(text: string): string[] {
 	return [...new Set(all)];
 }
 
-/**
- * normalizes text for comparison: lowercase, trim, collapse whitespace.
- */
+// normalizes text for comparison: lowercase, trim, collapse whitespace
 export function normalizeText(text: string): string {
 	return text.toLowerCase().trim().replace(/\s+/g, ' ');
 }

--- a/src/lib/engine/parser/contact-extractor.ts
+++ b/src/lib/engine/parser/contact-extractor.ts
@@ -7,10 +7,7 @@ const GITHUB_REGEX = /(?:https?:\/\/)?(?:www\.)?github\.com\/[\w-]+\/?/i;
 const WEBSITE_REGEX =
 	/https?:\/\/(?!.*(?:linkedin|github)\.com)[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}(?:\/\S*)?/i;
 
-/**
- * extracts contact information from the top portion of a resume.
- * focuses on the first ~10 lines where contact info typically lives.
- */
+// extracts contact info from the top ~10 lines of the resume
 export function extractContact(lines: string[]): ContactInfo {
 	// contact info is almost always in the first 10 lines
 	const searchLines = lines.slice(0, Math.min(lines.length, 15));
@@ -32,13 +29,7 @@ function extractFirst(text: string, regex: RegExp): string | null {
 	return match ? match[0].trim() : null;
 }
 
-/**
- * extracts the candidate name from the resume.
- * the name is typically the first non-empty line that:
- * - doesn't contain an email, phone, or URL
- * - is relatively short (< 50 chars)
- * - contains at least 2 words
- */
+// extracts candidate name from first few lines (short, non-url, 2-5 word line)
 function extractName(lines: string[]): string | null {
 	for (const line of lines.slice(0, 5)) {
 		const trimmed = line.trim();
@@ -62,10 +53,7 @@ function extractName(lines: string[]): string | null {
 	return null;
 }
 
-/**
- * extracts location from the contact section.
- * looks for patterns like "City, State" or "City, State ZIP"
- */
+// extracts location from contact section (e.g. "City, State" or "City, ST ZIP")
 function extractLocation(lines: string[]): string | null {
 	const locationPatterns = [
 		// City, ST

--- a/src/lib/engine/parser/date-extractor.ts
+++ b/src/lib/engine/parser/date-extractor.ts
@@ -50,11 +50,7 @@ const DATE_RANGE_PATTERNS = [
 	/(?:jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:t(?:ember)?)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)\s*\.?\s*\d{4}/gi
 ];
 
-/**
- * extracts all date ranges from a block of text.
- * handles various formats: "Jan 2023 - Present", "2022 - 2024", "01/2023 - 12/2024"
- * prioritizes range patterns over standalone dates to avoid duplicates.
- */
+// extracts all date ranges from text, prioritizing ranges over standalone dates
 export function extractDateRanges(text: string): DateRange[] {
 	const ranges: DateRange[] = [];
 	// track which character positions have already been matched
@@ -83,9 +79,7 @@ export function extractDateRanges(text: string): DateRange[] {
 	return ranges;
 }
 
-/**
- * parses a date range string into a structured DateRange.
- */
+// parses a date range string into a structured DateRange
 function parseDateRange(raw: string): DateRange | null {
 	const isCurrent = CURRENT_INDICATORS.test(raw);
 
@@ -108,9 +102,7 @@ function parseDateRange(raw: string): DateRange | null {
 	};
 }
 
-/**
- * normalizes a date string to "YYYY-MM" or "YYYY" format.
- */
+// normalizes a date string to "YYYY-MM" or "YYYY" format
 function normalizeDate(dateStr: string): string | null {
 	const cleaned = dateStr.trim().toLowerCase();
 
@@ -155,10 +147,7 @@ function normalizeDate(dateStr: string): string | null {
 	return null;
 }
 
-/**
- * extracts the first date range found in a line of text.
- * useful for parsing experience/education entries.
- */
+// extracts the first date range found in a line of text
 export function extractFirstDateRange(text: string): DateRange | null {
 	const ranges = extractDateRanges(text);
 	return ranges.length > 0 ? ranges[0] : null;

--- a/src/lib/engine/parser/docx-parser.ts
+++ b/src/lib/engine/parser/docx-parser.ts
@@ -7,11 +7,7 @@ interface DOCXParseResult {
 	hasImages: boolean;
 }
 
-/**
- * extracts text content from a DOCX file using mammoth.
- * mammoth converts DOCX to plaintext, stripping formatting
- * but preserving document structure (paragraphs, lists).
- */
+// extracts text from a DOCX file via mammoth, preserving paragraph/list structure
 export async function parseDOCX(file: File): Promise<DOCXParseResult> {
 	const buffer = await file.arrayBuffer();
 

--- a/src/lib/engine/parser/index.ts
+++ b/src/lib/engine/parser/index.ts
@@ -13,11 +13,7 @@ import type {
 	ResumeSection
 } from './types';
 
-/**
- * main entry point for parsing a resume file.
- * supports PDF and DOCX formats.
- * returns a fully structured ParsedResume or errors.
- */
+// main entry point: parses PDF/DOCX into structured ParsedResume
 export async function parseResume(file: File): Promise<ParseResult> {
 	const errors: string[] = [];
 	const warnings: string[] = [];
@@ -130,9 +126,7 @@ function getFileType(file: File): 'pdf' | 'docx' | null {
 	return null;
 }
 
-/**
- * extracts structured experience entries from experience sections.
- */
+// extracts structured experience entries from experience sections
 function extractExperience(sections: ResumeSection[]): ExperienceEntry[] {
 	const expSections = sections.filter((s) => s.type === 'experience');
 	const entries: ExperienceEntry[] = [];
@@ -169,14 +163,7 @@ function extractExperience(sections: ResumeSection[]): ExperienceEntry[] {
 	return entries;
 }
 
-/**
- * parses a job title and company from the header lines of an experience entry.
- * handles formats like:
- * - "Software Engineer | Google"
- * - "Software Engineer, Google"
- * - "Software Engineer at Google"
- * - "Google" (line 1) "Software Engineer" (line 2)
- */
+// parses title/company from header. handles "Title | Co", "Title at Co", "Title, Co", two-line
 function parseJobHeader(line1: string, line2: string): { title: string; company: string } {
 	// remove date patterns from lines for cleaner parsing
 	const cleanLine1 = line1
@@ -218,9 +205,7 @@ function parseJobHeader(line1: string, line2: string): { title: string; company:
 	return { title: cleanLine1, company: '' };
 }
 
-/**
- * extracts structured education entries from education sections.
- */
+// extracts structured education entries from education sections
 function extractEducation(sections: ResumeSection[]): EducationEntry[] {
 	const eduSections = sections.filter((s) => s.type === 'education');
 	const entries: EducationEntry[] = [];
@@ -307,9 +292,7 @@ function extractHonors(lines: string[]): string[] {
 	return lines.filter((l) => honorsKeywords.test(l)).map((l) => l.trim());
 }
 
-/**
- * extracts project entries from project sections.
- */
+// extracts project entries from project sections
 function extractProjects(sections: ResumeSection[]): ProjectEntry[] {
 	const projSections = sections.filter((s) => s.type === 'projects');
 	const entries: ProjectEntry[] = [];
@@ -353,9 +336,7 @@ function extractProjects(sections: ResumeSection[]): ProjectEntry[] {
 	return entries;
 }
 
-/**
- * extracts certifications from certification sections.
- */
+// extracts certifications from certification sections
 function extractCertifications(sections: ResumeSection[]): CertificationEntry[] {
 	const certSections = sections.filter((s) => s.type === 'certifications');
 	const entries: CertificationEntry[] = [];
@@ -383,10 +364,7 @@ function extractCertifications(sections: ResumeSection[]): CertificationEntry[] 
 	return entries;
 }
 
-/**
- * extracts skills from skills sections.
- * handles various formats: comma-separated, bullet lists, "Category: skill1, skill2"
- */
+// extracts skills from skills sections. handles comma-separated, bullets, "Category: skill1, skill2"
 function extractSkills(sections: ResumeSection[]): string[] {
 	const skillSections = sections.filter((s) => s.type === 'skills');
 	const skills: string[] = [];
@@ -422,19 +400,13 @@ function extractSkills(sections: ResumeSection[]): string[] {
 	});
 }
 
-/**
- * extracts the summary/objective from the resume.
- */
+// extracts the summary/objective section text
 function extractSummary(sections: ResumeSection[]): string | null {
 	const summarySection = sections.find((s) => s.type === 'summary');
 	return summarySection ? summarySection.content.trim() : null;
 }
 
-/**
- * splits section content into individual entries.
- * entries are separated by blank lines or by lines that look like new entry headers
- * (e.g., lines with dates, company names, or titles).
- */
+// splits section content into entries using blank lines and date-containing headers as boundaries
 function splitIntoEntries(content: string): string[] {
 	const lines = content.split('\n');
 	const entries: string[] = [];

--- a/src/lib/engine/parser/pdf-parser.ts
+++ b/src/lib/engine/parser/pdf-parser.ts
@@ -24,11 +24,7 @@ interface PDFParseResult {
 	hasImages: boolean;
 }
 
-/**
- * extracts text content from a PDF file with layout awareness.
- * reconstructs line ordering based on y-position to handle
- * multi-column layouts that ATS parsers struggle with.
- */
+// extracts text from a PDF with layout-aware line reconstruction
 export async function parsePDF(file: File): Promise<PDFParseResult> {
 	const buffer = await file.arrayBuffer();
 	const pdf = await pdfjsLib.getDocument({ data: buffer }).promise;
@@ -85,11 +81,7 @@ export async function parsePDF(file: File): Promise<PDFParseResult> {
 	};
 }
 
-/**
- * groups text items into lines based on y-position clustering.
- * items within 3px y-distance are considered the same line.
- * lines are sorted top-to-bottom, items within a line left-to-right.
- */
+// groups text items into lines by y-position (3px threshold), sorted top-to-bottom
 function reconstructLines(items: PDFTextLine[]): string[] {
 	if (items.length === 0) return [];
 
@@ -125,10 +117,7 @@ function reconstructLines(items: PDFTextLine[]): string[] {
 	return lines.filter((line) => line.trim().length > 0);
 }
 
-/**
- * merges text items on the same line, inserting spaces
- * where there are significant gaps between items.
- */
+// merges text items on the same line, inserting spaces at significant gaps
 function mergeLine(items: PDFTextLine[]): string {
 	if (items.length === 0) return '';
 	if (items.length === 1) return items[0].text;
@@ -149,10 +138,7 @@ function mergeLine(items: PDFTextLine[]): string {
 	return result;
 }
 
-/**
- * detects multi-column layouts by analyzing x-position distribution.
- * if text items cluster into 2+ distinct x-ranges, it's likely multi-column.
- */
+// detects multi-column layouts by checking for distinct x-position clusters
 function detectMultipleColumns(items: PDFTextLine[]): boolean {
 	if (items.length < 20) return false;
 
@@ -180,10 +166,7 @@ function detectMultipleColumns(items: PDFTextLine[]): boolean {
 	return false;
 }
 
-/**
- * detects table-like structures by looking for aligned columns
- * of text with consistent spacing patterns.
- */
+// detects table-like structures by looking for aligned columns with consistent gaps
 function detectTables(items: PDFTextLine[]): boolean {
 	if (items.length < 10) return false;
 

--- a/src/lib/engine/parser/section-detector.ts
+++ b/src/lib/engine/parser/section-detector.ts
@@ -1,9 +1,6 @@
 import type { ResumeSection, SectionType } from './types';
 
-/**
- * maps common resume section headers to their canonical types.
- * handles variations across industries and formats.
- */
+// maps common resume section headers to canonical types
 const SECTION_PATTERNS: Record<SectionType, RegExp[]> = {
 	contact: [/^(contact\s*(info(rmation)?)?|personal\s*(info(rmation)?|details))$/i],
 	summary: [
@@ -34,13 +31,7 @@ const SECTION_PATTERNS: Record<SectionType, RegExp[]> = {
 	unknown: []
 };
 
-/**
- * heuristics for identifying section headers:
- * - all caps or title case
- * - short (1-5 words)
- * - often followed by a colon or horizontal rule
- * - may be preceded by a blank line
- */
+// checks if a line is a section header using pattern matching and heuristics
 function isSectionHeader(line: string, prevLine: string | null, nextLine: string | null): boolean {
 	const trimmed = line.trim();
 
@@ -77,9 +68,7 @@ function isSectionHeader(line: string, prevLine: string | null, nextLine: string
 	return false;
 }
 
-/**
- * classifies a section header string into a canonical section type.
- */
+// classifies a section header string into a canonical SectionType
 function classifySection(header: string): SectionType {
 	const cleaned = header.replace(/[:\-_|]/g, '').trim();
 
@@ -92,10 +81,7 @@ function classifySection(header: string): SectionType {
 	return 'unknown';
 }
 
-/**
- * detects and extracts sections from resume text.
- * returns an array of sections with their type, header, content, and line ranges.
- */
+// detects and extracts sections from resume lines with type, header, content, and line ranges
 export function detectSections(lines: string[]): ResumeSection[] {
 	const sections: ResumeSection[] = [];
 	const headerIndices: { index: number; header: string; type: SectionType }[] = [];

--- a/src/lib/engine/scorer/education-scorer.ts
+++ b/src/lib/engine/scorer/education-scorer.ts
@@ -34,11 +34,7 @@ const DEGREE_LEVELS: Record<string, number> = {
 	certification: 1
 };
 
-/**
- * scores education section quality.
- * evaluates: degree presence, institution mention, dates, GPA, honors.
- * this is a general score; JD-specific matching happens in the keyword matcher.
- */
+// scores education section: degree, institution, dates, GPA, honors
 export function scoreEducation(educationText: string): EducationScore {
 	if (!educationText || educationText.trim().length === 0) {
 		return {

--- a/src/lib/engine/scorer/engine.ts
+++ b/src/lib/engine/scorer/engine.ts
@@ -6,23 +6,12 @@ import { scoreExperience } from './experience-scorer';
 import { scoreEducation } from './education-scorer';
 import { matchKeywords } from './keyword-matcher';
 
-/**
- * scores a resume against all 6 ATS system profiles.
- * this is the main entry point for the scoring engine.
- *
- * each profile applies different weights, strictness levels,
- * and keyword strategies to simulate how the real system would
- * evaluate the resume.
- *
- * deterministic: same input always produces the same output.
- */
+// scores a resume against all 6 ATS profiles. deterministic: same input = same output
 export function scoreResume(input: ScoringInput): ScoreResult[] {
 	return ALL_PROFILES.map((profile) => scoreAgainstProfile(input, profile));
 }
 
-/**
- * scores a resume against a single ATS profile.
- */
+// scores a resume against a single ATS profile
 export function scoreAgainstProfile(input: ScoringInput, profile: ATSProfile): ScoreResult {
 	const breakdown = computeBreakdown(input, profile);
 	const weightedScore = computeWeightedScore(breakdown, profile);
@@ -46,9 +35,7 @@ export function scoreAgainstProfile(input: ScoringInput, profile: ATSProfile): S
 	};
 }
 
-/**
- * computes the individual breakdown scores for each category.
- */
+// runs each individual scorer and assembles the breakdown
 function computeBreakdown(input: ScoringInput, profile: ATSProfile): ScoreBreakdown {
 	const formatting = scoreFormatting(input, profile.parsingStrictness);
 	const sections = scoreSections(input.resumeSections, profile.requiredSections);
@@ -91,10 +78,7 @@ function computeBreakdown(input: ScoringInput, profile: ATSProfile): ScoreBreakd
 	};
 }
 
-/**
- * applies the profile's category weights to produce a single weighted score.
- * the quantification weight is factored into the experience score.
- */
+// applies profile weights to produce a single 0-100 score
 function computeWeightedScore(breakdown: ScoreBreakdown, profile: ATSProfile): number {
 	const { weights } = profile;
 
@@ -117,10 +101,7 @@ function computeWeightedScore(breakdown: ScoreBreakdown, profile: ATSProfile): n
 	return weighted;
 }
 
-/**
- * runs all quirk checks for a profile and sums the adjustments.
- * negative penalties = deductions, negative penalties (like -5) = bonuses.
- */
+// runs quirk checks for a profile. negative penalty = bonus, positive = deduction
 function computeQuirkAdjustment(
 	input: ScoringInput,
 	profile: ATSProfile
@@ -139,11 +120,7 @@ function computeQuirkAdjustment(
 	return { totalAdjustment, messages };
 }
 
-/**
- * generates actionable suggestions based on scoring results.
- * these are rule-based (deterministic). LLM-powered suggestions
- * come later as an enhancement layer.
- */
+// generates rule-based suggestions. LLM enhancement is layered on top separately
 function generateSuggestions(
 	breakdown: ScoreBreakdown,
 	profile: ATSProfile,

--- a/src/lib/engine/scorer/experience-scorer.ts
+++ b/src/lib/engine/scorer/experience-scorer.ts
@@ -1,7 +1,4 @@
-/**
- * action verbs that indicate strong, quantifiable experience.
- * ATS systems and recruiters look for these in bullet points.
- */
+// strong action verbs that ATS systems and recruiters look for in bullet points
 const STRONG_ACTION_VERBS = new Set([
 	'achieved',
 	'accelerated',
@@ -102,10 +99,7 @@ const STRONG_ACTION_VERBS = new Set([
 	'upgraded'
 ]);
 
-/**
- * patterns that indicate quantified achievements.
- * these are gold for ATS scoring because they show measurable impact.
- */
+// patterns indicating quantified achievements (measurable impact boosts ATS scores)
 const QUANTIFICATION_PATTERNS = [
 	/\d+%/, // percentages: "increased by 30%"
 	/\$[\d,]+/, // dollar amounts: "$1.2M"
@@ -126,13 +120,7 @@ interface ExperienceScore {
 	highlights: string[];
 }
 
-/**
- * scores the quality and relevance of experience entries.
- * evaluates:
- * - quantified achievements (numbers, percentages, dollar amounts)
- * - strong action verbs (led, built, increased, etc.)
- * - bullet point density and quality
- */
+// scores experience quality: quantified achievements, action verbs, bullet density
 export function scoreExperience(bullets: string[]): ExperienceScore {
 	if (bullets.length === 0) {
 		return {

--- a/src/lib/engine/scorer/format-scorer.ts
+++ b/src/lib/engine/scorer/format-scorer.ts
@@ -6,11 +6,7 @@ interface FormatScore {
 	details: string[];
 }
 
-/**
- * scores resume formatting and parseability.
- * this is what determines if an ATS can even READ the resume.
- * strict ATS systems (Workday, Taleo) penalize formatting issues heavily.
- */
+// scores resume formatting and parseability; strict ATS systems penalize heavily
 export function scoreFormatting(input: ScoringInput, strictness: number): FormatScore {
 	const issues: string[] = [];
 	const details: string[] = [];

--- a/src/lib/engine/scorer/keyword-matcher.ts
+++ b/src/lib/engine/scorer/keyword-matcher.ts
@@ -9,16 +9,8 @@ interface KeywordMatchResult {
 	synonymMatched: string[];
 }
 
-/**
- * matches resume keywords against job description keywords.
- * supports three strategies that map to different ATS behaviors:
- *
- * - exact: only counts literal keyword matches (Workday, Taleo, SuccessFactors)
- * - fuzzy: exact + synonym matching via the synonym database (iCIMS)
- * - semantic: fuzzy + partial/contextual matching (Greenhouse, Lever)
- *
- * the strategy reflects how strict the real ATS system is.
- */
+// matches resume keywords against JD keywords using exact, fuzzy, or semantic strategy
+// strategy reflects real ATS strictness (exact for Workday/Taleo, semantic for Greenhouse/Lever)
 export function matchKeywords(
 	resumeText: string,
 	jobDescription: string,
@@ -111,10 +103,7 @@ export function matchKeywords(
 	return { score, matched, missing, synonymMatched };
 }
 
-/**
- * performs a quick keyword overlap check without synonym matching.
- * used for the general (no JD) scoring mode.
- */
+// quick keyword overlap check without synonym matching, used for no-JD scoring mode
 export function quickKeywordScore(resumeText: string, referenceText: string): number {
 	const overlap = computeKeywordOverlap(resumeText, referenceText);
 	return Math.round(overlap.score * 100);

--- a/src/lib/engine/scorer/profiles/greenhouse.ts
+++ b/src/lib/engine/scorer/profiles/greenhouse.ts
@@ -1,20 +1,7 @@
 import type { ATSProfile } from './types';
 
-/**
- * Greenhouse (greenhouse.io)
- *
- * modern ATS popular with tech companies and high-growth startups.
- * uses structured scorecards and is more lenient on formatting.
- * focuses on experience relevance over keyword density.
- *
- * key behaviors:
- * - lenient parser that handles most formats well
- * - structured hiring with scorecards
- * - values experience quality over keyword quantity
- * - semantic matching considers context
- * - less reliant on exact keyword matching
- * - supports structured data import
- */
+// greenhouse: modern ATS for tech/startups, lenient parsing, semantic matching
+// values experience quality and scorecards over keyword density
 export const GREENHOUSE_PROFILE: ATSProfile = {
 	name: 'Greenhouse',
 	vendor: 'Greenhouse Software',

--- a/src/lib/engine/scorer/profiles/icims.ts
+++ b/src/lib/engine/scorer/profiles/icims.ts
@@ -1,19 +1,7 @@
 import type { ATSProfile } from './types';
 
-/**
- * iCIMS Talent Cloud (icims.com)
- *
- * modern ATS platform used by mid-to-large enterprises.
- * more tolerant of formatting variations than Workday/Taleo.
- * uses AI-assisted matching for better keyword understanding.
- *
- * key behaviors:
- * - more forgiving parser than Workday/Taleo
- * - AI-assisted matching considers context and related terms
- * - still relies on keyword matching but with fuzzy matching
- * - better handling of different resume formats
- * - supports skills taxonomies for broader matching
- */
+// icims: mid-to-large enterprise ATS, AI-assisted fuzzy keyword matching
+// more format-tolerant than Workday/Taleo, supports skills taxonomies
 export const ICIMS_PROFILE: ATSProfile = {
 	name: 'iCIMS',
 	vendor: 'iCIMS, Inc.',

--- a/src/lib/engine/scorer/profiles/index.ts
+++ b/src/lib/engine/scorer/profiles/index.ts
@@ -14,9 +14,7 @@ import { GREENHOUSE_PROFILE } from './greenhouse';
 import { LEVER_PROFILE } from './lever';
 import { SUCCESSFACTORS_PROFILE } from './successfactors';
 
-/**
- * all ATS profiles in one array, ordered by market share/strictness.
- */
+// all ATS profiles ordered by market share/strictness
 export const ALL_PROFILES: ATSProfile[] = [
 	WORKDAY_PROFILE,
 	TALEO_PROFILE,
@@ -26,9 +24,7 @@ export const ALL_PROFILES: ATSProfile[] = [
 	LEVER_PROFILE
 ];
 
-/**
- * lookup a profile by name (case-insensitive).
- */
+// lookup a profile by name (case-insensitive)
 export function getProfile(name: string): ATSProfile | undefined {
 	return ALL_PROFILES.find((p) => p.name.toLowerCase() === name.toLowerCase());
 }

--- a/src/lib/engine/scorer/profiles/lever.ts
+++ b/src/lib/engine/scorer/profiles/lever.ts
@@ -1,20 +1,7 @@
 import type { ATSProfile } from './types';
 
-/**
- * Lever (lever.co)
- *
- * modern ATS/CRM hybrid popular with startups and tech companies.
- * emphasizes candidate relationship and context matching.
- * most lenient of the major ATS platforms.
- *
- * key behaviors:
- * - very lenient parser
- * - CRM-style candidate tracking
- * - contextual matching beyond keywords
- * - values narrative and cultural fit signals
- * - good at extracting meaning from unstructured text
- * - supports diverse resume formats well
- */
+// lever: ATS/CRM hybrid for startups, most lenient parser of the major platforms
+// contextual matching, values narrative quality over strict keyword density
 export const LEVER_PROFILE: ATSProfile = {
 	name: 'Lever',
 	vendor: 'Lever (Employ Inc.)',

--- a/src/lib/engine/scorer/profiles/successfactors.ts
+++ b/src/lib/engine/scorer/profiles/successfactors.ts
@@ -1,20 +1,7 @@
 import type { ATSProfile } from './types';
 
-/**
- * SAP SuccessFactors Recruiting (sap.com/products/hcm)
- *
- * enterprise HCM suite used by large multinationals.
- * very structured approach to resume parsing.
- * tightly integrated with SAP's HR ecosystem.
- *
- * key behaviors:
- * - enterprise-grade structured data parsing
- * - maps resume data to rigid internal fields
- * - expects very standard formatting and section structure
- * - keyword matching is exact and field-based
- * - heavily used in manufacturing, pharma, and large enterprise
- * - date format sensitivity is high
- */
+// successfactors: enterprise HCM by SAP, rigid field mapping, exact keyword matching
+// expects standard formatting and structured sections, date-sensitive
 export const SUCCESSFACTORS_PROFILE: ATSProfile = {
 	name: 'SuccessFactors',
 	vendor: 'SAP SE',

--- a/src/lib/engine/scorer/profiles/taleo.ts
+++ b/src/lib/engine/scorer/profiles/taleo.ts
@@ -1,19 +1,7 @@
 import type { ATSProfile } from './types';
 
-/**
- * Oracle Taleo (taleo.net)
- *
- * one of the oldest and most established ATS platforms.
- * heavily used in enterprise, government, and large corporations.
- * known for rigid boolean keyword filtering and strict parsing.
- *
- * key behaviors:
- * - boolean keyword search is the primary filter mechanism
- * - recruiters set "knockout questions" that auto-reject resumes
- * - very structured parsing; sections must be clearly delineated
- * - date parsing is strict
- * - older parser technology, struggles with modern formats
- */
+// taleo: legacy oracle ATS, boolean keyword filtering, knockout questions
+// rigid parsing with strict date and section requirements
 export const TALEO_PROFILE: ATSProfile = {
 	name: 'Taleo',
 	vendor: 'Oracle Corporation',

--- a/src/lib/engine/scorer/profiles/workday.ts
+++ b/src/lib/engine/scorer/profiles/workday.ts
@@ -1,19 +1,7 @@
 import type { ATSProfile } from './types';
 
-/**
- * Workday Recruiting (workday.com)
- *
- * the most widely used ATS among Fortune 500 companies.
- * known for strict resume parsing, single-column preference,
- * and heavy reliance on exact keyword matching.
- *
- * key behaviors:
- * - very strict parser that struggles with creative formats
- * - prefers single-column, chronological resumes
- * - uses exact keyword matching against job requisition fields
- * - parses sections rigidly; expects clear headers
- * - date parsing is format-sensitive
- */
+// workday: most used ATS in Fortune 500, strict parsing, exact keyword matching
+// prefers single-column chronological resumes with clear section headers
 export const WORKDAY_PROFILE: ATSProfile = {
 	name: 'Workday',
 	vendor: 'Workday, Inc.',

--- a/src/lib/engine/scorer/section-scorer.ts
+++ b/src/lib/engine/scorer/section-scorer.ts
@@ -4,11 +4,7 @@ interface SectionScore {
 	missing: string[];
 }
 
-/**
- * scores section completeness based on what the ATS profile expects.
- * different systems have different required sections.
- * e.g., Workday expects very structured sections while Lever is more lenient.
- */
+// scores section completeness based on the ATS profile's required sections
 export function scoreSections(presentSections: string[], requiredSections: string[]): SectionScore {
 	const presentSet = new Set(presentSections.map((s) => s.toLowerCase()));
 	const present: string[] = [];

--- a/src/lib/stores/resume.svelte.ts
+++ b/src/lib/stores/resume.svelte.ts
@@ -1,9 +1,6 @@
 import type { ParsedResume, ParseResult } from '$engine/parser/types';
 
-/**
- * svelte 5 rune-based store for resume state.
- * tracks the uploaded file, parsed data, and parsing status.
- */
+// tracks uploaded file, parsed data, and parsing status
 class ResumeStore {
 	file = $state<File | null>(null);
 	parseResult = $state<ParseResult | null>(null);

--- a/src/lib/stores/scores.svelte.ts
+++ b/src/lib/stores/scores.svelte.ts
@@ -2,10 +2,7 @@ import type { ScoreResult } from '$engine/scorer/types';
 import type { LLMAnalysis } from '$engine/llm/types';
 import type { ParsedJobDescription } from '$engine/job-parser/types';
 
-/**
- * svelte 5 rune-based store for scoring state.
- * tracks all ATS scores, LLM analysis, and JD parsing.
- */
+// tracks ATS scores, LLM analysis, and job description state
 class ScoresStore {
 	results = $state<ScoreResult[]>([]);
 	llmAnalysis = $state<LLMAnalysis | null>(null);

--- a/src/lib/stores/settings.svelte.ts
+++ b/src/lib/stores/settings.svelte.ts
@@ -1,6 +1,4 @@
-/**
- * svelte 5 rune-based store for app settings.
- */
+// svelte 5 rune-based store for app settings
 class SettingsStore {
 	selectedSystems = $state<string[]>([
 		'Workday',

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import '../app.css';
+	import Navbar from '$components/ui/Navbar.svelte';
 
 	let { children } = $props();
 </script>
@@ -8,4 +9,5 @@
 	<title>ATS Screener - Free Resume Scanner for Real HCMS Platforms</title>
 </svelte:head>
 
+<Navbar />
 {@render children()}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,84 +1,28 @@
 <script lang="ts">
-	// landing page - will be built out in feature/ui-landing
+	import Hero from '$components/landing/Hero.svelte';
+	import Features from '$components/landing/Features.svelte';
+	import HowItWorks from '$components/landing/HowItWorks.svelte';
+	import Footer from '$components/landing/Footer.svelte';
 </script>
 
+<svelte:head>
+	<title>ATS Screener - Free Resume Scanner for Real HCMS Platforms</title>
+	<meta
+		name="description"
+		content="Free ATS resume screener simulating Workday, Taleo, iCIMS, Greenhouse, Lever, and SuccessFactors. Get real scores, not made-up numbers."
+	/>
+</svelte:head>
+
 <main class="landing">
-	<section class="hero">
-		<div class="container">
-			<h1 class="hero-title">
-				stop guessing your
-				<span class="gradient-text">ATS score</span>
-			</h1>
-			<p class="hero-subtitle">
-				free resume screener that simulates real HCMS platforms. accurate scores for Workday, Taleo,
-				Greenhouse, iCIMS, Lever, and SuccessFactors.
-			</p>
-			<a href="/scanner" class="cta-button"> scan your resume </a>
-		</div>
-	</section>
+	<Hero />
+	<Features />
+	<HowItWorks />
+	<Footer />
 </main>
 
 <style>
 	.landing {
+		/* no extra padding needed, each section handles its own spacing */
 		min-height: 100dvh;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-	}
-
-	.hero {
-		text-align: center;
-		padding: var(--space-16) 0;
-	}
-
-	.hero-title {
-		font-size: var(--text-6xl);
-		font-weight: var(--weight-bold);
-		letter-spacing: -0.03em;
-		margin-bottom: var(--space-6);
-	}
-
-	.gradient-text {
-		background: var(--gradient-primary);
-		-webkit-background-clip: text;
-		-webkit-text-fill-color: transparent;
-		background-clip: text;
-	}
-
-	.hero-subtitle {
-		font-size: var(--text-xl);
-		color: var(--text-secondary);
-		max-width: 600px;
-		margin: 0 auto var(--space-10);
-		line-height: var(--leading-relaxed);
-	}
-
-	.cta-button {
-		display: inline-flex;
-		align-items: center;
-		padding: var(--space-4) var(--space-8);
-		background: var(--gradient-primary);
-		color: white;
-		font-weight: var(--weight-semibold);
-		font-size: var(--text-lg);
-		border-radius: var(--radius-lg);
-		transition: all var(--duration-normal) var(--ease-out-expo);
-		box-shadow: var(--glow-accent);
-	}
-
-	.cta-button:hover {
-		transform: translateY(-2px);
-		box-shadow: var(--glow-accent), var(--shadow-lg);
-		color: white;
-	}
-
-	@media (max-width: 768px) {
-		.hero-title {
-			font-size: var(--text-4xl);
-		}
-
-		.hero-subtitle {
-			font-size: var(--text-base);
-		}
 	}
 </style>

--- a/src/routes/scanner/+page.svelte
+++ b/src/routes/scanner/+page.svelte
@@ -1,31 +1,295 @@
 <script lang="ts">
-	// scanner page - will be built out in feature/ui-scanner
+	import ResumeUploader from '$components/upload/ResumeUploader.svelte';
+	import JobDescriptionInput from '$components/upload/JobDescriptionInput.svelte';
+	import ScoreDashboard from '$components/scoring/ScoreDashboard.svelte';
+	import { resumeStore } from '$stores/resume.svelte';
+	import { scoresStore } from '$stores/scores.svelte';
+	import { parseResume } from '$engine/parser';
+	import { scoreResume } from '$engine/scorer/engine';
+	import type { ScoringInput } from '$engine/scorer/types';
+
+	// tracks whether the scan button has been clicked at least once
+	let hasScanned = $state(false);
+
+	// re-derive readiness from stores so the scan button reacts to changes
+	const canScan = $derived(resumeStore.isReady && !scoresStore.isScoring);
+
+	// triggered when the user uploads a file via ResumeUploader
+	// runs the parser immediately so results are ready when they hit "scan"
+	async function handleFileReady() {
+		if (!resumeStore.file) return;
+
+		resumeStore.startParsing();
+		try {
+			const result = await parseResume(resumeStore.file);
+			resumeStore.finishParsing(result);
+		} catch (err) {
+			const msg = err instanceof Error ? err.message : 'failed to parse resume';
+			resumeStore.setError(msg);
+		}
+	}
+
+	// builds the ScoringInput from parsed resume data
+	function buildScoringInput(): ScoringInput {
+		const resume = resumeStore.resume!;
+		return {
+			resumeText: resume.rawText,
+			resumeSkills: resume.skills,
+			resumeSections: resume.sections.map((s) => s.type),
+			experienceBullets: resume.experience.flatMap((e) => e.bullets),
+			// join all education entries into one string for the scorer
+			educationText: resume.education.map((e) => e.rawText).join('\n'),
+			hasMultipleColumns: resume.metadata.hasMultipleColumns,
+			hasTables: resume.metadata.hasTables,
+			hasImages: resume.metadata.hasImages,
+			pageCount: resume.metadata.pageCount,
+			wordCount: resume.metadata.wordCount,
+			// only pass JD if user actually typed something
+			jobDescription: scoresStore.hasJobDescription ? scoresStore.jobDescription : undefined
+		};
+	}
+
+	// runs the scoring engine against all 6 ATS profiles
+	async function handleScan() {
+		if (!resumeStore.isReady) return;
+
+		hasScanned = true;
+		scoresStore.startScoring();
+
+		try {
+			const input = buildScoringInput();
+			const results = scoreResume(input);
+			scoresStore.finishScoring(results);
+		} catch (err) {
+			const msg = err instanceof Error ? err.message : 'scoring failed';
+			scoresStore.setError(msg);
+		}
+	}
+
+	// resets everything so the user can start fresh
+	function handleReset() {
+		resumeStore.reset();
+		scoresStore.reset();
+		hasScanned = false;
+	}
+
+	// auto-parse whenever a new file is set
+	$effect(() => {
+		if (resumeStore.file && !resumeStore.isParsing && !resumeStore.parseResult) {
+			handleFileReady();
+		}
+	});
 </script>
+
+<svelte:head>
+	<title>Resume Scanner - ATS Screener</title>
+</svelte:head>
 
 <main class="scanner">
 	<div class="container">
-		<h1 class="page-title">resume scanner</h1>
-		<p class="page-subtitle">
-			upload your resume and optionally paste a job description for targeted scoring
-		</p>
+		<div class="scanner-header">
+			<h1 class="page-title">resume scanner</h1>
+			<p class="page-subtitle">
+				upload your resume and optionally paste a job description for targeted scoring
+			</p>
+		</div>
+
+		<div class="scanner-body">
+			<!-- upload section -->
+			<section class="upload-section">
+				<ResumeUploader />
+				<JobDescriptionInput />
+
+				{#if resumeStore.warnings.length > 0}
+					<div class="warnings">
+						{#each resumeStore.warnings as warning}
+							<p class="warning-item">⚠ {warning}</p>
+						{/each}
+					</div>
+				{/if}
+
+				<div class="actions">
+					{#if scoresStore.hasResults}
+						<button class="btn-secondary" onclick={handleReset}> start over </button>
+					{/if}
+
+					<button class="btn-scan" disabled={!canScan} onclick={handleScan}>
+						{#if scoresStore.isScoring}
+							<span class="spinner-inline"></span>
+							scoring...
+						{:else if scoresStore.hasResults}
+							re-scan
+						{:else}
+							scan resume
+						{/if}
+					</button>
+				</div>
+
+				{#if scoresStore.error}
+					<p class="error">{scoresStore.error}</p>
+				{/if}
+			</section>
+
+			<!-- results section - only shows after scanning -->
+			{#if hasScanned}
+				<section class="results-section">
+					<ScoreDashboard />
+				</section>
+			{/if}
+		</div>
 	</div>
 </main>
 
 <style>
 	.scanner {
 		min-height: 100dvh;
-		padding-top: var(--space-16);
+		padding: 6rem 2rem 4rem;
+	}
+
+	.container {
+		max-width: 1200px;
+		margin: 0 auto;
+	}
+
+	.scanner-header {
+		margin-bottom: 2.5rem;
 	}
 
 	.page-title {
-		font-size: var(--text-4xl);
-		font-weight: var(--weight-bold);
+		font-size: clamp(2rem, 5vw, 3rem);
+		font-weight: 800;
 		letter-spacing: -0.02em;
-		margin-bottom: var(--space-3);
+		margin-bottom: 0.5rem;
+		color: var(--text-primary);
 	}
 
 	.page-subtitle {
-		font-size: var(--text-lg);
+		font-size: 1.1rem;
 		color: var(--text-secondary);
+		line-height: 1.5;
+	}
+
+	.upload-section {
+		max-width: 640px;
+	}
+
+	.warnings {
+		margin-top: 1rem;
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+	}
+
+	.warning-item {
+		font-size: 0.85rem;
+		color: #eab308;
+		padding: 0.5rem 1rem;
+		background: rgba(234, 179, 8, 0.05);
+		border: 1px solid rgba(234, 179, 8, 0.15);
+		border-radius: var(--radius-md);
+	}
+
+	.actions {
+		display: flex;
+		gap: 1rem;
+		margin-top: 2rem;
+	}
+
+	.btn-scan {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.5rem;
+		padding: 0.875rem 2rem;
+		font-size: 1rem;
+		font-weight: 600;
+		color: var(--color-bg-primary);
+		background: var(--gradient-primary);
+		border: none;
+		border-radius: var(--radius-lg);
+		cursor: pointer;
+		transition:
+			transform 0.2s ease,
+			box-shadow 0.2s ease,
+			opacity 0.2s ease;
+	}
+
+	.btn-scan:hover:not(:disabled) {
+		transform: translateY(-2px);
+		box-shadow:
+			0 0 30px rgba(6, 182, 212, 0.3),
+			0 0 60px rgba(59, 130, 246, 0.15);
+	}
+
+	.btn-scan:disabled {
+		opacity: 0.4;
+		cursor: not-allowed;
+	}
+
+	.btn-secondary {
+		padding: 0.875rem 1.5rem;
+		font-size: 1rem;
+		font-weight: 600;
+		color: var(--text-secondary);
+		background: var(--glass-bg);
+		border: 1px solid var(--glass-border);
+		border-radius: var(--radius-lg);
+		cursor: pointer;
+		transition:
+			border-color 0.2s ease,
+			color 0.2s ease;
+	}
+
+	.btn-secondary:hover {
+		border-color: var(--accent-cyan);
+		color: var(--text-primary);
+	}
+
+	/* small inline spinner for the scoring state */
+	.spinner-inline {
+		width: 16px;
+		height: 16px;
+		border: 2px solid rgba(0, 0, 0, 0.2);
+		border-top-color: var(--color-bg-primary);
+		border-radius: 50%;
+		animation: spin 0.6s linear infinite;
+	}
+
+	@keyframes spin {
+		to {
+			transform: rotate(360deg);
+		}
+	}
+
+	.error {
+		margin-top: 1rem;
+		color: #ef4444;
+		font-size: 0.9rem;
+	}
+
+	.results-section {
+		margin-top: 3rem;
+		/* fade in smoothly when results appear */
+		animation: fadeIn 0.4s ease;
+	}
+
+	@keyframes fadeIn {
+		from {
+			opacity: 0;
+			transform: translateY(10px);
+		}
+		to {
+			opacity: 1;
+			transform: translateY(0);
+		}
+	}
+
+	@media (max-width: 640px) {
+		.scanner {
+			padding: 4rem 1.5rem 3rem;
+		}
+
+		.actions {
+			flex-direction: column;
+		}
 	}
 </style>


### PR DESCRIPTION
builds the complete frontend layer: landing page, scanner page with upload-parse-score-display flow, and all supporting components.

**landing page**
- Hero with mouse-tracking radial glow, shimmer CTA button, animated stats bar
- Features bento grid with per-card spotlight effects (6 cards)
- HowItWorks 4-step guide with connector lines
- Footer with github link

**scanner page (the real deal)**
- ResumeUploader: drag-drop + file picker, PDF/DOCX validation, 10MB max
- JobDescriptionInput: expandable textarea for targeted mode
- full wiring: upload -> auto-parse via `parseResume()` -> `scoreResume()` against all 6 ATS profiles -> ScoreDashboard
- supports both general (resume-only) and targeted (resume + JD) modes
- ScoreCard: SVG ring progress, color-coded breakdown bars (formatting/keywords/sections/experience/education), pass/fail badge, spotlight hover
- ScoreDashboard: avg score summary, pass count, deduplicated suggestions from all 6 profiles

**navigation**
- fixed navbar with glassmorphic backdrop blur
- mobile hamburger with animated X transition
- active route highlighting

**code quality**
- replaced all JSDoc blocks with brief lowercase inline comments across 30 files
- lint: 0 errors, typecheck: 0 errors, 98 tests passing, build clean
- a11y: svelte-ignore for decorative mousemove handlers on spotlight effects

all 6 commits pass the full validation pipeline locally (lint + typecheck + format + test + build).