### PR TITLE
feat: share/og pipeline, history insights, scanner UX upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,53 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2026-04-25
+
+### Added
+
+- **Share + OG pipeline**: dynamic `/api/og` PNG endpoint via `@vercel/og` (content-addressed by score/pass/total/delta, CDN-cached at `s-maxage=86400`); new `/share` landing page emits `og:image` pointing at `/api/og` so LinkedIn / X / iMessage previews show the user's actual score
+- **ShareBadge polish**: "Copy share link" + "Share to X" buttons; LinkedIn share-text now appends the `/share` URL so its crawler can fetch the rich preview
+- **Comparison band on dashboard**: "you went from 67 to 78 (+11)" with up/down/flat states and a Twitter share-intent on positive deltas
+- **Per-card delta pill** anchored to each ScoreCard's score ring
+- **Per-row delta** in the scan-history dropdown
+- **Journey stats card on /history**: total improvement, best score, scan count, strongest-gain platform, days span
+- **Score timeline SVG chart on /history**: line chart with hover tooltips, no chart-library dep
+- **Live JD skill-extraction preview**: as the user types a JD, parse on a 400ms debounce and show detected role/industry/level + extracted skill chips (matched skills get a green check)
+- **Before/after example templates** on expanded suggestion cards (7 categories) with one-click copy on each block
+- **Cancellable in-flight scoring**: re-scan or reset aborts the prior fetch instead of leaking a stale response into state
+- **Live retry-after countdown** in the LLM-fallback toast when `/api/analyze` returns 429
+- **In-memory result cache** on `/api/analyze`, SHA-256 keyed by full prompt; same-input requests skip the LLM (verified live: 46s to 81ms, ~570x). Response shape adds `_cached` flag (additive, non-breaking)
+- **Improved rate-limit response**: `Retry-After` header + `retryAfter` body field, distinguishes minute vs daily reason, no longer double-charges minute slots on daily failures
+- **Auxiliary endpoints**: `/healthz` (JSON liveness probe), dynamic `/robots.txt` and `/sitemap.xml` (origin-tracking), `/api/csp-report` (logs CSP violations to Vercel logs)
+- **Security headers via hooks**: HSTS, Referrer-Policy, Permissions-Policy, X-Content-Type-Options, X-Frame-Options DENY, plus `Content-Security-Policy-Report-Only`
+- **Per-route SEO**: `SeoHead` component with og/twitter/canonical, plus JSON-LD `SoftwareApplication` on the landing page
+- **Branded `+error.svelte`** for 404 / 429 / 5xx
+- **Custom `/docs/[...slug]` catchall** for the Astro docs build with path-traversal protection (replaces hooks-based docs serving)
+- **Login form hardening**: email normalization (trim + lowercase) prevents duplicate-account bug from casing/whitespace; displayName maxlength
+
+### Changed
+
+- **Firebase SDK lazy-loaded** out of the root layout chunk (~488kb no longer ships to landing-page visitors who never sign in)
+- **`@vercel/og` response re-wrapped** so `Cache-Control` actually applies (the constructor's headers option concatenates rather than replaces)
+- **Migrated `$app/stores` to `$app/state`** (deprecated in newer SvelteKit)
+- **Single source of truth for `<meta name="robots">`**: removed the static tag from `app.html`; `SeoHead` now emits exactly one tag (indexable or noindex per route) so noIndex pages no longer ship conflicting directives
+- **`/api/og` runtime**: moved off the deprecated `runtime: 'edge'` config to default node runtime
+
+### Fixed
+
+- **`[object Object]` rendered in per-platform suggestions**: `ScoreBreakdown.svelte` interpolated structured suggestions without type-narrowing. Fixed with `suggestionText` / `suggestionDetails` helpers (same pattern report.ts already used). Hardened the equivalent fallback branch in `ScoreDashboard.svelte` with a `typeof` guard
+- **Rate-limiter cleanup throttled** to once per 30s so it doesn't run O(n) on every request once the IP map exceeds threshold (real perf cliff at scale)
+- **Snapshot-at-`startScoring`** fixes a race where a rapid re-scan compared against the wrong "previous" entry while the firestore save was still in flight
+- **Production build error**: moved docs serving out of `hooks.server.ts` into a `/docs/[...slug]` catchall so node-only `fs/path` imports don't pollute the shared bundle (was a real prod-blocking error from the edge bundler trying to resolve Node built-ins)
+- **JD-preview unhandled rejection**: debounced parser now wraps the IIFE in try/catch so transient parse failures don't surface as unhandled rejections
+- **Pass/total tampering**: `/api/og` and `/share` now clamp `pass` to `<= total` so a crafted URL like `?pass=6&total=1` cannot render impossible text
+- **Timeline y-coordinate clamped** to `[0, 100]` so anomalous out-of-range scores still render inside the chart padding box
+- **Suggestion copy buttons**: outer suggestion-card changed from `<button>` to `<div role="button">` so the inner copy `<button>`s are valid HTML (no nested interactive elements)
+
+### Tests
+
+- 184 tests passing (started at 106): added coverage for classification, fallback, cache, rate-limiter, comparison, timeline, journey, suggestion templates
+
 ## [0.1.0] - 2026-02-20
 
 ### Added

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,11 +21,14 @@ This project has both client-side and server-side components. Security considera
 
 - **Resume file privacy**: Resume files (PDF/DOCX) are parsed entirely in the browser using Web Workers. The original file is never uploaded to any server.
 - **Text transmission**: Extracted text from your resume is sent to Google Gemini for AI-powered scoring analysis. Only the text content is transmitted, not the file itself.
-- **Authentication**: Firebase Authentication handles user sign-in (Google + email/password). Auth tokens are managed by the Firebase SDK.
+- **Authentication**: Firebase Authentication handles user sign-in (Google + email/password). Auth tokens are managed by the Firebase SDK. Email is normalized (trim + lowercase) at signup/signin to prevent duplicate-account creation from casing variants.
 - **Data storage**: Scan history (scores and metadata) is stored in Cloud Firestore. Each user can only read/write their own data via Firestore security rules.
 - **API key protection**: Server-side API keys (Gemini, etc.) are stored as environment variables and never exposed to the client.
-- **Rate limiting**: The LLM proxy endpoint implements per-IP rate limiting to prevent abuse.
-- **Input sanitization**: All user inputs (resume text, job descriptions) are validated and length-capped before processing.
+- **Rate limiting**: The LLM proxy endpoint implements per-IP rate limiting (10 RPM, 200 RPD) and emits a standard `Retry-After` header on `429`. The cleanup sweep is throttled so an over-threshold map cannot stall request handling.
+- **Input sanitization**: All user inputs (resume text, job descriptions, OG / share query params) are validated and length-capped before processing. Tampered share parameters are clamped (e.g. `pass <= total`) so a crafted URL cannot render impossible state.
+- **Security headers**: All responses set HSTS (1y, includeSubDomains, preload), `Referrer-Policy: strict-origin-when-cross-origin`, `Permissions-Policy` opting out of camera/microphone/geolocation/payment/usb, `X-Content-Type-Options: nosniff`, and `X-Frame-Options: DENY`.
+- **Content Security Policy**: Currently shipped in `Content-Security-Policy-Report-Only` mode with violations posted to `/api/csp-report` (logged to Vercel logs only, no persistent storage). The directives cover SvelteKit hydration, Google Fonts, Firebase Auth + Firestore, and the LLM proxies.
+- **Static-file path traversal**: The `/docs/[...slug]` catchall validates that every resolved file path stays under `static/docs/` (resolve + `startsWith` check, plus `realpath` check against symlink escapes).
 
 ## Supported Versions
 

--- a/docs/src/content/docs/api/endpoints.md
+++ b/docs/src/content/docs/api/endpoints.md
@@ -127,11 +127,11 @@ The server keeps a SHA-256 keyed in-memory LRU of recent prompts (200 entries, 2
 
 ## Auxiliary Endpoints
 
-| Path                | Method | Purpose                                                                                |
-| ------------------- | ------ | -------------------------------------------------------------------------------------- |
-| `/healthz`          | GET    | Liveness probe — JSON `{ status, timestamp }`. For uptime monitors                     |
-| `/robots.txt`       | GET    | Dynamic; the `Sitemap:` URL tracks the deployment origin                               |
-| `/sitemap.xml`      | GET    | Dynamic; lists public routes (`/`, `/scanner`, `/about`) with `lastmod` and `priority` |
-| `/api/og`           | GET    | Edge-cached PNG (`@vercel/og`) for share previews. Query: `score`, `pass`, `total`, optional `delta` |
-| `/share`            | GET    | Branded share landing page; reads the same query params and emits `og:image` pointing at `/api/og`     |
-| `/api/csp-report`   | POST   | Receives Content-Security-Policy violation reports for the report-only header set by `hooks.server.ts` |
+| Path              | Method | Purpose                                                                                                |
+| ----------------- | ------ | ------------------------------------------------------------------------------------------------------ |
+| `/healthz`        | GET    | Liveness probe — JSON `{ status, timestamp }`. For uptime monitors                                     |
+| `/robots.txt`     | GET    | Dynamic; the `Sitemap:` URL tracks the deployment origin                                               |
+| `/sitemap.xml`    | GET    | Dynamic; lists public routes (`/`, `/scanner`, `/about`) with `lastmod` and `priority`                 |
+| `/api/og`         | GET    | Edge-cached PNG (`@vercel/og`) for share previews. Query: `score`, `pass`, `total`, optional `delta`   |
+| `/share`          | GET    | Branded share landing page; reads the same query params and emits `og:image` pointing at `/api/og`     |
+| `/api/csp-report` | POST   | Receives Content-Security-Policy violation reports for the report-only header set by `hooks.server.ts` |

--- a/docs/src/content/docs/api/endpoints.md
+++ b/docs/src/content/docs/api/endpoints.md
@@ -123,13 +123,13 @@ Extract structured requirements from a job description without scoring a resume.
 | `_fallback`              | boolean                    | `true` when all providers failed and the client must fall back to local rule-based scoring                 |
 | `_cached`                | boolean                    | `true` when the response was served from the in-memory result cache (sub-100ms, zero LLM cost)             |
 
-The server keeps a SHA-256 keyed in-memory LRU of recent prompts (200 entries, 24h TTL). Identical input hits the cache and returns instantly — the `_cached` flag tells you whether the response was a hit. The cache lives per Vercel instance; cold starts begin empty.
+The server keeps a SHA-256 keyed in-memory LRU of recent prompts (200 entries, 24h TTL). Identical input hits the cache and returns instantly; the `_cached` flag tells you whether the response was a hit. The cache lives per Vercel instance; cold starts begin empty.
 
 ## Auxiliary Endpoints
 
 | Path              | Method | Purpose                                                                                                |
 | ----------------- | ------ | ------------------------------------------------------------------------------------------------------ |
-| `/healthz`        | GET    | Liveness probe — JSON `{ status, timestamp }`. For uptime monitors                                     |
+| `/healthz`        | GET    | Liveness probe; JSON `{ status, timestamp }`. For uptime monitors                                      |
 | `/robots.txt`     | GET    | Dynamic; the `Sitemap:` URL tracks the deployment origin                                               |
 | `/sitemap.xml`    | GET    | Dynamic; lists public routes (`/`, `/scanner`, `/about`) with `lastmod` and `priority`                 |
 | `/api/og`         | GET    | Edge-cached PNG (`@vercel/og`) for share previews. Query: `score`, `pass`, `total`, optional `delta`   |

--- a/docs/src/content/docs/api/endpoints.md
+++ b/docs/src/content/docs/api/endpoints.md
@@ -103,20 +103,35 @@ Extract structured requirements from a job description without scoring a resume.
 			"suggestions": ["Add AWS and CI/CD keywords to match Workday's exact matching"]
 		}
 	],
-	"_provider": "gemini",
-	"_fallback": false
+	"_provider": "gemma-3-27b",
+	"_fallback": false,
+	"_cached": false
 }
 ```
 
 ### Response Fields
 
-| Field                    | Type     | Description                             |
-| ------------------------ | -------- | --------------------------------------- |
-| `results`                | array    | Array of 6 platform scoring objects     |
-| `results[].system`       | string   | Platform name                           |
-| `results[].overallScore` | number   | 0-100 weighted composite score          |
-| `results[].passesFilter` | boolean  | Whether resume passes initial screening |
-| `results[].breakdown`    | object   | Per-dimension scores and details        |
-| `results[].suggestions`  | string[] | Platform-specific improvement tips      |
-| `_provider`              | string   | Which LLM provider handled the request  |
-| `_fallback`              | boolean  | Whether a fallback provider was used    |
+| Field                    | Type                       | Description                                                                                                |
+| ------------------------ | -------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `results`                | array                      | Array of 6 platform scoring objects                                                                        |
+| `results[].system`       | string                     | Platform name                                                                                              |
+| `results[].overallScore` | number                     | 0-100 weighted composite score                                                                             |
+| `results[].passesFilter` | boolean                    | Whether resume passes initial screening                                                                    |
+| `results[].breakdown`    | object                     | Per-dimension scores and details                                                                           |
+| `results[].suggestions`  | string \| StructuredItem[] | Platform-specific improvement tips. May be plain strings (rule-based) or structured objects (LLM-enhanced) |
+| `_provider`              | string                     | Which LLM provider handled the request (e.g. `gemma-3-27b`, `groq-llama-3.3-70b`)                          |
+| `_fallback`              | boolean                    | `true` when all providers failed and the client must fall back to local rule-based scoring                 |
+| `_cached`                | boolean                    | `true` when the response was served from the in-memory result cache (sub-100ms, zero LLM cost)             |
+
+The server keeps a SHA-256 keyed in-memory LRU of recent prompts (200 entries, 24h TTL). Identical input hits the cache and returns instantly — the `_cached` flag tells you whether the response was a hit. The cache lives per Vercel instance; cold starts begin empty.
+
+## Auxiliary Endpoints
+
+| Path                | Method | Purpose                                                                                |
+| ------------------- | ------ | -------------------------------------------------------------------------------------- |
+| `/healthz`          | GET    | Liveness probe — JSON `{ status, timestamp }`. For uptime monitors                     |
+| `/robots.txt`       | GET    | Dynamic; the `Sitemap:` URL tracks the deployment origin                               |
+| `/sitemap.xml`      | GET    | Dynamic; lists public routes (`/`, `/scanner`, `/about`) with `lastmod` and `priority` |
+| `/api/og`           | GET    | Edge-cached PNG (`@vercel/og`) for share previews. Query: `score`, `pass`, `total`, optional `delta` |
+| `/share`            | GET    | Branded share landing page; reads the same query params and emits `og:image` pointing at `/api/og`     |
+| `/api/csp-report`   | POST   | Receives Content-Security-Policy violation reports for the report-only header set by `hooks.server.ts` |

--- a/docs/src/content/docs/api/rate-limits.md
+++ b/docs/src/content/docs/api/rate-limits.md
@@ -32,18 +32,28 @@ Cache-Control: no-store
 
 ## Handling Rate Limits
 
-When you receive a `429` response:
+When you receive a `429` response, the body distinguishes which window was hit and the response includes a `Retry-After` header set to the seconds-until-reset for that window:
+
+```http
+HTTP/1.1 429 Too Many Requests
+Retry-After: 60
+Content-Type: application/json
+```
 
 ```json
 {
-	"error": "rate limit exceeded. try again in 60 seconds."
+	"error": "rate limit exceeded: too many requests this minute. retry after 60s.",
+	"retryAfter": 60
 }
 ```
 
+The error string ends with either `too many requests this minute` (per-minute window) or `daily limit reached` (per-day window). The `retryAfter` field (seconds) and the `Retry-After` header always match; clients can use either.
+
 **Best practices:**
 
-- Implement exponential backoff in your client
-- Cache results locally to avoid redundant requests
+- Honor the `Retry-After` header — it is the exact reset window for the limit you tripped
+- Cache results locally to avoid redundant requests (the server also caches identical inputs in-memory; see the `_cached` flag in [endpoints](./endpoints))
+- Implement exponential backoff for transient 5xx errors (rate-limit 429s should use Retry-After directly)
 - For high-volume use, self-host with your own API keys
 
 ## Self-Hosted Limits

--- a/docs/src/content/docs/api/rate-limits.md
+++ b/docs/src/content/docs/api/rate-limits.md
@@ -51,7 +51,7 @@ The error string ends with either `too many requests this minute` (per-minute wi
 
 **Best practices:**
 
-- Honor the `Retry-After` header — it is the exact reset window for the limit you tripped
+- Honor the `Retry-After` header (it is the exact reset window for the limit you tripped)
 - Cache results locally to avoid redundant requests (the server also caches identical inputs in-memory; see the `_cached` flag in [endpoints](./endpoints))
 - Implement exponential backoff for transient 5xx errors (rate-limit 429s should use Retry-After directly)
 - For high-volume use, self-host with your own API keys

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
 	"dependencies": {
 		"@number-flow/svelte": "^0.3.11",
 		"@selemondev/svelte-marquee": "^0.1.1",
+		"@vercel/og": "^0.11.1",
 		"bits-ui": "^2.16.0",
 		"compromise": "^14.14.3",
 		"firebase": "^12.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ats-screener",
-	"version": "0.1.0",
+	"version": "0.2.0",
 	"private": true,
 	"license": "MIT",
 	"type": "module",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@selemondev/svelte-marquee':
         specifier: ^0.1.1
         version: 0.1.1(shiki@3.22.0)(svelte@5.53.0)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1))
+      '@vercel/og':
+        specifier: ^0.11.1
+        version: 0.11.1
       bits-ui:
         specifier: ^2.16.0
         version: 2.16.1(@internationalized/date@3.11.0)(@sveltejs/kit@2.52.2(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.0)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)))(svelte@5.53.0)(typescript@5.9.3)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)))(svelte@5.53.0)
@@ -144,6 +147,9 @@ packages:
   '@csstools/css-tokenizer@3.0.4':
     resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
     engines: {node: '>=18'}
+
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
@@ -592,6 +598,143 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
+    engines: {node: '>=18'}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.34.5':
+    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
+    cpu: [arm]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-linux-arm64@0.34.5':
+    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linux-arm@0.34.5':
+    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@img/sharp-linux-s390x@0.34.5':
+    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@img/sharp-linux-x64@0.34.5':
+    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-wasm32@0.34.5':
+    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [wasm32]
+
+  '@img/sharp-win32-arm64@0.34.5':
+    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-ia32@0.34.5':
+    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.34.5':
+    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [win32]
+
   '@internationalized/date@3.11.0':
     resolution: {integrity: sha512-BOx5huLAWhicM9/ZFs84CzP+V3gBW6vlpM02yzsdYC7TGlZJX1OJiEEHcSayF00Z+3jLlm4w79amvSt6RqKN3Q==}
 
@@ -732,6 +875,10 @@ packages:
 
   '@protobufjs/utf8@1.1.0':
     resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
+
+  '@resvg/resvg-wasm@2.4.0':
+    resolution: {integrity: sha512-C7c51Nn4yTxXFKvgh2txJFNweaVcfUPQxwEUFw4aWsCmfiBDJsTSwviIF8EcwjQ6k8bPyMWCl1vw4BdxE569Cg==}
+    engines: {node: '>= 10'}
 
   '@rollup/pluginutils@5.3.0':
     resolution: {integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==}
@@ -895,6 +1042,11 @@ packages:
 
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
+
+  '@shuding/opentype.js@1.4.0-beta.0':
+    resolution: {integrity: sha512-3NgmNyH3l/Hv6EvsWJbsvpcpUba6R8IREQ83nH83cyakCw7uM1arZKNfHwv1Wz6jgqrF/j4x5ELvR6PnK9nTcA==}
+    engines: {node: '>= 8.0.0'}
+    hasBin: true
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -1163,6 +1315,10 @@ packages:
     engines: {node: '>=20'}
     hasBin: true
 
+  '@vercel/og@0.11.1':
+    resolution: {integrity: sha512-02rXXRABFq1B03w3aNhcVfxkY+8Ba5QFi4ax0zS0oOiD/LL9WUd/LA7BjVPakrQmVhIBjuo2oBM5U25R9IuXMg==}
+    engines: {node: '>=16'}
+
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
 
@@ -1272,6 +1428,10 @@ packages:
     resolution: {integrity: sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==}
     engines: {node: '>= 0.6.0'}
 
+  base64-js@0.0.8:
+    resolution: {integrity: sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==}
+    engines: {node: '>= 0.4'}
+
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -1309,6 +1469,9 @@ packages:
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
+
+  camelize@1.0.1:
+    resolution: {integrity: sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==}
 
   canvg@3.0.11:
     resolution: {integrity: sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==}
@@ -1390,8 +1553,25 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css-background-parser@0.1.0:
+    resolution: {integrity: sha512-2EZLisiZQ+7m4wwur/qiYJRniHX4K5Tc9w93MT3AS0WS1u5kaZ4FKXlOTBhOjc+CgEgPiGY+fX1yWD8UwpEqUA==}
+
+  css-box-shadow@1.0.0-3:
+    resolution: {integrity: sha512-9jaqR6e7Ohds+aWwmhe6wILJ99xYQbfmK9QQB9CcMjDbTxPZjwEmUQpU91OG05Xgm8BahT5fW+svbsQGjS/zPg==}
+
+  css-color-keywords@1.0.0:
+    resolution: {integrity: sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==}
+    engines: {node: '>=4'}
+
+  css-gradient-parser@0.0.17:
+    resolution: {integrity: sha512-w2Xy9UMMwlKtou0vlRnXvWglPAceXCTtcmVSo8ZBUvqCV5aXEFP/PC6d+I464810I9FT++UACwTD5511bmGPUg==}
+    engines: {node: '>=16'}
+
   css-line-break@2.1.0:
     resolution: {integrity: sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==}
+
+  css-to-react-native@3.2.0:
+    resolution: {integrity: sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==}
 
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
@@ -1470,6 +1650,10 @@ packages:
     resolution: {integrity: sha512-/RInbCy1d4P6Zdfa+TMVsf/ufZVotat5hCw3QXmWtjU+3pFEOvOQ7ibo3aIxyCJw2leIeAMjmPj+1SLJiCpdrQ==}
     engines: {node: '>=12.0.0'}
 
+  emoji-regex-xs@2.0.1:
+    resolution: {integrity: sha512-1QFuh8l7LqUcKe24LsPUNzjrzJQ7pgRwp1QMcZ5MX6mFplk2zQ08NVCM84++1cveaUUYtcCYHmeFEuNg16sU4g==}
+    engines: {node: '>=10.0.0'}
+
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
@@ -1508,6 +1692,9 @@ packages:
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -1623,6 +1810,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fflate@0.7.4:
+    resolution: {integrity: sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw==}
 
   fflate@0.8.2:
     resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
@@ -1745,6 +1935,10 @@ packages:
 
   hastscript@9.0.1:
     resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
+
+  hex-rgb@4.3.0:
+    resolution: {integrity: sha512-Ox1pJVrDCyGHMG9CFg1tmrRUMRPRsAWYc/PinY0XzJU4K7y7vjNoLKIQ7BR5UJMCxNN8EM1MNDmHWA/B3aZUuw==}
+    engines: {node: '>=6'}
 
   hey-listen@1.0.8:
     resolution: {integrity: sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q==}
@@ -1959,6 +2153,9 @@ packages:
     resolution: {integrity: sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==}
     engines: {node: '>=10'}
 
+  linebreak@1.1.0:
+    resolution: {integrity: sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==}
+
   locate-character@3.0.0:
     resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
 
@@ -2141,6 +2338,9 @@ packages:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
 
+  pako@0.2.9:
+    resolution: {integrity: sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==}
+
   pako@1.0.11:
     resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
 
@@ -2150,6 +2350,9 @@ packages:
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
+
+  parse-css-color@0.2.1:
+    resolution: {integrity: sha512-bwS/GGIFV3b6KS4uwpzCFj4w297Yl3uqnSgIPsoQkx7GMLROXfMnWvxfNkL0oh8HVhZA4hvJoEoEIqonfJ3BWg==}
 
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
@@ -2228,6 +2431,9 @@ packages:
   postcss-selector-parser@6.1.2:
     resolution: {integrity: sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==}
     engines: {node: '>=4'}
+
+  postcss-value-parser@4.2.0:
+    resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
@@ -2337,6 +2543,10 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
+  satori@0.25.0:
+    resolution: {integrity: sha512-utINfLxrYrmSnLvxFT4ZwgwWa8KOjrz7ans32V5wItgHVmzESl/9i33nE38uG0miycab8hUqQtDlOpqrIpB/iw==}
+    engines: {node: '>=16'}
+
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
     engines: {node: '>=v12.22.7'}
@@ -2351,6 +2561,10 @@ packages:
 
   setimmediate@1.0.5:
     resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
+
+  sharp@0.34.5:
+    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -2399,6 +2613,9 @@ packages:
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
+
+  string.prototype.codepointat@0.2.1:
+    resolution: {integrity: sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg==}
 
   string_decoder@1.1.1:
     resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
@@ -2486,6 +2703,9 @@ packages:
   text-segmentation@1.0.3:
     resolution: {integrity: sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==}
 
+  tiny-inflate@1.0.3:
+    resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -2563,6 +2783,9 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  unicode-trie@2.0.0:
+    resolution: {integrity: sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==}
 
   unist-util-is@6.0.1:
     resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
@@ -2778,6 +3001,9 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
+  yoga-layout@3.2.1:
+    resolution: {integrity: sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==}
+
   zimmerframe@1.1.4:
     resolution: {integrity: sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==}
 
@@ -2823,6 +3049,11 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.4
 
   '@csstools/css-tokenizer@3.0.4': {}
+
+  '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
 
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
@@ -3304,6 +3535,103 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
+  '@img/colour@1.1.0':
+    optional: true
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-darwin-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-arm@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-s390x@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-wasm32@0.34.5':
+    dependencies:
+      '@emnapi/runtime': 1.10.0
+    optional: true
+
+  '@img/sharp-win32-arm64@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-ia32@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.34.5':
+    optional: true
+
   '@internationalized/date@3.11.0':
     dependencies:
       '@swc/helpers': 0.5.18
@@ -3426,6 +3754,8 @@ snapshots:
   '@protobufjs/pool@1.1.0': {}
 
   '@protobufjs/utf8@1.1.0': {}
+
+  '@resvg/resvg-wasm@2.4.0': {}
 
   '@rollup/pluginutils@5.3.0(rollup@4.58.0)':
     dependencies:
@@ -3560,6 +3890,11 @@ snapshots:
       '@types/hast': 3.0.4
 
   '@shikijs/vscode-textmate@10.0.2': {}
+
+  '@shuding/opentype.js@1.4.0-beta.0':
+    dependencies:
+      fflate: 0.7.4
+      string.prototype.codepointat: 0.2.1
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -3863,6 +4198,13 @@ snapshots:
       - rollup
       - supports-color
 
+  '@vercel/og@0.11.1':
+    dependencies:
+      '@resvg/resvg-wasm': 2.4.0
+      satori: 0.25.0
+    optionalDependencies:
+      sharp: 0.34.5
+
   '@vitest/expect@3.2.4':
     dependencies:
       '@types/chai': 5.2.3
@@ -3963,6 +4305,8 @@ snapshots:
   base64-arraybuffer@1.0.2:
     optional: true
 
+  base64-js@0.0.8: {}
+
   base64-js@1.5.1: {}
 
   bindings@1.5.0:
@@ -4005,6 +4349,8 @@ snapshots:
       function-bind: 1.1.2
 
   callsites@3.1.0: {}
+
+  camelize@1.0.1: {}
 
   canvg@3.0.11:
     dependencies:
@@ -4088,10 +4434,24 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css-background-parser@0.1.0: {}
+
+  css-box-shadow@1.0.0-3: {}
+
+  css-color-keywords@1.0.0: {}
+
+  css-gradient-parser@0.0.17: {}
+
   css-line-break@2.1.0:
     dependencies:
       utrie: 1.0.2
     optional: true
+
+  css-to-react-native@3.2.0:
+    dependencies:
+      camelize: 1.0.1
+      css-color-keywords: 1.0.0
+      postcss-value-parser: 4.2.0
 
   cssesc@3.0.0: {}
 
@@ -4151,6 +4511,8 @@ snapshots:
 
   efrt@2.7.0: {}
 
+  emoji-regex-xs@2.0.1: {}
+
   emoji-regex@8.0.0: {}
 
   enhanced-resolve@5.19.0:
@@ -4207,6 +4569,8 @@ snapshots:
       '@esbuild/win32-x64': 0.25.12
 
   escalade@3.2.0: {}
+
+  escape-html@1.0.3: {}
 
   escape-string-regexp@4.0.0: {}
 
@@ -4348,6 +4712,8 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
+
+  fflate@0.7.4: {}
 
   fflate@0.8.2: {}
 
@@ -4505,6 +4871,8 @@ snapshots:
       hast-util-parse-selector: 4.0.0
       property-information: 7.1.0
       space-separated-tokens: 2.0.2
+
+  hex-rgb@4.3.0: {}
 
   hey-listen@1.0.8: {}
 
@@ -4709,6 +5077,11 @@ snapshots:
 
   lilconfig@2.1.0: {}
 
+  linebreak@1.1.0:
+    dependencies:
+      base64-js: 0.0.8
+      unicode-trie: 2.0.0
+
   locate-character@3.0.0: {}
 
   locate-path@6.0.0:
@@ -4886,6 +5259,8 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
+  pako@0.2.9: {}
+
   pako@1.0.11: {}
 
   pako@2.1.0: {}
@@ -4893,6 +5268,11 @@ snapshots:
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
+
+  parse-css-color@0.2.1:
+    dependencies:
+      color-name: 1.1.4
+      hex-rgb: 4.3.0
 
   parse5@7.3.0:
     dependencies:
@@ -4951,6 +5331,8 @@ snapshots:
     dependencies:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
+
+  postcss-value-parser@4.2.0: {}
 
   postcss@8.5.6:
     dependencies:
@@ -5087,6 +5469,20 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
+  satori@0.25.0:
+    dependencies:
+      '@shuding/opentype.js': 1.4.0-beta.0
+      css-background-parser: 0.1.0
+      css-box-shadow: 1.0.0-3
+      css-gradient-parser: 0.0.17
+      css-to-react-native: 3.2.0
+      emoji-regex-xs: 2.0.1
+      escape-html: 1.0.3
+      linebreak: 1.1.0
+      parse-css-color: 0.2.1
+      postcss-value-parser: 4.2.0
+      yoga-layout: 3.2.1
+
   saxes@6.0.0:
     dependencies:
       xmlchars: 2.2.0
@@ -5096,6 +5492,38 @@ snapshots:
   set-cookie-parser@3.0.1: {}
 
   setimmediate@1.0.5: {}
+
+  sharp@0.34.5:
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.7.4
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.34.5
+      '@img/sharp-darwin-x64': 0.34.5
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+      '@img/sharp-libvips-linux-arm': 1.2.4
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+      '@img/sharp-libvips-linux-x64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+      '@img/sharp-linux-arm': 0.34.5
+      '@img/sharp-linux-arm64': 0.34.5
+      '@img/sharp-linux-ppc64': 0.34.5
+      '@img/sharp-linux-riscv64': 0.34.5
+      '@img/sharp-linux-s390x': 0.34.5
+      '@img/sharp-linux-x64': 0.34.5
+      '@img/sharp-linuxmusl-arm64': 0.34.5
+      '@img/sharp-linuxmusl-x64': 0.34.5
+      '@img/sharp-wasm32': 0.34.5
+      '@img/sharp-win32-arm64': 0.34.5
+      '@img/sharp-win32-ia32': 0.34.5
+      '@img/sharp-win32-x64': 0.34.5
+    optional: true
 
   shebang-command@2.0.0:
     dependencies:
@@ -5146,6 +5574,8 @@ snapshots:
       emoji-regex: 8.0.0
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
+
+  string.prototype.codepointat@0.2.1: {}
 
   string_decoder@1.1.1:
     dependencies:
@@ -5256,6 +5686,8 @@ snapshots:
       utrie: 1.0.2
     optional: true
 
+  tiny-inflate@1.0.3: {}
+
   tinybench@2.9.0: {}
 
   tinyexec@0.3.2: {}
@@ -5317,6 +5749,11 @@ snapshots:
   underscore@1.13.8: {}
 
   undici-types@6.21.0: {}
+
+  unicode-trie@2.0.0:
+    dependencies:
+      pako: 0.2.9
+      tiny-inflate: 1.0.3
 
   unist-util-is@6.0.1:
     dependencies:
@@ -5521,6 +5958,8 @@ snapshots:
       yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}
+
+  yoga-layout@3.2.1: {}
 
   zimmerframe@1.1.4: {}
 

--- a/src/app.html
+++ b/src/app.html
@@ -3,38 +3,10 @@
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<meta
-			name="description"
-			content="Free ATS resume screener that simulates real HCMS platforms. Get accurate scores for Workday, Taleo, iCIMS, Greenhouse, Lever, and SuccessFactors."
-		/>
 		<meta name="theme-color" content="#0a0a1a" />
 		<meta name="author" content="Sunny Patel" />
 		<meta name="robots" content="index, follow" />
-
-		<!-- open graph -->
-		<meta property="og:type" content="website" />
-		<meta property="og:site_name" content="ATS Screener" />
-		<meta property="og:url" content="https://ats-screener.vercel.app" />
-		<meta property="og:title" content="ATS Screener - Free Resume Scanner for Real ATS Platforms" />
-		<meta
-			property="og:description"
-			content="Free, open-source resume screener simulating Workday, Taleo, iCIMS, Greenhouse, Lever, and SuccessFactors. Real scores, not made-up numbers."
-		/>
-		<meta property="og:image" content="https://ats-screener.vercel.app/og-image.png" />
-		<meta property="og:image:width" content="1200" />
-		<meta property="og:image:height" content="630" />
-
-		<!-- twitter card -->
-		<meta name="twitter:card" content="summary_large_image" />
-		<meta
-			name="twitter:title"
-			content="ATS Screener - Free Resume Scanner for Real ATS Platforms"
-		/>
-		<meta
-			name="twitter:description"
-			content="Free, open-source resume screener simulating Workday, Taleo, iCIMS, Greenhouse, Lever, and SuccessFactors. Real scores, not made-up numbers."
-		/>
-		<meta name="twitter:image" content="https://ats-screener.vercel.app/og-image.png" />
+		<!-- per-route og/twitter/title/description/canonical are emitted by SeoHead -->
 
 		<link rel="icon" href="%sveltekit.assets%/favicon.svg" />
 		<link rel="apple-touch-icon" href="%sveltekit.assets%/apple-touch-icon.png" />

--- a/src/app.html
+++ b/src/app.html
@@ -5,8 +5,9 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="theme-color" content="#0a0a1a" />
 		<meta name="author" content="Sunny Patel" />
-		<meta name="robots" content="index, follow" />
-		<!-- per-route og/twitter/title/description/canonical are emitted by SeoHead -->
+		<!-- per-route robots/og/twitter/title/description/canonical are emitted by
+		     SeoHead. avoid a static robots tag here so noIndex pages don't ship
+		     conflicting directives ("index, follow" + "noindex, nofollow") -->
 
 		<link rel="icon" href="%sveltekit.assets%/favicon.svg" />
 		<link rel="apple-touch-icon" href="%sveltekit.assets%/apple-touch-icon.png" />

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -2,6 +2,22 @@ import type { Handle } from '@sveltejs/kit';
 import { readFileSync, existsSync } from 'fs';
 import { join } from 'path';
 
+// applied as defaults: routes that already set a header keep their value
+const SECURITY_HEADERS: Record<string, string> = {
+	'Strict-Transport-Security': 'max-age=31536000; includeSubDomains; preload',
+	'Referrer-Policy': 'strict-origin-when-cross-origin',
+	'Permissions-Policy': 'camera=(), microphone=(), geolocation=(), payment=(), usb=()',
+	'X-Content-Type-Options': 'nosniff',
+	'X-Frame-Options': 'DENY'
+};
+
+function applySecurityHeaders(response: Response): Response {
+	for (const [name, value] of Object.entries(SECURITY_HEADERS)) {
+		if (!response.headers.has(name)) response.headers.set(name, value);
+	}
+	return response;
+}
+
 export const handle: Handle = async ({ event, resolve }) => {
 	const path = event.url.pathname;
 
@@ -12,11 +28,13 @@ export const handle: Handle = async ({ event, resolve }) => {
 		const withIndex = join(staticBase, path, 'index.html');
 		if (existsSync(withIndex)) {
 			const html = readFileSync(withIndex, 'utf-8');
-			return new Response(html, {
-				headers: { 'Content-Type': 'text/html; charset=utf-8' }
-			});
+			return applySecurityHeaders(
+				new Response(html, {
+					headers: { 'Content-Type': 'text/html; charset=utf-8' }
+				})
+			);
 		}
 	}
 
-	return resolve(event);
+	return applySecurityHeaders(await resolve(event));
 };

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -36,8 +36,10 @@ function applySecurityHeaders(response: Response, path: string): Response {
 	for (const [name, value] of Object.entries(SECURITY_HEADERS)) {
 		if (!response.headers.has(name)) response.headers.set(name, value);
 	}
-	// don't apply CSP to the csp-report endpoint itself (avoid feedback loops on
-	// any future violation in error responses) or to non-html responses where it's irrelevant
+	// emit CSP-Report-Only on every response except the report endpoint itself
+	// (avoids feedback loops on its own error responses). browsers apply CSP
+	// directives only on document/iframe contexts so the header is benign on
+	// JSON / image / svg responses, just unread bytes on the wire
 	if (path !== '/api/csp-report' && !response.headers.has('Content-Security-Policy-Report-Only')) {
 		response.headers.set('Content-Security-Policy-Report-Only', CSP_REPORT_ONLY);
 	}

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -11,9 +11,34 @@ const SECURITY_HEADERS: Record<string, string> = {
 	'X-Frame-Options': 'DENY'
 };
 
-function applySecurityHeaders(response: Response): Response {
+// CSP in report-only mode: violations are reported to /api/csp-report but
+// nothing is blocked. lets us observe what would break before enforcing.
+// directives are sized for: SvelteKit hydration (inline scripts/styles),
+// Google Fonts, Firebase Auth (popup + APIs), Firestore, and the LLM proxies
+// the api/analyze route uses (groq + gemini are server-side, not in client connect-src)
+const CSP_REPORT_ONLY = [
+	"default-src 'self'",
+	"script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+	"style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+	"font-src 'self' https://fonts.gstatic.com",
+	"img-src 'self' data: https:",
+	"connect-src 'self' https://*.googleapis.com https://*.firebaseio.com https://*.firebaseapp.com https://*.firebase.com",
+	"frame-src 'self' https://*.firebaseapp.com https://accounts.google.com",
+	"worker-src 'self' blob:",
+	"object-src 'none'",
+	"base-uri 'self'",
+	"form-action 'self'",
+	'report-uri /api/csp-report'
+].join('; ');
+
+function applySecurityHeaders(response: Response, path: string): Response {
 	for (const [name, value] of Object.entries(SECURITY_HEADERS)) {
 		if (!response.headers.has(name)) response.headers.set(name, value);
+	}
+	// don't apply CSP to the csp-report endpoint itself (avoid feedback loops on
+	// any future violation in error responses) or to non-html responses where it's irrelevant
+	if (path !== '/api/csp-report' && !response.headers.has('Content-Security-Policy-Report-Only')) {
+		response.headers.set('Content-Security-Policy-Report-Only', CSP_REPORT_ONLY);
 	}
 	return response;
 }
@@ -31,10 +56,11 @@ export const handle: Handle = async ({ event, resolve }) => {
 			return applySecurityHeaders(
 				new Response(html, {
 					headers: { 'Content-Type': 'text/html; charset=utf-8' }
-				})
+				}),
+				path
 			);
 		}
 	}
 
-	return applySecurityHeaders(await resolve(event));
+	return applySecurityHeaders(await resolve(event), path);
 };

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,6 +1,7 @@
 import type { Handle } from '@sveltejs/kit';
-import { readFileSync, existsSync } from 'fs';
-import { join } from 'path';
+// no node built-ins here - hooks.server.ts is bundled into BOTH node and edge
+// route functions, and edge bundling fails on fs/path/node:crypto. docs serving
+// (which used fs) lives in a node-runtime catchall route at /docs/[...slug]
 
 // applied as defaults: routes that already set a header keep their value
 const SECURITY_HEADERS: Record<string, string> = {
@@ -45,22 +46,5 @@ function applySecurityHeaders(response: Response, path: string): Response {
 
 export const handle: Handle = async ({ event, resolve }) => {
 	const path = event.url.pathname;
-
-	// serve static docs (Astro Starlight build output)
-	if (path.startsWith('/docs')) {
-		const staticBase = join(process.cwd(), 'static');
-		// try path/index.html for directory-style URLs
-		const withIndex = join(staticBase, path, 'index.html');
-		if (existsSync(withIndex)) {
-			const html = readFileSync(withIndex, 'utf-8');
-			return applySecurityHeaders(
-				new Response(html, {
-					headers: { 'Content-Type': 'text/html; charset=utf-8' }
-				}),
-				path
-			);
-		}
-	}
-
 	return applySecurityHeaders(await resolve(event), path);
 };

--- a/src/lib/components/landing/Hero.svelte
+++ b/src/lib/components/landing/Hero.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
-	import { doc, getDoc } from 'firebase/firestore';
-	import { db } from '$lib/firebase';
+	import { getFirebase } from '$lib/firebase';
 	import FlipWords from '$components/ui/FlipWords.svelte';
 	import SparklesText from '$components/ui/SparklesText.svelte';
 	import NumberFlow from '@number-flow/svelte';
@@ -62,14 +61,20 @@
 	onMount(() => {
 		mounted = true;
 
-		// fetch live user count
-		getDoc(doc(db, 'stats', 'public'))
-			.then((snap) => {
+		// fetch live user count - lazy-imports firebase so the landing page
+		// doesn't pull the SDK into its critical bundle
+		(async () => {
+			try {
+				const { db } = await getFirebase();
+				const { doc, getDoc } = await import('firebase/firestore');
+				const snap = await getDoc(doc(db, 'stats', 'public'));
 				if (snap.exists()) {
 					userCount = snap.data().userCount ?? 0;
 				}
-			})
-			.catch(() => {});
+			} catch {
+				// non-critical; counter falls back to 0
+			}
+		})();
 	});
 
 	// converts pixel coords to percentage of hero bounds for the glow

--- a/src/lib/components/scoring/ScanHistory.svelte
+++ b/src/lib/components/scoring/ScanHistory.svelte
@@ -52,7 +52,11 @@
 
 {#if hasHistory}
 	<div class="history-section">
-		<button class="history-toggle" onclick={() => (expanded = !expanded)}>
+		<button
+			class="history-toggle"
+			onclick={() => (expanded = !expanded)}
+			aria-expanded={expanded}
+		>
 			<div class="toggle-left">
 				<svg
 					width="14"

--- a/src/lib/components/scoring/ScanHistory.svelte
+++ b/src/lib/components/scoring/ScanHistory.svelte
@@ -52,11 +52,7 @@
 
 {#if hasHistory}
 	<div class="history-section">
-		<button
-			class="history-toggle"
-			onclick={() => (expanded = !expanded)}
-			aria-expanded={expanded}
-		>
+		<button class="history-toggle" onclick={() => (expanded = !expanded)} aria-expanded={expanded}>
 			<div class="toggle-left">
 				<svg
 					width="14"

--- a/src/lib/components/scoring/ScanHistory.svelte
+++ b/src/lib/components/scoring/ScanHistory.svelte
@@ -6,6 +6,14 @@
 	const history = $derived(scoresStore.history);
 	const hasHistory = $derived(history.length > 0);
 
+	// per-row average-score delta vs the chronologically prior scan;
+	// history is newest-first so history[i+1] is the previous one
+	function deltaFor(index: number): number | null {
+		const prior = history[index + 1];
+		if (!prior) return null;
+		return history[index].averageScore - prior.averageScore;
+	}
+
 	function formatDate(iso: string): string {
 		const d = new Date(iso);
 		const now = new Date();
@@ -76,14 +84,27 @@
 
 		{#if expanded}
 			<div class="history-list">
-				{#each history as entry (entry.id)}
+				{#each history as entry, i (entry.id)}
+					{@const delta = deltaFor(i)}
 					<button
 						class="history-entry"
 						onclick={() => handleLoadEntry(entry)}
 						title="Click to view these results"
 					>
-						<div class="entry-score" style="color: {scoreColor(entry.averageScore)}">
-							{entry.averageScore}
+						<div class="entry-score-block">
+							<div class="entry-score" style="color: {scoreColor(entry.averageScore)}">
+								{entry.averageScore}
+							</div>
+							{#if delta !== null && delta !== 0}
+								<span
+									class="entry-delta"
+									class:positive={delta > 0}
+									class:negative={delta < 0}
+									title="{delta > 0 ? '+' : ''}{delta} vs previous scan"
+								>
+									{delta > 0 ? '+' : ''}{delta}
+								</span>
+							{/if}
 						</div>
 						<div class="entry-details">
 							<div class="entry-info">
@@ -238,12 +259,39 @@
 		background: rgba(6, 182, 212, 0.04);
 	}
 
+	.entry-score-block {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 0.15rem;
+		min-width: 2.5rem;
+	}
+
 	.entry-score {
 		font-size: 1.1rem;
 		font-weight: 800;
 		font-variant-numeric: tabular-nums;
-		min-width: 2.5rem;
 		text-align: center;
+		line-height: 1;
+	}
+
+	.entry-delta {
+		font-size: 0.62rem;
+		font-weight: 700;
+		font-variant-numeric: tabular-nums;
+		padding: 0.05rem 0.32rem;
+		border-radius: var(--radius-full);
+		line-height: 1.4;
+	}
+
+	.entry-delta.positive {
+		color: #22c55e;
+		background: rgba(34, 197, 94, 0.12);
+	}
+
+	.entry-delta.negative {
+		color: #ef4444;
+		background: rgba(239, 68, 68, 0.12);
 	}
 
 	.entry-details {

--- a/src/lib/components/scoring/ScoreBreakdown.svelte
+++ b/src/lib/components/scoring/ScoreBreakdown.svelte
@@ -9,7 +9,11 @@
 </script>
 
 <div class="breakdown" class:expanded>
-	<button class="breakdown-toggle" onclick={() => (expanded = !expanded)}>
+	<button
+		class="breakdown-toggle"
+		onclick={() => (expanded = !expanded)}
+		aria-expanded={expanded}
+	>
 		<div class="toggle-left">
 			<span class="toggle-system">{result.system}</span>
 			<span class="toggle-vendor">{result.vendor}</span>

--- a/src/lib/components/scoring/ScoreBreakdown.svelte
+++ b/src/lib/components/scoring/ScoreBreakdown.svelte
@@ -1,11 +1,26 @@
 <script lang="ts">
-	import type { ScoreResult } from '$engine/scorer/types';
+	import type { ScoreResult, Suggestion, StructuredSuggestion } from '$engine/scorer/types';
 	import { getScoreColor, getScoreLabel } from '$engine/scorer/classification';
 
 	let { result }: { result: ScoreResult } = $props();
 
 	// toggles the expanded state for this breakdown
 	let expanded = $state(false);
+
+	// suggestions can be either a plain string (legacy/rule-based path) or a
+	// StructuredSuggestion object (LLM path). without narrowing, svelte's text
+	// interpolation falls back to String(obj) and renders "[object Object]"
+	function isStructured(s: Suggestion): s is StructuredSuggestion {
+		return typeof s === 'object' && s !== null && 'summary' in s;
+	}
+	function suggestionText(s: Suggestion): string {
+		if (typeof s === 'string') return s;
+		if (isStructured(s)) return s.summary;
+		return '';
+	}
+	function suggestionDetails(s: Suggestion): string[] {
+		return isStructured(s) ? s.details : [];
+	}
 </script>
 
 <div class="breakdown" class:expanded>
@@ -190,7 +205,20 @@
 					<h4>Suggestions for {result.system}</h4>
 					<ul class="suggestion-list">
 						{#each result.suggestions as suggestion}
-							<li>{suggestion}</li>
+							{@const text = suggestionText(suggestion)}
+							{@const details = suggestionDetails(suggestion)}
+							{#if text}
+								<li>
+									<span class="suggestion-text">{text}</span>
+									{#if details.length > 0}
+										<ul class="suggestion-detail-list">
+											{#each details as detail}
+												<li>{detail}</li>
+											{/each}
+										</ul>
+									{/if}
+								</li>
+							{/if}
 						{/each}
 					</ul>
 				</div>
@@ -426,5 +454,32 @@
 		left: 0;
 		color: var(--accent-cyan);
 		font-weight: bold;
+	}
+
+	.suggestion-text {
+		display: block;
+	}
+
+	.suggestion-detail-list {
+		list-style: none;
+		padding: 0;
+		margin: 0.4rem 0 0.2rem;
+		display: flex;
+		flex-direction: column;
+		gap: 0.2rem;
+	}
+
+	.suggestion-detail-list li {
+		font-size: 0.78rem;
+		color: var(--text-tertiary);
+		padding-left: 0.85rem;
+		line-height: 1.5;
+	}
+
+	.suggestion-detail-list li::before {
+		content: '·';
+		left: 0;
+		color: var(--text-tertiary);
+		opacity: 0.7;
 	}
 </style>

--- a/src/lib/components/scoring/ScoreBreakdown.svelte
+++ b/src/lib/components/scoring/ScoreBreakdown.svelte
@@ -24,11 +24,7 @@
 </script>
 
 <div class="breakdown" class:expanded>
-	<button
-		class="breakdown-toggle"
-		onclick={() => (expanded = !expanded)}
-		aria-expanded={expanded}
-	>
+	<button class="breakdown-toggle" onclick={() => (expanded = !expanded)} aria-expanded={expanded}>
 		<div class="toggle-left">
 			<span class="toggle-system">{result.system}</span>
 			<span class="toggle-vendor">{result.vendor}</span>

--- a/src/lib/components/scoring/ScoreCard.svelte
+++ b/src/lib/components/scoring/ScoreCard.svelte
@@ -6,9 +6,7 @@
 
 	// only show the delta pill when there's a meaningful, signed change vs the
 	// previous scan; identical scores stay quiet to avoid visual noise
-	const delta = $derived(
-		previousScore !== undefined ? result.overallScore - previousScore : null
-	);
+	const delta = $derived(previousScore !== undefined ? result.overallScore - previousScore : null);
 	const showDelta = $derived(delta !== null && delta !== 0);
 
 	// mouse position in px for the spotlight hover effect

--- a/src/lib/components/scoring/ScoreCard.svelte
+++ b/src/lib/components/scoring/ScoreCard.svelte
@@ -2,7 +2,14 @@
 	import type { ScoreResult } from '$engine/scorer/types';
 	import { getScoreColor, getScoreLabel } from '$engine/scorer/classification';
 
-	let { result }: { result: ScoreResult } = $props();
+	let { result, previousScore }: { result: ScoreResult; previousScore?: number } = $props();
+
+	// only show the delta pill when there's a meaningful, signed change vs the
+	// previous scan; identical scores stay quiet to avoid visual noise
+	const delta = $derived(
+		previousScore !== undefined ? result.overallScore - previousScore : null
+	);
+	const showDelta = $derived(delta !== null && delta !== 0);
 
 	// mouse position in px for the spotlight hover effect
 	let mouseX = $state(0);
@@ -74,6 +81,16 @@
 			<span class="score-value" style="color: {scoreColor}">
 				{result.overallScore}
 			</span>
+			{#if showDelta && delta !== null}
+				<span
+					class="score-delta"
+					class:positive={delta > 0}
+					class:negative={delta < 0}
+					title="{delta > 0 ? '+' : ''}{delta} vs previous scan"
+				>
+					{delta > 0 ? '+' : ''}{delta}
+				</span>
+			{/if}
 		</div>
 	</div>
 
@@ -234,6 +251,32 @@
 
 	.score-progress {
 		transition: stroke-dashoffset 1.2s cubic-bezier(0.16, 1, 0.3, 1);
+	}
+
+	.score-delta {
+		position: absolute;
+		bottom: -10px;
+		right: -8px;
+		padding: 0.08rem 0.42rem;
+		font-size: 0.62rem;
+		font-weight: 700;
+		font-variant-numeric: tabular-nums;
+		border-radius: var(--radius-full);
+		line-height: 1.4;
+		white-space: nowrap;
+		box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
+	}
+
+	.score-delta.positive {
+		color: #22c55e;
+		background: rgba(34, 197, 94, 0.18);
+		border: 1px solid rgba(34, 197, 94, 0.32);
+	}
+
+	.score-delta.negative {
+		color: #ef4444;
+		background: rgba(239, 68, 68, 0.18);
+		border: 1px solid rgba(239, 68, 68, 0.32);
 	}
 
 	.card-status {

--- a/src/lib/components/scoring/ScoreDashboard.svelte
+++ b/src/lib/components/scoring/ScoreDashboard.svelte
@@ -9,6 +9,7 @@
 	import { generatePDF } from '$engine/scorer/report';
 	import { getScoreColor, getScoreLabel } from '$engine/scorer/classification';
 	import { computeScanComparison } from '$engine/scorer/comparison';
+	import { getExampleFor } from '$engine/suggestions/templates';
 	import type { Suggestion, StructuredSuggestion } from '$engine/scorer/types';
 
 	// derived stats for the summary card header
@@ -592,6 +593,12 @@
 								</div>
 							</div>
 							{#if expandedSuggestion === i}
+								{@const suggestionText = structured
+									? suggestion.summary
+									: typeof suggestion === 'string'
+										? suggestion
+										: ''}
+								{@const example = getExampleFor(suggestionText)}
 								<div class="suggestion-card-body">
 									{#if structured && suggestion.details.length > 0}
 										<ul class="suggestion-details">
@@ -601,6 +608,21 @@
 										</ul>
 									{:else if !structured}
 										<p>{suggestion}</p>
+									{/if}
+									{#if example}
+										<div class="suggestion-example">
+											<p class="example-tip">{example.tip}</p>
+											<div class="example-pair">
+												<div class="example-block before">
+													<span class="example-label">Before</span>
+													<pre>{example.before}</pre>
+												</div>
+												<div class="example-block after">
+													<span class="example-label">After</span>
+													<pre>{example.after}</pre>
+												</div>
+											</div>
+										</div>
 									{/if}
 								</div>
 							{/if}
@@ -1289,6 +1311,79 @@
 		border-radius: 50%;
 		background: var(--accent-cyan);
 		opacity: 0.6;
+	}
+
+	/* before/after example block inside expanded suggestion */
+	.suggestion-example {
+		margin-top: 1rem;
+		padding: 0.85rem 1rem 0.95rem;
+		background: rgba(255, 255, 255, 0.02);
+		border: 1px solid var(--glass-border);
+		border-radius: var(--radius-md);
+	}
+
+	.example-tip {
+		font-size: 0.78rem;
+		color: var(--text-secondary);
+		margin: 0 0 0.75rem;
+		line-height: 1.55;
+	}
+
+	.example-pair {
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+		gap: 0.6rem;
+	}
+
+	.example-block {
+		padding: 0.55rem 0.75rem;
+		border-radius: var(--radius-sm);
+		border: 1px solid;
+		min-width: 0;
+	}
+
+	.example-block.before {
+		background: rgba(239, 68, 68, 0.05);
+		border-color: rgba(239, 68, 68, 0.18);
+	}
+
+	.example-block.after {
+		background: rgba(34, 197, 94, 0.05);
+		border-color: rgba(34, 197, 94, 0.2);
+	}
+
+	.example-label {
+		display: block;
+		font-size: 0.62rem;
+		font-weight: 700;
+		text-transform: uppercase;
+		letter-spacing: 0.1em;
+		margin-bottom: 0.35rem;
+		opacity: 0.8;
+	}
+
+	.example-block.before .example-label {
+		color: #ef4444;
+	}
+
+	.example-block.after .example-label {
+		color: #22c55e;
+	}
+
+	.example-block pre {
+		margin: 0;
+		font-family: var(--font-mono);
+		font-size: 0.74rem;
+		line-height: 1.55;
+		color: var(--text-secondary);
+		white-space: pre-wrap;
+		word-break: break-word;
+	}
+
+	@media (max-width: 640px) {
+		.example-pair {
+			grid-template-columns: 1fr;
+		}
 	}
 
 	@keyframes cardExpand {

--- a/src/lib/components/scoring/ScoreDashboard.svelte
+++ b/src/lib/components/scoring/ScoreDashboard.svelte
@@ -104,6 +104,16 @@
 			? computeScanComparison(scoresStore.results, previousScan.results)
 			: null
 	);
+
+	// twitter share intent for the "I improved" moment - origin pulled from the
+	// page so preview deploys share their own URLs, not a hardcoded production one
+	function shareImprovementToTwitter() {
+		if (!comparison || comparison.deltaAverage <= 0) return;
+		const text = `Just improved my ATS resume score from ${comparison.previousAverage} to ${comparison.currentAverage} (+${comparison.deltaAverage}) using @ATSScreener — free, simulates how Workday, Lever, iCIMS and others actually parse resumes`;
+		const url = typeof window !== 'undefined' ? window.location.origin : '';
+		const shareUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(text)}&url=${encodeURIComponent(url)}`;
+		window.open(shareUrl, '_blank', 'noopener,noreferrer,width=600,height=520');
+	}
 </script>
 
 {#if scoresStore.hasResults}
@@ -254,6 +264,21 @@
 						{/if}
 						{#if comparison.unchanged > 0 && comparison.improved === 0 && comparison.regressed === 0}
 							<span class="meta-chip">{comparison.unchanged} unchanged</span>
+						{/if}
+						{#if positive}
+							<button
+								class="share-improvement-btn"
+								onclick={shareImprovementToTwitter}
+								title="Share this improvement on X"
+								aria-label="Share improvement on X"
+							>
+								<svg width="13" height="13" viewBox="0 0 24 24" fill="currentColor">
+									<path
+										d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"
+									/>
+								</svg>
+								Share +{comparison.deltaAverage}
+							</button>
 						{/if}
 					</div>
 				</div>
@@ -879,6 +904,35 @@
 		color: #ef4444;
 		border-color: rgba(239, 68, 68, 0.2);
 		background: rgba(239, 68, 68, 0.06);
+	}
+
+	.share-improvement-btn {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.32rem;
+		padding: 0.18rem 0.6rem;
+		font-size: 0.74rem;
+		font-weight: 600;
+		font-family: inherit;
+		color: var(--text-primary);
+		background: rgba(255, 255, 255, 0.08);
+		border: 1px solid rgba(255, 255, 255, 0.12);
+		border-radius: var(--radius-full);
+		cursor: pointer;
+		transition:
+			background 0.18s ease,
+			border-color 0.18s ease,
+			transform 0.18s ease;
+	}
+
+	.share-improvement-btn:hover {
+		background: rgba(34, 197, 94, 0.12);
+		border-color: rgba(34, 197, 94, 0.35);
+		transform: translateY(-1px);
+	}
+
+	.share-improvement-btn svg {
+		opacity: 0.85;
 	}
 
 	.fallback-toast-actions {

--- a/src/lib/components/scoring/ScoreDashboard.svelte
+++ b/src/lib/components/scoring/ScoreDashboard.svelte
@@ -79,10 +79,12 @@
 	let copiedKey = $state<string | null>(null);
 	let copiedTimer: ReturnType<typeof setTimeout> | null = null;
 
-	async function copyExample(text: string, key: string, e: MouseEvent) {
-		// the example block is inside a <button class="suggestion-card">, so without
+	// widened to Event so both pointer and keyboard handlers can pass through
+	// without unsafe casts (KeyboardEvent and MouseEvent both have stopPropagation)
+	async function copyExample(text: string, key: string, e: Event) {
+		// the example block is inside the suggestion-card click target, so without
 		// stopping propagation the click bubbles up and toggles the suggestion's
-		// expanded state - which collapses the block the user just copied from
+		// expanded state, which collapses the block the user just copied from
 		e.stopPropagation();
 		try {
 			await navigator.clipboard.writeText(text);
@@ -148,7 +150,7 @@
 	// dynamic PNG rendering this user's actual delta and score
 	function shareImprovementToTwitter() {
 		if (!comparison || comparison.deltaAverage <= 0 || typeof window === 'undefined') return;
-		const text = `Just improved my ATS resume score from ${comparison.previousAverage} to ${comparison.currentAverage} (+${comparison.deltaAverage}) using @ATSScreener — free, simulates how Workday, Lever, iCIMS and others actually parse resumes`;
+		const text = `Just improved my ATS resume score from ${comparison.previousAverage} to ${comparison.currentAverage} (+${comparison.deltaAverage}) using @ATSScreener (free, simulates how Workday, Lever, iCIMS and others actually parse resumes)`;
 		const params = new URLSearchParams({
 			score: String(scoresStore.averageScore),
 			pass: String(scoresStore.passingCount),
@@ -582,10 +584,22 @@
 									: i < 4
 										? 'medium'
 										: 'low'}
-						<button
+						<!-- div+role=button instead of <button> so the nested copy <button>s
+						     inside the body don't violate "no interactive descendants in a
+						     button" (invalid HTML, broken keyboard/screen-reader semantics) -->
+						<div
 							class="suggestion-card"
 							class:expanded={expandedSuggestion === i}
+							role="button"
+							tabindex="0"
+							aria-expanded={expandedSuggestion === i}
 							onclick={() => toggleSuggestion(i)}
+							onkeydown={(e) => {
+								if (e.key === 'Enter' || e.key === ' ') {
+									e.preventDefault();
+									toggleSuggestion(i);
+								}
+							}}
 						>
 							<div class="suggestion-card-header">
 								<div class="suggestion-card-left">
@@ -653,22 +667,11 @@
 												<div class="example-block before">
 													<div class="example-block-header">
 														<span class="example-label">Before</span>
-														<span
+														<button
+															type="button"
 															class="copy-btn"
 															class:copied={copiedKey === `${i}-before`}
-															role="button"
-															tabindex="0"
 															onclick={(e) => copyExample(example.before, `${i}-before`, e)}
-															onkeydown={(e) => {
-																if (e.key === 'Enter' || e.key === ' ') {
-																	e.preventDefault();
-																	copyExample(
-																		example.before,
-																		`${i}-before`,
-																		e as unknown as MouseEvent
-																	);
-																}
-															}}
 															aria-label="Copy before text"
 														>
 															{#if copiedKey === `${i}-before`}
@@ -699,29 +702,18 @@
 																</svg>
 																Copy
 															{/if}
-														</span>
+														</button>
 													</div>
 													<pre>{example.before}</pre>
 												</div>
 												<div class="example-block after">
 													<div class="example-block-header">
 														<span class="example-label">After</span>
-														<span
+														<button
+															type="button"
 															class="copy-btn"
 															class:copied={copiedKey === `${i}-after`}
-															role="button"
-															tabindex="0"
 															onclick={(e) => copyExample(example.after, `${i}-after`, e)}
-															onkeydown={(e) => {
-																if (e.key === 'Enter' || e.key === ' ') {
-																	e.preventDefault();
-																	copyExample(
-																		example.after,
-																		`${i}-after`,
-																		e as unknown as MouseEvent
-																	);
-																}
-															}}
 															aria-label="Copy after text"
 														>
 															{#if copiedKey === `${i}-after`}
@@ -752,7 +744,7 @@
 																</svg>
 																Copy
 															{/if}
-														</span>
+														</button>
 													</div>
 													<pre>{example.after}</pre>
 												</div>
@@ -761,7 +753,7 @@
 									{/if}
 								</div>
 							{/if}
-						</button>
+						</div>
 					{/each}
 				</div>
 			</div>

--- a/src/lib/components/scoring/ScoreDashboard.svelte
+++ b/src/lib/components/scoring/ScoreDashboard.svelte
@@ -71,6 +71,22 @@
 
 	// alias for backward compat in template
 	const getAvgColor = getScoreColor;
+
+	// live countdown for the rate-limit retry hint inside the fallback toast
+	// only ticks while the toast is visible and a retry timestamp is set
+	let now = $state(Date.now());
+	$effect(() => {
+		if (!scoresStore.llmFallback || scoresStore.llmRetryAtMs === null) return;
+		const id = setInterval(() => {
+			now = Date.now();
+		}, 1000);
+		return () => clearInterval(id);
+	});
+	const retrySecondsRemaining = $derived(
+		scoresStore.llmRetryAtMs !== null
+			? Math.max(0, Math.ceil((scoresStore.llmRetryAtMs - now) / 1000))
+			: 0
+	);
 </script>
 
 {#if scoresStore.hasResults}
@@ -168,6 +184,11 @@
 							(rule-based analysis), but the AI suggestions/accuracy won't be as specific. try again
 							later, or if you want to help keep this free for everyone
 							<span class="fallback-emoji">😅</span>
+							{#if retrySecondsRemaining > 0}
+								<span class="fallback-retry-hint">
+									AI scoring re-available in <strong>{retrySecondsRemaining}s</strong>
+								</span>
+							{/if}
 						</p>
 					</div>
 					<div class="fallback-toast-actions">
@@ -642,6 +663,19 @@
 		font-size: 1rem;
 		vertical-align: middle;
 		line-height: 1;
+	}
+
+	.fallback-retry-hint {
+		display: block;
+		margin-top: 0.4rem;
+		font-size: 0.78rem;
+		color: var(--text-tertiary);
+		font-variant-numeric: tabular-nums;
+	}
+
+	.fallback-retry-hint strong {
+		color: var(--accent-cyan);
+		font-weight: 600;
 	}
 
 	.fallback-toast-actions {

--- a/src/lib/components/scoring/ScoreDashboard.svelte
+++ b/src/lib/components/scoring/ScoreDashboard.svelte
@@ -640,7 +640,11 @@
 											{/each}
 										</ul>
 									{:else if !structured}
-										<p>{suggestion}</p>
+										<!-- defensive: if suggestion is somehow a non-string non-structured
+										value (e.g. malformed LLM output), interpolating directly would
+										render "[object Object]" - same class as the bug fixed in
+										ScoreBreakdown. typeof guard keeps the render type-safe -->
+										<p>{typeof suggestion === 'string' ? suggestion : ''}</p>
 									{/if}
 									{#if example}
 										<div class="suggestion-example">

--- a/src/lib/components/scoring/ScoreDashboard.svelte
+++ b/src/lib/components/scoring/ScoreDashboard.svelte
@@ -8,6 +8,7 @@
 	import ShareBadge from './ShareBadge.svelte';
 	import { generatePDF } from '$engine/scorer/report';
 	import { getScoreColor, getScoreLabel } from '$engine/scorer/classification';
+	import { computeScanComparison } from '$engine/scorer/comparison';
 	import type { Suggestion, StructuredSuggestion } from '$engine/scorer/types';
 
 	// derived stats for the summary card header
@@ -87,6 +88,22 @@
 			? Math.max(0, Math.ceil((scoresStore.llmRetryAtMs - now) / 1000))
 			: 0
 	);
+
+	// scan-vs-previous-scan comparison
+	// startScoring snapshots the previous top-of-history into previousScanForComparison,
+	// which avoids the brief race where scanHistory[1] is stale before the post-save reload
+	// finishes; we fall back to scanHistory[1] for any path that didn't go through startScoring
+	// suppressed when viewing a snapshot loaded from history
+	const previousScan = $derived(
+		scoresStore.isFromHistory
+			? null
+			: (scoresStore.previousScanForComparison ?? scoresStore.scanHistory[1] ?? null)
+	);
+	const comparison = $derived(
+		previousScan && scoresStore.hasResults
+			? computeScanComparison(scoresStore.results, previousScan.results)
+			: null
+	);
 </script>
 
 {#if scoresStore.hasResults}
@@ -158,6 +175,89 @@
 					</div>
 				</div>
 			</div>
+
+			{#if comparison}
+				{@const positive = comparison.deltaAverage > 0}
+				{@const negative = comparison.deltaAverage < 0}
+				<div
+					class="comparison-band"
+					class:up={positive}
+					class:down={negative}
+					class:flat={!positive && !negative}
+				>
+					<div class="comparison-headline">
+						{#if positive}
+							<svg
+								width="16"
+								height="16"
+								viewBox="0 0 24 24"
+								fill="none"
+								stroke="currentColor"
+								stroke-width="2"
+							>
+								<polyline points="17 6 23 6 23 12" />
+								<path d="M1 18l8-8 4 4 9-9" />
+							</svg>
+						{:else if negative}
+							<svg
+								width="16"
+								height="16"
+								viewBox="0 0 24 24"
+								fill="none"
+								stroke="currentColor"
+								stroke-width="2"
+							>
+								<polyline points="17 18 23 18 23 12" />
+								<path d="M1 6l8 8 4-4 9 9" />
+							</svg>
+						{:else}
+							<svg
+								width="16"
+								height="16"
+								viewBox="0 0 24 24"
+								fill="none"
+								stroke="currentColor"
+								stroke-width="2"
+							>
+								<line x1="5" y1="12" x2="19" y2="12" />
+							</svg>
+						{/if}
+						<span class="comparison-text">
+							{#if positive}
+								Your score went from <strong>{comparison.previousAverage}</strong> to
+								<strong>{comparison.currentAverage}</strong>
+								<span class="delta-pill positive">+{comparison.deltaAverage}</span>
+							{:else if negative}
+								Your score moved from <strong>{comparison.previousAverage}</strong> to
+								<strong>{comparison.currentAverage}</strong>
+								<span class="delta-pill negative">{comparison.deltaAverage}</span>
+							{:else}
+								No change since your last scan ({comparison.currentAverage})
+							{/if}
+						</span>
+					</div>
+					<div class="comparison-meta">
+						{#if comparison.deltaPassing !== 0}
+							<span
+								class="meta-chip"
+								class:positive={comparison.deltaPassing > 0}
+								class:negative={comparison.deltaPassing < 0}
+							>
+								{comparison.previousPassing} → {comparison.currentPassing} passing
+							</span>
+						{/if}
+						{#if comparison.improved > 0}
+							<span class="meta-chip positive">{comparison.improved} improved</span>
+						{/if}
+						{#if comparison.regressed > 0}
+							<span class="meta-chip negative">{comparison.regressed} regressed</span>
+						{/if}
+						{#if comparison.unchanged > 0 && comparison.improved === 0 && comparison.regressed === 0}
+							<span class="meta-chip">{comparison.unchanged} unchanged</span>
+						{/if}
+					</div>
+				</div>
+			{/if}
 
 			{#if scoresStore.llmFallback}
 				<div class="fallback-toast">
@@ -676,6 +776,109 @@
 	.fallback-retry-hint strong {
 		color: var(--accent-cyan);
 		font-weight: 600;
+	}
+
+	/* scan-vs-previous comparison band */
+	.comparison-band {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.75rem 1rem;
+		margin-top: 1rem;
+		padding: 0.75rem 1.1rem;
+		border-radius: var(--radius-lg);
+		background: var(--glass-bg);
+		border: 1px solid var(--glass-border);
+		backdrop-filter: blur(12px);
+	}
+
+	.comparison-band.up {
+		border-color: rgba(34, 197, 94, 0.25);
+		background: rgba(34, 197, 94, 0.04);
+	}
+
+	.comparison-band.down {
+		border-color: rgba(239, 68, 68, 0.22);
+		background: rgba(239, 68, 68, 0.04);
+	}
+
+	.comparison-band.flat {
+		border-color: rgba(255, 255, 255, 0.08);
+	}
+
+	.comparison-headline {
+		display: flex;
+		align-items: center;
+		gap: 0.6rem;
+		font-size: 0.88rem;
+		color: var(--text-secondary);
+	}
+
+	.comparison-band.up .comparison-headline svg {
+		color: #22c55e;
+	}
+
+	.comparison-band.down .comparison-headline svg {
+		color: #ef4444;
+	}
+
+	.comparison-band.flat .comparison-headline svg {
+		color: var(--text-tertiary);
+	}
+
+	.comparison-text strong {
+		color: var(--text-primary);
+		font-variant-numeric: tabular-nums;
+	}
+
+	.delta-pill {
+		display: inline-flex;
+		align-items: center;
+		padding: 0.1rem 0.5rem;
+		margin-left: 0.4rem;
+		font-size: 0.78rem;
+		font-weight: 600;
+		border-radius: var(--radius-full);
+		font-variant-numeric: tabular-nums;
+	}
+
+	.delta-pill.positive {
+		color: #22c55e;
+		background: rgba(34, 197, 94, 0.12);
+	}
+
+	.delta-pill.negative {
+		color: #ef4444;
+		background: rgba(239, 68, 68, 0.12);
+	}
+
+	.comparison-meta {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.4rem;
+	}
+
+	.meta-chip {
+		padding: 0.18rem 0.55rem;
+		font-size: 0.74rem;
+		color: var(--text-tertiary);
+		border-radius: var(--radius-full);
+		background: rgba(255, 255, 255, 0.04);
+		border: 1px solid rgba(255, 255, 255, 0.06);
+		font-variant-numeric: tabular-nums;
+	}
+
+	.meta-chip.positive {
+		color: #22c55e;
+		border-color: rgba(34, 197, 94, 0.2);
+		background: rgba(34, 197, 94, 0.06);
+	}
+
+	.meta-chip.negative {
+		color: #ef4444;
+		border-color: rgba(239, 68, 68, 0.2);
+		background: rgba(239, 68, 68, 0.06);
 	}
 
 	.fallback-toast-actions {

--- a/src/lib/components/scoring/ScoreDashboard.svelte
+++ b/src/lib/components/scoring/ScoreDashboard.svelte
@@ -74,6 +74,39 @@
 	// alias for backward compat in template
 	const getAvgColor = getScoreColor;
 
+	// per-block copy state for the example blocks - keyed by `${suggestionIndex}-${'before'|'after'}`
+	// so multiple copies can show their "copied" state without trampling each other
+	let copiedKey = $state<string | null>(null);
+	let copiedTimer: ReturnType<typeof setTimeout> | null = null;
+
+	async function copyExample(text: string, key: string, e: MouseEvent) {
+		// the example block is inside a <button class="suggestion-card">, so without
+		// stopping propagation the click bubbles up and toggles the suggestion's
+		// expanded state - which collapses the block the user just copied from
+		e.stopPropagation();
+		try {
+			await navigator.clipboard.writeText(text);
+		} catch {
+			const ta = document.createElement('textarea');
+			ta.value = text;
+			ta.style.position = 'fixed';
+			ta.style.opacity = '0';
+			document.body.appendChild(ta);
+			ta.select();
+			try {
+				document.execCommand('copy');
+			} finally {
+				document.body.removeChild(ta);
+			}
+		}
+		copiedKey = key;
+		if (copiedTimer) clearTimeout(copiedTimer);
+		copiedTimer = setTimeout(() => {
+			copiedKey = null;
+			copiedTimer = null;
+		}, 1600);
+	}
+
 	// live countdown for the rate-limit retry hint inside the fallback toast
 	// only ticks while the toast is visible and a retry timestamp is set
 	let now = $state(Date.now());
@@ -614,11 +647,109 @@
 											<p class="example-tip">{example.tip}</p>
 											<div class="example-pair">
 												<div class="example-block before">
-													<span class="example-label">Before</span>
+													<div class="example-block-header">
+														<span class="example-label">Before</span>
+														<span
+															class="copy-btn"
+															class:copied={copiedKey === `${i}-before`}
+															role="button"
+															tabindex="0"
+															onclick={(e) => copyExample(example.before, `${i}-before`, e)}
+															onkeydown={(e) => {
+																if (e.key === 'Enter' || e.key === ' ') {
+																	e.preventDefault();
+																	copyExample(
+																		example.before,
+																		`${i}-before`,
+																		e as unknown as MouseEvent
+																	);
+																}
+															}}
+															aria-label="Copy before text"
+														>
+															{#if copiedKey === `${i}-before`}
+																<svg
+																	width="11"
+																	height="11"
+																	viewBox="0 0 24 24"
+																	fill="none"
+																	stroke="currentColor"
+																	stroke-width="3"
+																>
+																	<polyline points="20,6 9,17 4,12" />
+																</svg>
+																Copied
+															{:else}
+																<svg
+																	width="11"
+																	height="11"
+																	viewBox="0 0 24 24"
+																	fill="none"
+																	stroke="currentColor"
+																	stroke-width="2"
+																>
+																	<rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+																	<path
+																		d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"
+																	/>
+																</svg>
+																Copy
+															{/if}
+														</span>
+													</div>
 													<pre>{example.before}</pre>
 												</div>
 												<div class="example-block after">
-													<span class="example-label">After</span>
+													<div class="example-block-header">
+														<span class="example-label">After</span>
+														<span
+															class="copy-btn"
+															class:copied={copiedKey === `${i}-after`}
+															role="button"
+															tabindex="0"
+															onclick={(e) => copyExample(example.after, `${i}-after`, e)}
+															onkeydown={(e) => {
+																if (e.key === 'Enter' || e.key === ' ') {
+																	e.preventDefault();
+																	copyExample(
+																		example.after,
+																		`${i}-after`,
+																		e as unknown as MouseEvent
+																	);
+																}
+															}}
+															aria-label="Copy after text"
+														>
+															{#if copiedKey === `${i}-after`}
+																<svg
+																	width="11"
+																	height="11"
+																	viewBox="0 0 24 24"
+																	fill="none"
+																	stroke="currentColor"
+																	stroke-width="3"
+																>
+																	<polyline points="20,6 9,17 4,12" />
+																</svg>
+																Copied
+															{:else}
+																<svg
+																	width="11"
+																	height="11"
+																	viewBox="0 0 24 24"
+																	fill="none"
+																	stroke="currentColor"
+																	stroke-width="2"
+																>
+																	<rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+																	<path
+																		d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"
+																	/>
+																</svg>
+																Copy
+															{/if}
+														</span>
+													</div>
 													<pre>{example.after}</pre>
 												</div>
 											</div>
@@ -1352,14 +1483,57 @@
 		border-color: rgba(34, 197, 94, 0.2);
 	}
 
+	.example-block-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.5rem;
+		margin-bottom: 0.35rem;
+	}
+
 	.example-label {
 		display: block;
 		font-size: 0.62rem;
 		font-weight: 700;
 		text-transform: uppercase;
 		letter-spacing: 0.1em;
-		margin-bottom: 0.35rem;
 		opacity: 0.8;
+	}
+
+	.copy-btn {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.25rem;
+		padding: 0.1rem 0.45rem;
+		font-size: 0.66rem;
+		font-weight: 600;
+		color: var(--text-tertiary);
+		background: rgba(255, 255, 255, 0.04);
+		border: 1px solid rgba(255, 255, 255, 0.08);
+		border-radius: var(--radius-full);
+		cursor: pointer;
+		transition:
+			background 0.15s ease,
+			border-color 0.15s ease,
+			color 0.15s ease;
+		user-select: none;
+	}
+
+	.copy-btn:hover {
+		background: rgba(255, 255, 255, 0.08);
+		border-color: rgba(255, 255, 255, 0.16);
+		color: var(--text-secondary);
+	}
+
+	.copy-btn:focus-visible {
+		outline: 2px solid var(--accent-cyan);
+		outline-offset: 2px;
+	}
+
+	.copy-btn.copied {
+		color: #22c55e;
+		background: rgba(34, 197, 94, 0.1);
+		border-color: rgba(34, 197, 94, 0.28);
 	}
 
 	.example-block.before .example-label {

--- a/src/lib/components/scoring/ScoreDashboard.svelte
+++ b/src/lib/components/scoring/ScoreDashboard.svelte
@@ -105,14 +105,21 @@
 			: null
 	);
 
-	// twitter share intent for the "I improved" moment - origin pulled from the
-	// page so preview deploys share their own URLs, not a hardcoded production one
+	// twitter share intent for the "I improved" moment - the URL points at /share
+	// (not the homepage) so twitter's crawler fetches a page whose og:image is a
+	// dynamic PNG rendering this user's actual delta and score
 	function shareImprovementToTwitter() {
-		if (!comparison || comparison.deltaAverage <= 0) return;
+		if (!comparison || comparison.deltaAverage <= 0 || typeof window === 'undefined') return;
 		const text = `Just improved my ATS resume score from ${comparison.previousAverage} to ${comparison.currentAverage} (+${comparison.deltaAverage}) using @ATSScreener — free, simulates how Workday, Lever, iCIMS and others actually parse resumes`;
-		const url = typeof window !== 'undefined' ? window.location.origin : '';
-		const shareUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(text)}&url=${encodeURIComponent(url)}`;
-		window.open(shareUrl, '_blank', 'noopener,noreferrer,width=600,height=520');
+		const params = new URLSearchParams({
+			score: String(scoresStore.averageScore),
+			pass: String(scoresStore.passingCount),
+			total: String(scoresStore.results.length),
+			delta: String(comparison.deltaAverage)
+		});
+		const sharePageUrl = `${window.location.origin}/share?${params.toString()}`;
+		const intent = `https://twitter.com/intent/tweet?text=${encodeURIComponent(text)}&url=${encodeURIComponent(sharePageUrl)}`;
+		window.open(intent, '_blank', 'noopener,noreferrer,width=600,height=520');
 	}
 </script>
 

--- a/src/lib/components/scoring/ScoreDashboard.svelte
+++ b/src/lib/components/scoring/ScoreDashboard.svelte
@@ -104,6 +104,10 @@
 			? computeScanComparison(scoresStore.results, previousScan.results)
 			: null
 	);
+	// fast lookup so each ScoreCard can render its own delta in the grid
+	const previousByPlatform = $derived(
+		new Map(comparison?.platforms.map((p) => [p.system, p.previous]) ?? [])
+	);
 
 	// twitter share intent for the "I improved" moment - the URL points at /share
 	// (not the homepage) so twitter's crawler fetches a page whose og:image is a
@@ -487,7 +491,7 @@
 		{#if activeView === 'cards'}
 			<div class="scores-grid">
 				{#each scoresStore.results as result (result.system)}
-					<ScoreCard {result} />
+					<ScoreCard {result} previousScore={previousByPlatform.get(result.system)} />
 				{/each}
 			</div>
 		{:else}

--- a/src/lib/components/scoring/ScoreTimeline.svelte
+++ b/src/lib/components/scoring/ScoreTimeline.svelte
@@ -1,0 +1,276 @@
+<script lang="ts">
+	import { computeTimeline, type TimelinePoint } from '$engine/scorer/timeline';
+	import { getScoreColor } from '$engine/scorer/classification';
+	import type { ScanHistoryEntry } from '$stores/scores.svelte';
+
+	let { entries }: { entries: ScanHistoryEntry[] } = $props();
+
+	const chart = $derived(
+		computeTimeline(
+			entries.map((e) => ({
+				id: e.id,
+				timestamp: e.timestamp,
+				averageScore: e.averageScore,
+				fileName: e.fileName,
+				mode: e.mode
+			}))
+		)
+	);
+
+	let hoverIndex = $state<number | null>(null);
+	const hoverPoint = $derived(
+		hoverIndex !== null && chart ? (chart.points[hoverIndex] ?? null) : null
+	);
+
+	function shortDate(iso: string): string {
+		const d = new Date(iso);
+		return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+	}
+
+	function fmtTooltipDate(iso: string): string {
+		const d = new Date(iso);
+		return d.toLocaleDateString('en-US', {
+			month: 'short',
+			day: 'numeric',
+			year: 'numeric'
+		});
+	}
+
+	// pick the index whose x is closest to the pointer; works for sparse points
+	function handleMove(e: PointerEvent, svgEl: SVGSVGElement) {
+		if (!chart) return;
+		const rect = svgEl.getBoundingClientRect();
+		const xRatio = (e.clientX - rect.left) / rect.width;
+		const xInChart = xRatio * chart.width;
+		let nearest = 0;
+		let bestDist = Infinity;
+		for (let i = 0; i < chart.points.length; i++) {
+			const d = Math.abs(chart.points[i].x - xInChart);
+			if (d < bestDist) {
+				bestDist = d;
+				nearest = i;
+			}
+		}
+		hoverIndex = nearest;
+	}
+
+	function handleLeave() {
+		hoverIndex = null;
+	}
+
+	// per-point hover dots get a slight halo when active
+	function dotRadius(p: TimelinePoint, active: boolean): number {
+		void p;
+		return active ? 6 : 4;
+	}
+</script>
+
+{#if chart}
+	<div class="timeline-wrap">
+		<div class="timeline-header">
+			<h3>Score over time</h3>
+			<span class="timeline-meta">{chart.points.length} scans</span>
+		</div>
+		<div class="chart-shell">
+			<svg
+				viewBox="0 0 {chart.width} {chart.height}"
+				preserveAspectRatio="none"
+				class="timeline-svg"
+				role="img"
+				aria-label="Line chart of resume scores over time"
+				onpointermove={(e) => handleMove(e, e.currentTarget as SVGSVGElement)}
+				onpointerleave={handleLeave}
+			>
+				<defs>
+					<linearGradient id="timelineFill" x1="0" y1="0" x2="0" y2="1">
+						<stop offset="0%" stop-color="#06b6d4" stop-opacity="0.32" />
+						<stop offset="100%" stop-color="#06b6d4" stop-opacity="0" />
+					</linearGradient>
+					<linearGradient id="timelineStroke" x1="0" y1="0" x2="1" y2="0">
+						<stop offset="0%" stop-color="#06b6d4" />
+						<stop offset="100%" stop-color="#8b5cf6" />
+					</linearGradient>
+				</defs>
+
+				<!-- baseline rule -->
+				<line
+					x1={chart.innerLeft}
+					y1={chart.innerBottom}
+					x2={chart.innerRight}
+					y2={chart.innerBottom}
+					stroke="rgba(255,255,255,0.06)"
+					stroke-width="1"
+				/>
+
+				<!-- area fill -->
+				<path d={chart.areaD} fill="url(#timelineFill)" />
+				<!-- line -->
+				<path
+					d={chart.pathD}
+					fill="none"
+					stroke="url(#timelineStroke)"
+					stroke-width="2"
+					stroke-linecap="round"
+					stroke-linejoin="round"
+				/>
+
+				<!-- score dots -->
+				{#each chart.points as p, i}
+					<circle
+						cx={p.x}
+						cy={p.y}
+						r={dotRadius(p, hoverIndex === i)}
+						fill={getScoreColor(p.score)}
+						stroke="var(--color-bg-primary)"
+						stroke-width="2"
+					/>
+				{/each}
+
+				<!-- guide line at the hovered x -->
+				{#if hoverPoint}
+					<line
+						x1={hoverPoint.x}
+						y1={chart.innerTop}
+						x2={hoverPoint.x}
+						y2={chart.innerBottom}
+						stroke="rgba(255,255,255,0.18)"
+						stroke-width="1"
+						stroke-dasharray="3 3"
+					/>
+				{/if}
+			</svg>
+
+			<!-- absolute-positioned tooltip; placed in DOM (not SVG) so it can use real CSS -->
+			{#if hoverPoint && chart}
+				{@const xPct = (hoverPoint.x / chart.width) * 100}
+				{@const onLeft = xPct > 65}
+				<div
+					class="timeline-tooltip"
+					class:left={onLeft}
+					style="left: {xPct}%; top: {(hoverPoint.y / chart.height) * 100}%;"
+				>
+					<div class="tooltip-row">
+						<span class="tooltip-score" style="color: {getScoreColor(hoverPoint.score)}">
+							{hoverPoint.score}
+						</span>
+						<span class="tooltip-mode">{hoverPoint.mode}</span>
+					</div>
+					{#if hoverPoint.fileName}
+						<div class="tooltip-file">{hoverPoint.fileName}</div>
+					{/if}
+					<div class="tooltip-date">{fmtTooltipDate(hoverPoint.timestamp)}</div>
+				</div>
+			{/if}
+		</div>
+
+		<!-- x-axis labels: first and last only to avoid clutter -->
+		<div class="x-axis">
+			<span>{shortDate(chart.points[0].timestamp)}</span>
+			<span>{shortDate(chart.points[chart.points.length - 1].timestamp)}</span>
+		</div>
+	</div>
+{/if}
+
+<style>
+	.timeline-wrap {
+		padding: 1.25rem 1.25rem 1rem;
+		background: var(--glass-bg);
+		border: 1px solid var(--glass-border);
+		border-radius: var(--radius-lg);
+		backdrop-filter: blur(12px);
+	}
+
+	.timeline-header {
+		display: flex;
+		align-items: baseline;
+		justify-content: space-between;
+		margin-bottom: 0.85rem;
+	}
+
+	.timeline-header h3 {
+		font-size: 0.92rem;
+		font-weight: 700;
+		color: var(--text-primary);
+		margin: 0;
+	}
+
+	.timeline-meta {
+		font-size: 0.72rem;
+		color: var(--text-tertiary);
+		font-variant-numeric: tabular-nums;
+	}
+
+	.chart-shell {
+		position: relative;
+		width: 100%;
+	}
+
+	.timeline-svg {
+		width: 100%;
+		height: 220px;
+		display: block;
+		touch-action: none;
+	}
+
+	.timeline-tooltip {
+		position: absolute;
+		transform: translate(-50%, calc(-100% - 12px));
+		padding: 0.5rem 0.75rem;
+		background: rgba(10, 10, 26, 0.96);
+		border: 1px solid var(--glass-border);
+		border-radius: var(--radius-md);
+		pointer-events: none;
+		min-width: 110px;
+		box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+		backdrop-filter: blur(8px);
+	}
+
+	.timeline-tooltip.left {
+		transform: translate(calc(-100% + 8px), calc(-100% - 12px));
+	}
+
+	.tooltip-row {
+		display: flex;
+		align-items: baseline;
+		gap: 0.5rem;
+	}
+
+	.tooltip-score {
+		font-size: 1.2rem;
+		font-weight: 800;
+		font-variant-numeric: tabular-nums;
+	}
+
+	.tooltip-mode {
+		font-size: 0.65rem;
+		text-transform: uppercase;
+		letter-spacing: 0.08em;
+		color: var(--text-tertiary);
+	}
+
+	.tooltip-file {
+		font-size: 0.72rem;
+		color: var(--text-secondary);
+		margin-top: 0.2rem;
+		max-width: 180px;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.tooltip-date {
+		font-size: 0.7rem;
+		color: var(--text-tertiary);
+		margin-top: 0.15rem;
+	}
+
+	.x-axis {
+		display: flex;
+		justify-content: space-between;
+		font-size: 0.7rem;
+		color: var(--text-tertiary);
+		font-variant-numeric: tabular-nums;
+		padding: 0 0.5rem;
+		margin-top: 0.4rem;
+	}
+</style>

--- a/src/lib/components/scoring/ShareBadge.svelte
+++ b/src/lib/components/scoring/ShareBadge.svelte
@@ -125,6 +125,15 @@
 		window.open(url, '_blank', 'noopener,noreferrer');
 	}
 
+	function shareToTwitter() {
+		// X has a 280-char tweet cap; build a tighter version of shareText
+		const tight = `Just scored ${avgScore}/100 on ATS Screener — free, simulates how Workday, Lever, iCIMS and others actually parse resumes. ${passCount}/${totalCount} systems passed.`;
+		const params = new URLSearchParams({ text: tight });
+		if (shareUrl) params.set('url', shareUrl);
+		const url = `https://twitter.com/intent/tweet?${params.toString()}`;
+		window.open(url, '_blank', 'noopener,noreferrer,width=600,height=520');
+	}
+
 	function addToLinkedInProfile() {
 		const d = new Date();
 		const year = d.getFullYear();
@@ -620,6 +629,15 @@
 						Share to LinkedIn
 					</button>
 
+					<button class="action-btn twitter" onclick={shareToTwitter}>
+						<svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
+							<path
+								d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"
+							/>
+						</svg>
+						Share to X
+					</button>
+
 					<button class="action-btn secondary" onclick={addToLinkedInProfile}>
 						<svg
 							width="16"
@@ -823,6 +841,18 @@
 		background: rgba(10, 102, 194, 0.25);
 		border-color: rgba(10, 102, 194, 0.45);
 		box-shadow: 0 0 20px rgba(10, 102, 194, 0.1);
+	}
+
+	.action-btn.twitter {
+		background: rgba(255, 255, 255, 0.06);
+		border-color: rgba(255, 255, 255, 0.14);
+		color: var(--text-primary);
+	}
+
+	.action-btn.twitter:hover {
+		background: rgba(255, 255, 255, 0.1);
+		border-color: rgba(255, 255, 255, 0.22);
+		box-shadow: 0 0 18px rgba(255, 255, 255, 0.05);
 	}
 
 	.action-btn.secondary {

--- a/src/lib/components/scoring/ShareBadge.svelte
+++ b/src/lib/components/scoring/ShareBadge.svelte
@@ -25,9 +25,47 @@
 	const circumference = 2 * Math.PI * 58;
 	const dashOffset = $derived(circumference - (avgScore / 100) * circumference);
 
+	// score-encoded share URL pointed at the /share landing page; that page's
+	// og:image references /api/og with the same params, so when LinkedIn or
+	// Twitter scrape this URL the preview shows the user's actual score
+	const shareUrl = $derived.by(() => {
+		if (typeof window === 'undefined') return '';
+		const params = new URLSearchParams({
+			score: String(avgScore),
+			pass: String(passCount),
+			total: String(totalCount)
+		});
+		return `${window.location.origin}/share?${params.toString()}`;
+	});
+
 	const shareText = $derived(
 		`Just scored ${avgScore}/100 on ATS Screener, a free open-source resume tool by linkedin.com/in/sunny-patel-30b460204 that simulates how real ATS platforms (Workday, Taleo, iCIMS, Greenhouse, Lever, and SuccessFactors) parse your resume.\n\n${passCount}/${totalCount} systems passed. Try it free at ats-screener.vercel.app\n\n#ATSScreener #Resume #JobSearch #OpenSource #CareerTips`
 	);
+
+	let copyState = $state<'idle' | 'copied'>('idle');
+	async function copyShareLink() {
+		if (!shareUrl) return;
+		try {
+			await navigator.clipboard.writeText(shareUrl);
+			copyState = 'copied';
+			setTimeout(() => (copyState = 'idle'), 1800);
+		} catch {
+			// clipboard API can fail on insecure origins; fall back to textarea+execCommand
+			const ta = document.createElement('textarea');
+			ta.value = shareUrl;
+			ta.style.position = 'fixed';
+			ta.style.opacity = '0';
+			document.body.appendChild(ta);
+			ta.select();
+			try {
+				document.execCommand('copy');
+				copyState = 'copied';
+				setTimeout(() => (copyState = 'idle'), 1800);
+			} finally {
+				document.body.removeChild(ta);
+			}
+		}
+	}
 
 	function close() {
 		open = false;
@@ -80,7 +118,10 @@
 	}
 
 	function shareToLinkedIn() {
-		const url = `https://www.linkedin.com/feed/?shareActive=true&text=${encodeURIComponent(shareText)}`;
+		// include the /share URL in the post text so linkedin's crawler fetches
+		// it and renders the dynamic OG card in the preview
+		const fullText = shareUrl ? `${shareText}\n\n${shareUrl}` : shareText;
+		const url = `https://www.linkedin.com/feed/?shareActive=true&text=${encodeURIComponent(fullText)}`;
 		window.open(url, '_blank', 'noopener,noreferrer');
 	}
 
@@ -593,6 +634,39 @@
 							<line x1="8" y1="12" x2="16" y2="12" />
 						</svg>
 						Add to LinkedIn Profile
+					</button>
+
+					<button
+						class="action-btn secondary"
+						onclick={copyShareLink}
+						aria-label="Copy share link"
+					>
+						{#if copyState === 'copied'}
+							<svg
+								width="16"
+								height="16"
+								viewBox="0 0 24 24"
+								fill="none"
+								stroke="#22c55e"
+								stroke-width="2"
+							>
+								<polyline points="20,6 9,17 4,12" />
+							</svg>
+							Link copied
+						{:else}
+							<svg
+								width="16"
+								height="16"
+								viewBox="0 0 24 24"
+								fill="none"
+								stroke="currentColor"
+								stroke-width="2"
+							>
+								<rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+								<path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+							</svg>
+							Copy share link
+						{/if}
 					</button>
 				</div>
 			</div>

--- a/src/lib/components/scoring/ShareBadge.svelte
+++ b/src/lib/components/scoring/ShareBadge.svelte
@@ -654,11 +654,7 @@
 						Add to LinkedIn Profile
 					</button>
 
-					<button
-						class="action-btn secondary"
-						onclick={copyShareLink}
-						aria-label="Copy share link"
-					>
+					<button class="action-btn secondary" onclick={copyShareLink} aria-label="Copy share link">
 						{#if copyState === 'copied'}
 							<svg
 								width="16"

--- a/src/lib/components/scoring/ShareBadge.svelte
+++ b/src/lib/components/scoring/ShareBadge.svelte
@@ -127,7 +127,7 @@
 
 	function shareToTwitter() {
 		// X has a 280-char tweet cap; build a tighter version of shareText
-		const tight = `Just scored ${avgScore}/100 on ATS Screener — free, simulates how Workday, Lever, iCIMS and others actually parse resumes. ${passCount}/${totalCount} systems passed.`;
+		const tight = `Just scored ${avgScore}/100 on ATS Screener (free, simulates how Workday, Lever, iCIMS and others actually parse resumes). ${passCount}/${totalCount} systems passed.`;
 		const params = new URLSearchParams({ text: tight });
 		if (shareUrl) params.set('url', shareUrl);
 		const url = `https://twitter.com/intent/tweet?${params.toString()}`;

--- a/src/lib/components/seo/SeoHead.svelte
+++ b/src/lib/components/seo/SeoHead.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { page } from '$app/stores';
+	import { page } from '$app/state';
 
 	// per-route meta tags - lifted out of app.html so each page can supply
 	// its own title/description/canonical without rendering duplicate og: tags
@@ -21,7 +21,7 @@
 		noIndex = false
 	}: Props = $props();
 
-	const url = $derived($page.url);
+	const url = $derived(page.url);
 	const resolvedCanonical = $derived(canonical ?? `${url.origin}${url.pathname}`);
 	const resolvedOgImage = $derived(
 		ogImage.startsWith('http') ? ogImage : `${url.origin}${ogImage}`
@@ -32,9 +32,9 @@
 	<title>{title}</title>
 	<meta name="description" content={description} />
 	<link rel="canonical" href={resolvedCanonical} />
-	{#if noIndex}
-		<meta name="robots" content="noindex, nofollow" />
-	{/if}
+	<!-- single source of truth for robots; app.html no longer emits a baseline
+	     so this attribute covers both indexable and noIndex pages without conflict -->
+	<meta name="robots" content={noIndex ? 'noindex, nofollow' : 'index, follow'} />
 
 	<meta property="og:type" content={ogType} />
 	<meta property="og:site_name" content="ATS Screener" />

--- a/src/lib/components/seo/SeoHead.svelte
+++ b/src/lib/components/seo/SeoHead.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+	import { page } from '$app/stores';
+
+	// per-route meta tags - lifted out of app.html so each page can supply
+	// its own title/description/canonical without rendering duplicate og: tags
+	interface Props {
+		title: string;
+		description: string;
+		ogImage?: string;
+		ogType?: 'website' | 'article';
+		canonical?: string;
+		noIndex?: boolean;
+	}
+
+	let {
+		title,
+		description,
+		ogImage = '/og-image.png',
+		ogType = 'website',
+		canonical,
+		noIndex = false
+	}: Props = $props();
+
+	const url = $derived($page.url);
+	const resolvedCanonical = $derived(canonical ?? `${url.origin}${url.pathname}`);
+	const resolvedOgImage = $derived(
+		ogImage.startsWith('http') ? ogImage : `${url.origin}${ogImage}`
+	);
+</script>
+
+<svelte:head>
+	<title>{title}</title>
+	<meta name="description" content={description} />
+	<link rel="canonical" href={resolvedCanonical} />
+	{#if noIndex}
+		<meta name="robots" content="noindex, nofollow" />
+	{/if}
+
+	<meta property="og:type" content={ogType} />
+	<meta property="og:site_name" content="ATS Screener" />
+	<meta property="og:url" content={resolvedCanonical} />
+	<meta property="og:title" content={title} />
+	<meta property="og:description" content={description} />
+	<meta property="og:image" content={resolvedOgImage} />
+	<meta property="og:image:width" content="1200" />
+	<meta property="og:image:height" content="630" />
+
+	<meta name="twitter:card" content="summary_large_image" />
+	<meta name="twitter:title" content={title} />
+	<meta name="twitter:description" content={description} />
+	<meta name="twitter:image" content={resolvedOgImage} />
+</svelte:head>

--- a/src/lib/components/ui/Navbar.svelte
+++ b/src/lib/components/ui/Navbar.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { page } from '$app/stores';
+	import { page } from '$app/state';
 	import { browser } from '$app/environment';
 	import Logo from './Logo.svelte';
 	import UserMenu from './UserMenu.svelte';
@@ -11,7 +11,7 @@
 	let mobileOpen = $state(false);
 
 	// highlight the active route
-	const currentPath = $derived($page.url.pathname);
+	const currentPath = $derived(page.url.pathname);
 	const isOnDocs = $derived(currentPath.startsWith('/docs'));
 	const isMac = $derived(browser ? navigator.platform.toUpperCase().includes('MAC') : true);
 

--- a/src/lib/components/upload/JobDescriptionInput.svelte
+++ b/src/lib/components/upload/JobDescriptionInput.svelte
@@ -74,7 +74,11 @@
 </script>
 
 <div class="jd-input">
-	<button class="jd-toggle" onclick={() => (expanded = !expanded)}>
+	<button
+		class="jd-toggle"
+		onclick={() => (expanded = !expanded)}
+		aria-expanded={expanded}
+	>
 		<span class="toggle-icon" class:expanded>
 			<svg
 				width="16"

--- a/src/lib/components/upload/JobDescriptionInput.svelte
+++ b/src/lib/components/upload/JobDescriptionInput.svelte
@@ -37,17 +37,24 @@
 		}
 		let cancelled = false;
 		(async () => {
-			const { parseJobDescription } = await import('$engine/job-parser');
-			if (cancelled) return;
-			const result = parseJobDescription(v);
-			if (cancelled) return;
-			parsed = {
-				extractedSkills: result.extractedSkills.slice(0, 12),
-				requiredSkills: result.requiredSkills,
-				experienceLevel: result.experienceLevel,
-				roleType: result.roleType,
-				industryContext: result.industryContext
-			};
+			try {
+				const { parseJobDescription } = await import('$engine/job-parser');
+				if (cancelled) return;
+				const result = parseJobDescription(v);
+				if (cancelled) return;
+				parsed = {
+					extractedSkills: result.extractedSkills.slice(0, 12),
+					requiredSkills: result.requiredSkills,
+					experienceLevel: result.experienceLevel,
+					roleType: result.roleType,
+					industryContext: result.industryContext
+				};
+			} catch (err) {
+				// preview is best-effort - if the parser throws (corrupt input,
+				// transient import failure), keep the previous parsed state and
+				// log so it's grep-able in console without breaking the scan flow
+				console.warn('[jd-preview] parse failed:', err);
+			}
 		})();
 		return () => {
 			cancelled = true;

--- a/src/lib/components/upload/JobDescriptionInput.svelte
+++ b/src/lib/components/upload/JobDescriptionInput.svelte
@@ -81,11 +81,7 @@
 </script>
 
 <div class="jd-input">
-	<button
-		class="jd-toggle"
-		onclick={() => (expanded = !expanded)}
-		aria-expanded={expanded}
-	>
+	<button class="jd-toggle" onclick={() => (expanded = !expanded)} aria-expanded={expanded}>
 		<span class="toggle-icon" class:expanded>
 			<svg
 				width="16"

--- a/src/lib/components/upload/JobDescriptionInput.svelte
+++ b/src/lib/components/upload/JobDescriptionInput.svelte
@@ -1,7 +1,76 @@
 <script lang="ts">
 	import { scoresStore } from '$stores/scores.svelte';
+	import { resumeStore } from '$stores/resume.svelte';
 
 	let expanded = $state(false);
+
+	// debounced JD value drives the live skill-extraction preview - parsing on
+	// every keystroke would re-tokenize a long JD on every char and feel laggy
+	const DEBOUNCE_MS = 400;
+	const MIN_JD_LENGTH_FOR_PREVIEW = 50;
+	let debouncedJD = $state('');
+	$effect(() => {
+		const v = scoresStore.jobDescription;
+		const id = setTimeout(() => {
+			debouncedJD = v;
+		}, DEBOUNCE_MS);
+		return () => clearTimeout(id);
+	});
+
+	type ParsedJD = {
+		extractedSkills: string[];
+		requiredSkills: string[];
+		experienceLevel: string;
+		roleType: string;
+		industryContext: string;
+	};
+	let parsed = $state<ParsedJD | null>(null);
+
+	// dynamically import the parser only when there's enough JD to preview - avoids
+	// pulling compromise/skills-taxonomy into the layout chunk for users who never
+	// open the JD section
+	$effect(() => {
+		const v = debouncedJD;
+		if (v.length < MIN_JD_LENGTH_FOR_PREVIEW) {
+			parsed = null;
+			return;
+		}
+		let cancelled = false;
+		(async () => {
+			const { parseJobDescription } = await import('$engine/job-parser');
+			if (cancelled) return;
+			const result = parseJobDescription(v);
+			if (cancelled) return;
+			parsed = {
+				extractedSkills: result.extractedSkills.slice(0, 12),
+				requiredSkills: result.requiredSkills,
+				experienceLevel: result.experienceLevel,
+				roleType: result.roleType,
+				industryContext: result.industryContext
+			};
+		})();
+		return () => {
+			cancelled = true;
+		};
+	});
+
+	const resumeSkillsSet = $derived(
+		new Set((resumeStore.resume?.skills ?? []).map((s) => s.toLowerCase()))
+	);
+
+	const matchSummary = $derived.by(() => {
+		if (!parsed || resumeSkillsSet.size === 0) return null;
+		const matched = parsed.extractedSkills.filter((s) => resumeSkillsSet.has(s.toLowerCase()));
+		return {
+			matched: matched.length,
+			total: parsed.extractedSkills.length,
+			matchedSet: new Set(matched.map((s) => s.toLowerCase()))
+		};
+	});
+
+	function isMatched(skill: string): boolean {
+		return matchSummary?.matchedSet.has(skill.toLowerCase()) ?? false;
+	}
 </script>
 
 <div class="jd-input">
@@ -48,6 +117,53 @@
 						<polyline points="22,4 12,14.01 9,11.01" />
 					</svg>
 					<span>Targeted mode active. Your resume will be scored against this specific job.</span>
+				</div>
+			{/if}
+
+			{#if parsed && parsed.extractedSkills.length > 0}
+				<div class="jd-preview">
+					<div class="jd-preview-header">
+						<span class="preview-label">Detected from JD</span>
+						{#if matchSummary}
+							<span
+								class="match-summary"
+								class:strong={matchSummary.matched / Math.max(matchSummary.total, 1) >= 0.6}
+							>
+								<strong>{matchSummary.matched}</strong> of
+								<strong>{matchSummary.total}</strong> in your resume
+							</span>
+						{/if}
+					</div>
+
+					<div class="jd-meta-chips">
+						{#if parsed.roleType !== 'other'}
+							<span class="meta-chip">{parsed.roleType}</span>
+						{/if}
+						{#if parsed.industryContext !== 'general'}
+							<span class="meta-chip">{parsed.industryContext}</span>
+						{/if}
+						<span class="meta-chip">{parsed.experienceLevel}</span>
+					</div>
+
+					<div class="skill-chips">
+						{#each parsed.extractedSkills as skill}
+							<span class="skill-chip" class:matched={isMatched(skill)}>
+								{#if isMatched(skill)}
+									<svg
+										width="10"
+										height="10"
+										viewBox="0 0 24 24"
+										fill="none"
+										stroke="currentColor"
+										stroke-width="3"
+									>
+										<polyline points="20,6 9,17 4,12" />
+									</svg>
+								{/if}
+								{skill}
+							</span>
+						{/each}
+					</div>
 				</div>
 			{/if}
 		</div>
@@ -133,5 +249,96 @@
 		background: rgba(6, 182, 212, 0.05);
 		border: 1px solid rgba(6, 182, 212, 0.15);
 		border-radius: var(--radius-md);
+	}
+
+	/* live preview block: detected role / industry / skills from the typed JD */
+	.jd-preview {
+		margin-top: 0.85rem;
+		padding: 0.85rem 1rem 1rem;
+		background: rgba(255, 255, 255, 0.02);
+		border: 1px solid var(--glass-border);
+		border-radius: var(--radius-md);
+		animation: previewIn 0.25s ease;
+	}
+
+	@keyframes previewIn {
+		from {
+			opacity: 0;
+			transform: translateY(-4px);
+		}
+	}
+
+	.jd-preview-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.75rem;
+		margin-bottom: 0.65rem;
+	}
+
+	.preview-label {
+		font-size: 0.7rem;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.08em;
+		color: var(--text-tertiary);
+	}
+
+	.match-summary {
+		font-size: 0.75rem;
+		color: var(--text-tertiary);
+		font-variant-numeric: tabular-nums;
+	}
+
+	.match-summary strong {
+		color: var(--text-secondary);
+		font-weight: 600;
+	}
+
+	.match-summary.strong strong {
+		color: #22c55e;
+	}
+
+	.jd-meta-chips {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.35rem;
+		margin-bottom: 0.6rem;
+	}
+
+	.meta-chip {
+		padding: 0.15rem 0.5rem;
+		font-size: 0.68rem;
+		font-weight: 500;
+		text-transform: capitalize;
+		color: var(--text-tertiary);
+		background: rgba(255, 255, 255, 0.04);
+		border: 1px solid rgba(255, 255, 255, 0.06);
+		border-radius: var(--radius-full);
+	}
+
+	.skill-chips {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.35rem;
+	}
+
+	.skill-chip {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.25rem;
+		padding: 0.18rem 0.55rem;
+		font-size: 0.74rem;
+		font-weight: 500;
+		color: var(--text-secondary);
+		background: rgba(6, 182, 212, 0.06);
+		border: 1px solid rgba(6, 182, 212, 0.15);
+		border-radius: var(--radius-full);
+	}
+
+	.skill-chip.matched {
+		color: #22c55e;
+		background: rgba(34, 197, 94, 0.1);
+		border-color: rgba(34, 197, 94, 0.28);
 	}
 </style>

--- a/src/lib/engine/llm/client.ts
+++ b/src/lib/engine/llm/client.ts
@@ -4,16 +4,29 @@ import { generateFallbackAnalysis } from './fallback';
 
 const CLIENT_TIMEOUT_MS = 65_000;
 
+// discriminated result so callers can distinguish "fall back to rule-based"
+// from "user cancelled, do nothing" - the two need different downstream handling
+export type ScoreLLMResult =
+	| { status: 'ok'; results: ScoreResult[]; provider: string; fallback: boolean }
+	| { status: 'error' }
+	| { status: 'cancelled' };
+
 // performs full LLM-powered ATS scoring via the server endpoint
-// falls back to rule-based if all providers fail
+// caller can pass an AbortSignal to cancel an in-flight request (e.g. on rescan/reset)
 export async function scoreLLM(
 	resumeText: string,
-	jobDescription?: string
-): Promise<{ results: ScoreResult[]; provider: string; fallback: boolean } | null> {
-	try {
-		const controller = new AbortController();
-		const timeout = setTimeout(() => controller.abort(), CLIENT_TIMEOUT_MS);
+	jobDescription?: string,
+	options?: { signal?: AbortSignal }
+): Promise<ScoreLLMResult> {
+	const external = options?.signal;
+	if (external?.aborted) return { status: 'cancelled' };
 
+	const controller = new AbortController();
+	const timeout = setTimeout(() => controller.abort(), CLIENT_TIMEOUT_MS);
+	const onExternalAbort = () => controller.abort();
+	external?.addEventListener('abort', onExternalAbort, { once: true });
+
+	try {
 		const response = await fetch('/api/analyze', {
 			method: 'POST',
 			headers: { 'Content-Type': 'application/json' },
@@ -25,12 +38,10 @@ export async function scoreLLM(
 			signal: controller.signal
 		});
 
-		clearTimeout(timeout);
-
 		if (!response.ok) {
 			const data = await response.json().catch(() => ({}));
 			console.warn('[scoreLLM] API returned', response.status, data.error ?? 'unknown error');
-			return null;
+			return { status: 'error' };
 		}
 
 		const data = await response.json();
@@ -39,7 +50,7 @@ export async function scoreLLM(
 			console.warn(
 				'[scoreLLM] response missing results or is fallback, falling back to rule-based'
 			);
-			return null;
+			return { status: 'error' };
 		}
 
 		// validate and normalize the LLM response to match ScoreResult[]
@@ -48,15 +59,20 @@ export async function scoreLLM(
 		);
 
 		return {
+			status: 'ok',
 			results,
 			provider: (data._provider as string) ?? 'unknown',
 			fallback: false
 		};
 	} catch (err) {
 		if (err instanceof DOMException && err.name === 'AbortError') {
+			if (external?.aborted) return { status: 'cancelled' };
 			console.warn('LLM scoring timed out after', CLIENT_TIMEOUT_MS, 'ms');
 		}
-		return null;
+		return { status: 'error' };
+	} finally {
+		clearTimeout(timeout);
+		external?.removeEventListener('abort', onExternalAbort);
 	}
 }
 

--- a/src/lib/engine/llm/client.ts
+++ b/src/lib/engine/llm/client.ts
@@ -6,9 +6,12 @@ const CLIENT_TIMEOUT_MS = 65_000;
 
 // discriminated result so callers can distinguish "fall back to rule-based"
 // from "user cancelled, do nothing" - the two need different downstream handling
+// rate_limited is treated like error for fallback purposes, but carries a retry
+// hint so the UI can tell users when the AI path will be available again
 export type ScoreLLMResult =
 	| { status: 'ok'; results: ScoreResult[]; provider: string; fallback: boolean }
 	| { status: 'error' }
+	| { status: 'rate_limited'; retryAfterSec: number }
 	| { status: 'cancelled' };
 
 // performs full LLM-powered ATS scoring via the server endpoint
@@ -41,6 +44,16 @@ export async function scoreLLM(
 		if (!response.ok) {
 			const data = await response.json().catch(() => ({}));
 			console.warn('[scoreLLM] API returned', response.status, data.error ?? 'unknown error');
+			if (response.status === 429) {
+				const headerVal = response.headers.get('Retry-After');
+				const retryAfterSec =
+					typeof data.retryAfter === 'number' && data.retryAfter > 0
+						? data.retryAfter
+						: headerVal && Number.isFinite(Number(headerVal))
+							? Math.max(1, Number(headerVal))
+							: 60;
+				return { status: 'rate_limited', retryAfterSec };
+			}
 			return { status: 'error' };
 		}
 

--- a/src/lib/engine/scorer/comparison.ts
+++ b/src/lib/engine/scorer/comparison.ts
@@ -1,0 +1,82 @@
+import type { ScoreResult } from './types';
+
+// pure comparison between two ATS scan result sets
+// used by the dashboard to show "you went from X to Y" deltas
+// kept side-effect free so unit tests can drive every branch deterministically
+
+export interface PlatformDelta {
+	system: string;
+	previous: number;
+	current: number;
+	delta: number;
+}
+
+export interface ScanComparison {
+	previousAverage: number;
+	currentAverage: number;
+	deltaAverage: number;
+	previousPassing: number;
+	currentPassing: number;
+	deltaPassing: number;
+	platforms: PlatformDelta[];
+	improved: number;
+	regressed: number;
+	unchanged: number;
+}
+
+function average(results: ScoreResult[]): number {
+	if (results.length === 0) return 0;
+	const sum = results.reduce((acc, r) => acc + r.overallScore, 0);
+	return Math.round(sum / results.length);
+}
+
+function passingCount(results: ScoreResult[]): number {
+	return results.filter((r) => r.passesFilter).length;
+}
+
+export function computeScanComparison(
+	current: ScoreResult[],
+	previous: ScoreResult[]
+): ScanComparison | null {
+	if (current.length === 0 || previous.length === 0) return null;
+
+	const currentAverage = average(current);
+	const previousAverage = average(previous);
+	const currentPassing = passingCount(current);
+	const previousPassing = passingCount(previous);
+
+	const previousBySystem = new Map(previous.map((r) => [r.system, r.overallScore]));
+
+	const platforms: PlatformDelta[] = [];
+	let improved = 0;
+	let regressed = 0;
+	let unchanged = 0;
+
+	for (const curr of current) {
+		const prevScore = previousBySystem.get(curr.system);
+		if (prevScore === undefined) continue;
+		const delta = curr.overallScore - prevScore;
+		platforms.push({
+			system: curr.system,
+			previous: prevScore,
+			current: curr.overallScore,
+			delta
+		});
+		if (delta > 0) improved++;
+		else if (delta < 0) regressed++;
+		else unchanged++;
+	}
+
+	return {
+		previousAverage,
+		currentAverage,
+		deltaAverage: currentAverage - previousAverage,
+		previousPassing,
+		currentPassing,
+		deltaPassing: currentPassing - previousPassing,
+		platforms,
+		improved,
+		regressed,
+		unchanged
+	};
+}

--- a/src/lib/engine/scorer/journey.ts
+++ b/src/lib/engine/scorer/journey.ts
@@ -1,0 +1,61 @@
+import type { ScoreResult } from './types';
+
+// derived insights across all of a user's scans. pure function so it's easy to
+// unit-test - no live store, no side effects, no async.
+
+interface JourneyInputEntry {
+	id: string;
+	timestamp: string;
+	averageScore: number;
+	results: ScoreResult[];
+}
+
+export interface JourneyStats {
+	totalScans: number;
+	firstScore: number;
+	latestScore: number;
+	totalDelta: number;
+	bestScore: number;
+	bestPlatformDelta: { system: string; delta: number } | null;
+	daysSpan: number;
+}
+
+export function computeJourneyStats(entries: JourneyInputEntry[]): JourneyStats | null {
+	if (entries.length === 0) return null;
+
+	// sort ascending by timestamp so [0] is oldest, [-1] is newest
+	const sorted = [...entries].sort((a, b) => a.timestamp.localeCompare(b.timestamp));
+	const first = sorted[0];
+	const latest = sorted[sorted.length - 1];
+
+	const bestScore = Math.max(...sorted.map((e) => e.averageScore));
+
+	// per-platform delta: latest minus first, only for platforms present in BOTH
+	let bestPlatformDelta: { system: string; delta: number } | null = null;
+	if (sorted.length >= 2) {
+		const firstBySystem = new Map(first.results.map((r) => [r.system, r.overallScore]));
+		for (const r of latest.results) {
+			const prev = firstBySystem.get(r.system);
+			if (prev === undefined) continue;
+			const delta = r.overallScore - prev;
+			if (!bestPlatformDelta || delta > bestPlatformDelta.delta) {
+				bestPlatformDelta = { system: r.system, delta };
+			}
+		}
+	}
+
+	const daysSpan = Math.max(
+		0,
+		Math.floor((Date.parse(latest.timestamp) - Date.parse(first.timestamp)) / 86_400_000)
+	);
+
+	return {
+		totalScans: sorted.length,
+		firstScore: first.averageScore,
+		latestScore: latest.averageScore,
+		totalDelta: latest.averageScore - first.averageScore,
+		bestScore,
+		bestPlatformDelta,
+		daysSpan
+	};
+}

--- a/src/lib/engine/scorer/timeline.ts
+++ b/src/lib/engine/scorer/timeline.ts
@@ -62,16 +62,19 @@ export function computeTimeline(
 	// sort ascending so leftmost point is the oldest scan
 	const sorted = [...entries].sort((a, b) => a.timestamp.localeCompare(b.timestamp));
 
-	// y scale: clamp to [0, 100] but pad slightly so the line never touches the edge
+	// y scale spans [0, 100]; clamp the geometry input so anomalous out-of-range
+	// scores still render INSIDE the chart instead of overflowing the padding box.
+	// the unclamped value still goes on `point.score` for tooltip display.
 	const yMin = 0;
 	const yMax = 100;
 	const yRange = yMax - yMin;
+	const clampScore = (s: number) => Math.max(yMin, Math.min(yMax, s));
 
 	const n = sorted.length;
 	const points: TimelinePoint[] = sorted.map((entry, i) => ({
 		x: innerLeft + (i * innerWidth) / Math.max(n - 1, 1),
 		// invert because SVG y grows downward
-		y: innerTop + (1 - (entry.averageScore - yMin) / yRange) * innerHeight,
+		y: innerTop + (1 - (clampScore(entry.averageScore) - yMin) / yRange) * innerHeight,
 		score: entry.averageScore,
 		timestamp: entry.timestamp,
 		fileName: entry.fileName,

--- a/src/lib/engine/scorer/timeline.ts
+++ b/src/lib/engine/scorer/timeline.ts
@@ -1,0 +1,104 @@
+// pure geometry helper for the score-timeline svg chart on /history.
+// extracted so the math is unit-testable without any DOM dependency.
+
+export interface TimelinePoint {
+	x: number;
+	y: number;
+	score: number;
+	timestamp: string;
+	fileName?: string;
+	mode: 'general' | 'targeted';
+	id: string;
+}
+
+export interface TimelineChart {
+	width: number;
+	height: number;
+	innerLeft: number;
+	innerRight: number;
+	innerTop: number;
+	innerBottom: number;
+	points: TimelinePoint[];
+	pathD: string;
+	areaD: string;
+	yMin: number;
+	yMax: number;
+}
+
+interface InputEntry {
+	id: string;
+	timestamp: string;
+	averageScore: number;
+	fileName?: string;
+	mode: 'general' | 'targeted';
+}
+
+const DEFAULTS = {
+	width: 720,
+	height: 220,
+	padLeft: 32,
+	padRight: 24,
+	padTop: 16,
+	padBottom: 32
+};
+
+// builds a left-to-right (oldest -> newest) time-axis chart from a list of
+// scan entries (input order doesn't matter; we sort by timestamp ascending)
+export function computeTimeline(
+	entries: InputEntry[],
+	viewBox: { width?: number; height?: number } = {}
+): TimelineChart | null {
+	if (entries.length < 2) return null;
+
+	const width = viewBox.width ?? DEFAULTS.width;
+	const height = viewBox.height ?? DEFAULTS.height;
+	const innerLeft = DEFAULTS.padLeft;
+	const innerRight = width - DEFAULTS.padRight;
+	const innerTop = DEFAULTS.padTop;
+	const innerBottom = height - DEFAULTS.padBottom;
+	const innerWidth = innerRight - innerLeft;
+	const innerHeight = innerBottom - innerTop;
+
+	// sort ascending so leftmost point is the oldest scan
+	const sorted = [...entries].sort((a, b) => a.timestamp.localeCompare(b.timestamp));
+
+	// y scale: clamp to [0, 100] but pad slightly so the line never touches the edge
+	const yMin = 0;
+	const yMax = 100;
+	const yRange = yMax - yMin;
+
+	const n = sorted.length;
+	const points: TimelinePoint[] = sorted.map((entry, i) => ({
+		x: innerLeft + (i * innerWidth) / Math.max(n - 1, 1),
+		// invert because SVG y grows downward
+		y: innerTop + (1 - (entry.averageScore - yMin) / yRange) * innerHeight,
+		score: entry.averageScore,
+		timestamp: entry.timestamp,
+		fileName: entry.fileName,
+		mode: entry.mode,
+		id: entry.id
+	}));
+
+	const pathD = points
+		.map((p, i) => `${i === 0 ? 'M' : 'L'} ${p.x.toFixed(2)} ${p.y.toFixed(2)}`)
+		.join(' ');
+	// area below the line for the soft fill
+	const areaD =
+		`${pathD} ` +
+		`L ${points[points.length - 1].x.toFixed(2)} ${innerBottom} ` +
+		`L ${points[0].x.toFixed(2)} ${innerBottom} Z`;
+
+	return {
+		width,
+		height,
+		innerLeft,
+		innerRight,
+		innerTop,
+		innerBottom,
+		points,
+		pathD,
+		areaD,
+		yMin,
+		yMax
+	};
+}

--- a/src/lib/engine/suggestions/templates.ts
+++ b/src/lib/engine/suggestions/templates.ts
@@ -29,11 +29,19 @@ export function classifySuggestion(text: string): SuggestionType | null {
 	if (/skills?\s+section|dedicated\s+skills|list\s+(your\s+)?skills/.test(t)) {
 		return 'skills-section';
 	}
-	if (/missing\s+(keyword|term|skill)|add(?:ing)?\s+(?:these\s+|the\s+)?(?:keyword|term|skill)|consider adding/.test(t)) {
+	if (
+		/missing\s+(keyword|term|skill)|add(?:ing)?\s+(?:these\s+|the\s+)?(?:keyword|term|skill)|consider adding/.test(
+			t
+		)
+	) {
 		return 'missing-keywords';
 	}
 	if (/short|more\s+detail|expand|length|too\s+brief/.test(t)) return 'short-resume';
-	if (/standard\s+section|section\s+(missing|header)|use\s+standard|recognised\s+section|recognized\s+section/.test(t)) {
+	if (
+		/standard\s+section|section\s+(missing|header)|use\s+standard|recognised\s+section|recognized\s+section/.test(
+			t
+		)
+	) {
 		return 'sections';
 	}
 	if (/format|multi.?column|tables?|images?|two.?column|page\s+limit|page\s+count/.test(t)) {

--- a/src/lib/engine/suggestions/templates.ts
+++ b/src/lib/engine/suggestions/templates.ts
@@ -1,0 +1,96 @@
+// classifies a suggestion's free-text summary into a known category and attaches
+// a concrete before/after example. pure functions, deterministic, no LLM.
+// returns null when no template fits, in which case the dashboard renders the
+// suggestion's own details and skips the example block
+
+export type SuggestionType =
+	| 'quantification'
+	| 'action-verbs'
+	| 'missing-keywords'
+	| 'skills-section'
+	| 'short-resume'
+	| 'sections'
+	| 'format';
+
+export interface SuggestionExample {
+	type: SuggestionType;
+	tip: string;
+	before: string;
+	after: string;
+}
+
+export function classifySuggestion(text: string): SuggestionType | null {
+	const t = text.toLowerCase();
+	// order matters: more specific patterns checked before broader ones
+	if (/quantif|metric|number|measur|impact|outcome/.test(t)) return 'quantification';
+	if (/action.{0,4}verb|passive.{0,4}voice|stronger.{0,4}verb|weak.{0,4}verb/.test(t)) {
+		return 'action-verbs';
+	}
+	if (/skills?\s+section|dedicated\s+skills|list\s+(your\s+)?skills/.test(t)) {
+		return 'skills-section';
+	}
+	if (/missing\s+(keyword|term|skill)|add(?:ing)?\s+(?:these\s+|the\s+)?(?:keyword|term|skill)|consider adding/.test(t)) {
+		return 'missing-keywords';
+	}
+	if (/short|more\s+detail|expand|length|too\s+brief/.test(t)) return 'short-resume';
+	if (/standard\s+section|section\s+(missing|header)|use\s+standard|recognised\s+section|recognized\s+section/.test(t)) {
+		return 'sections';
+	}
+	if (/format|multi.?column|tables?|images?|two.?column|page\s+limit|page\s+count/.test(t)) {
+		return 'format';
+	}
+	return null;
+}
+
+const EXAMPLES: Record<SuggestionType, SuggestionExample> = {
+	quantification: {
+		type: 'quantification',
+		tip: 'Add concrete numbers — percent improvements, dollar amounts, scale.',
+		before: 'Led the migration of the platform.',
+		after: 'Led the migration of the platform serving 2M daily users, reducing infra cost 38%.'
+	},
+	'action-verbs': {
+		type: 'action-verbs',
+		tip: 'Open every bullet with a strong action verb. Swap weak/passive forms.',
+		before: 'Was responsible for managing the deployment pipeline.',
+		after: 'Owned the deployment pipeline; cut release time from 4h to 12 minutes.'
+	},
+	'missing-keywords': {
+		type: 'missing-keywords',
+		tip: 'Weave missing JD keywords into a real bullet — never standalone keyword stuffing.',
+		before: 'Built backend services.',
+		after:
+			'Built Node.js / TypeScript / GraphQL backend services on AWS, integrated with PostgreSQL and Redis.'
+	},
+	'skills-section': {
+		type: 'skills-section',
+		tip: 'Add a single Skills section near the top, grouped by category.',
+		before: '(no skills section present)',
+		after:
+			'Skills\n  Languages: TypeScript, Python, Go\n  Cloud: AWS, GCP, Docker, Kubernetes\n  Data: PostgreSQL, Redis, BigQuery'
+	},
+	'short-resume': {
+		type: 'short-resume',
+		tip: 'Aim for one full page minimum, 4–6 quantified bullets per role.',
+		before: 'Software Engineer (2022-Present)\n  Worked on the backend.',
+		after:
+			'Software Engineer, Acme (2022-Present)\n  Cut p99 latency 45% by introducing per-request caching.\n  Owned migration to TypeScript across 12 services.\n  Led on-call rotation for the payments domain.'
+	},
+	sections: {
+		type: 'sections',
+		tip: 'Use these standard headers: Contact, Summary, Experience, Education, Skills.',
+		before: "My Background  /  Things I've Done  /  Stuff",
+		after: 'Experience  /  Education  /  Skills'
+	},
+	format: {
+		type: 'format',
+		tip: 'Single column. No tables, images, or icons. ATS parsers struggle with multi-column layouts and embedded objects.',
+		before: '(2-column layout, sidebar with skill icons)',
+		after: '(single column, plain text headers, no decorative graphics)'
+	}
+};
+
+export function getExampleFor(suggestionText: string): SuggestionExample | null {
+	const type = classifySuggestion(suggestionText);
+	return type ? EXAMPLES[type] : null;
+}

--- a/src/lib/engine/suggestions/templates.ts
+++ b/src/lib/engine/suggestions/templates.ts
@@ -53,7 +53,7 @@ export function classifySuggestion(text: string): SuggestionType | null {
 const EXAMPLES: Record<SuggestionType, SuggestionExample> = {
 	quantification: {
 		type: 'quantification',
-		tip: 'Add concrete numbers — percent improvements, dollar amounts, scale.',
+		tip: 'Add concrete numbers (percent improvements, dollar amounts, scale).',
 		before: 'Led the migration of the platform.',
 		after: 'Led the migration of the platform serving 2M daily users, reducing infra cost 38%.'
 	},
@@ -65,7 +65,7 @@ const EXAMPLES: Record<SuggestionType, SuggestionExample> = {
 	},
 	'missing-keywords': {
 		type: 'missing-keywords',
-		tip: 'Weave missing JD keywords into a real bullet — never standalone keyword stuffing.',
+		tip: 'Weave missing JD keywords into a real bullet, never standalone keyword stuffing.',
 		before: 'Built backend services.',
 		after:
 			'Built Node.js / TypeScript / GraphQL backend services on AWS, integrated with PostgreSQL and Redis.'

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -1,6 +1,6 @@
-import { initializeApp, getApps } from 'firebase/app';
-import { getAuth } from 'firebase/auth';
-import { getFirestore } from 'firebase/firestore';
+// firebase initialization is deferred behind a dynamic import so the SDK
+// (~480kb minified) is only fetched once a consumer actually needs auth or
+// firestore - landing-page visitors who never sign in pay zero
 import {
 	PUBLIC_FIREBASE_API_KEY,
 	PUBLIC_FIREBASE_AUTH_DOMAIN,
@@ -9,6 +9,8 @@ import {
 	PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
 	PUBLIC_FIREBASE_APP_ID
 } from '$env/static/public';
+import type { Auth } from 'firebase/auth';
+import type { Firestore } from 'firebase/firestore';
 
 const firebaseConfig = {
 	apiKey: PUBLIC_FIREBASE_API_KEY,
@@ -19,9 +21,21 @@ const firebaseConfig = {
 	appId: PUBLIC_FIREBASE_APP_ID
 };
 
-// prevent re-initialization on HMR
-const app = getApps().length === 0 ? initializeApp(firebaseConfig) : getApps()[0];
+let appPromise: Promise<{ auth: Auth; db: Firestore }> | null = null;
 
-export const auth = getAuth(app);
-// database was created as 'default' (not '(default)'), must specify explicitly
-export const db = getFirestore(app, 'default');
+// resolves to initialized auth + firestore handles, memoized so repeat callers
+// don't re-trigger the import or the initializeApp call
+export function getFirebase(): Promise<{ auth: Auth; db: Firestore }> {
+	if (appPromise) return appPromise;
+	appPromise = (async () => {
+		const [{ initializeApp, getApps }, { getAuth }, { getFirestore }] = await Promise.all([
+			import('firebase/app'),
+			import('firebase/auth'),
+			import('firebase/firestore')
+		]);
+		const app = getApps().length === 0 ? initializeApp(firebaseConfig) : getApps()[0];
+		// database was created as 'default' (not '(default)'), must specify explicitly
+		return { auth: getAuth(app), db: getFirestore(app, 'default') };
+	})();
+	return appPromise;
+}

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -1,24 +1,23 @@
 // firebase initialization is deferred behind a dynamic import so the SDK
 // (~480kb minified) is only fetched once a consumer actually needs auth or
-// firestore - landing-page visitors who never sign in pay zero
-import {
-	PUBLIC_FIREBASE_API_KEY,
-	PUBLIC_FIREBASE_AUTH_DOMAIN,
-	PUBLIC_FIREBASE_PROJECT_ID,
-	PUBLIC_FIREBASE_STORAGE_BUCKET,
-	PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
-	PUBLIC_FIREBASE_APP_ID
-} from '$env/static/public';
+// firestore. landing-page visitors who never sign in pay zero.
+//
+// using $env/dynamic/public (not /static/public) so the build does not fail
+// on Vercel preview deployments where the PUBLIC_FIREBASE_* vars are scoped
+// to Production only. on a preview deploy the values come back undefined,
+// firebase init throws at runtime, and the auth-aware code paths swallow it
+// gracefully (auth simply does not work on preview, which is the expectation)
+import { env } from '$env/dynamic/public';
 import type { Auth } from 'firebase/auth';
 import type { Firestore } from 'firebase/firestore';
 
 const firebaseConfig = {
-	apiKey: PUBLIC_FIREBASE_API_KEY,
-	authDomain: PUBLIC_FIREBASE_AUTH_DOMAIN,
-	projectId: PUBLIC_FIREBASE_PROJECT_ID,
-	storageBucket: PUBLIC_FIREBASE_STORAGE_BUCKET,
-	messagingSenderId: PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
-	appId: PUBLIC_FIREBASE_APP_ID
+	apiKey: env.PUBLIC_FIREBASE_API_KEY,
+	authDomain: env.PUBLIC_FIREBASE_AUTH_DOMAIN,
+	projectId: env.PUBLIC_FIREBASE_PROJECT_ID,
+	storageBucket: env.PUBLIC_FIREBASE_STORAGE_BUCKET,
+	messagingSenderId: env.PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
+	appId: env.PUBLIC_FIREBASE_APP_ID
 };
 
 let appPromise: Promise<{ auth: Auth; db: Firestore }> | null = null;

--- a/src/lib/stores/auth.svelte.ts
+++ b/src/lib/stores/auth.svelte.ts
@@ -1,21 +1,6 @@
 import { browser } from '$app/environment';
-import {
-	onAuthStateChanged,
-	signInWithPopup,
-	signInWithRedirect,
-	getRedirectResult,
-	getAdditionalUserInfo,
-	signInWithEmailAndPassword,
-	createUserWithEmailAndPassword,
-	sendEmailVerification,
-	sendPasswordResetEmail,
-	signOut as firebaseSignOut,
-	GoogleAuthProvider,
-	updateProfile,
-	type User
-} from 'firebase/auth';
-import { doc, updateDoc, increment } from 'firebase/firestore';
-import { auth, db } from '$lib/firebase';
+import type { User } from 'firebase/auth';
+import { getFirebase } from '$lib/firebase';
 
 class AuthStore {
 	user = $state<User | null>(null);
@@ -48,25 +33,37 @@ class AuthStore {
 
 	constructor() {
 		if (browser) {
-			onAuthStateChanged(auth, (user) => {
-				this.user = user;
-				this.loading = false;
-			});
-			// handle redirect result from signInWithRedirect fallback
-			getRedirectResult(auth)
-				.then((result) => {
-					if (result && getAdditionalUserInfo(result)?.isNewUser) {
-						this.incrementUserCount();
-					}
-				})
-				.catch(() => {});
+			void this.setupAuthListener();
 		} else {
 			this.loading = false;
 		}
 	}
 
+	private async setupAuthListener() {
+		const { auth } = await getFirebase();
+		const { onAuthStateChanged, getRedirectResult, getAdditionalUserInfo } = await import(
+			'firebase/auth'
+		);
+		onAuthStateChanged(auth, (user) => {
+			this.user = user;
+			this.loading = false;
+		});
+		// handle redirect result from signInWithRedirect fallback
+		try {
+			const result = await getRedirectResult(auth);
+			if (result && getAdditionalUserInfo(result)?.isNewUser) {
+				this.incrementUserCount();
+			}
+		} catch {
+			// non-critical; redirect path is the fallback for popup blockers
+		}
+	}
+
 	async signInWithGoogle() {
 		this.error = null;
+		const { auth } = await getFirebase();
+		const { GoogleAuthProvider, signInWithPopup, signInWithRedirect, getAdditionalUserInfo } =
+			await import('firebase/auth');
 		const provider = new GoogleAuthProvider();
 		try {
 			const result = await signInWithPopup(auth, provider);
@@ -94,6 +91,8 @@ class AuthStore {
 
 	async signInWithEmail(email: string, password: string) {
 		this.error = null;
+		const { auth } = await getFirebase();
+		const { signInWithEmailAndPassword } = await import('firebase/auth');
 		try {
 			await signInWithEmailAndPassword(auth, email, password);
 		} catch (err) {
@@ -104,6 +103,10 @@ class AuthStore {
 
 	async signUpWithEmail(email: string, password: string, displayName: string) {
 		this.error = null;
+		const { auth } = await getFirebase();
+		const { createUserWithEmailAndPassword, updateProfile, sendEmailVerification } = await import(
+			'firebase/auth'
+		);
 		try {
 			const credential = await createUserWithEmailAndPassword(auth, email, password);
 			if (displayName) {
@@ -123,6 +126,8 @@ class AuthStore {
 
 	async sendPasswordReset(email: string) {
 		this.error = null;
+		const { auth } = await getFirebase();
+		const { sendPasswordResetEmail } = await import('firebase/auth');
 		try {
 			await sendPasswordResetEmail(auth, email);
 		} catch (err) {
@@ -133,6 +138,8 @@ class AuthStore {
 
 	async signOut() {
 		this.error = null;
+		const { auth } = await getFirebase();
+		const { signOut: firebaseSignOut } = await import('firebase/auth');
 		try {
 			await firebaseSignOut(auth);
 		} catch (err) {
@@ -144,7 +151,9 @@ class AuthStore {
 		this.error = null;
 	}
 
-	private incrementUserCount() {
+	private async incrementUserCount() {
+		const { db } = await getFirebase();
+		const { doc, updateDoc, increment } = await import('firebase/firestore');
 		updateDoc(doc(db, 'stats', 'public'), {
 			userCount: increment(1)
 		}).catch(() => {

--- a/src/lib/stores/auth.svelte.ts
+++ b/src/lib/stores/auth.svelte.ts
@@ -41,9 +41,8 @@ class AuthStore {
 
 	private async setupAuthListener() {
 		const { auth } = await getFirebase();
-		const { onAuthStateChanged, getRedirectResult, getAdditionalUserInfo } = await import(
-			'firebase/auth'
-		);
+		const { onAuthStateChanged, getRedirectResult, getAdditionalUserInfo } =
+			await import('firebase/auth');
 		onAuthStateChanged(auth, (user) => {
 			this.user = user;
 			this.loading = false;
@@ -104,9 +103,8 @@ class AuthStore {
 	async signUpWithEmail(email: string, password: string, displayName: string) {
 		this.error = null;
 		const { auth } = await getFirebase();
-		const { createUserWithEmailAndPassword, updateProfile, sendEmailVerification } = await import(
-			'firebase/auth'
-		);
+		const { createUserWithEmailAndPassword, updateProfile, sendEmailVerification } =
+			await import('firebase/auth');
 		try {
 			const credential = await createUserWithEmailAndPassword(auth, email, password);
 			if (displayName) {

--- a/src/lib/stores/scores.svelte.ts
+++ b/src/lib/stores/scores.svelte.ts
@@ -154,9 +154,8 @@ class ScoresStore {
 		try {
 			const uid = authStore.user.uid;
 			const { db } = await getFirebase();
-			const { collection, addDoc, getDocs, deleteDoc, doc, query, orderBy } = await import(
-				'firebase/firestore'
-			);
+			const { collection, addDoc, getDocs, deleteDoc, doc, query, orderBy } =
+				await import('firebase/firestore');
 			const scansRef = collection(db, 'users', uid, 'scans');
 			const entry: Omit<ScanHistoryEntry, 'id'> = {
 				timestamp: new Date().toISOString(),
@@ -253,7 +252,11 @@ class ScoresStore {
 		this.isAnalyzing = true;
 	}
 
-	finishAnalyzing(analysis: LLMAnalysis | null, fallback: boolean, retryAtMs: number | null = null) {
+	finishAnalyzing(
+		analysis: LLMAnalysis | null,
+		fallback: boolean,
+		retryAtMs: number | null = null
+	) {
 		this.llmAnalysis = analysis;
 		this.llmFallback = fallback;
 		this.llmRetryAtMs = retryAtMs;

--- a/src/lib/stores/scores.svelte.ts
+++ b/src/lib/stores/scores.svelte.ts
@@ -45,6 +45,14 @@ class ScoresStore {
 	error = $state<string | null>(null);
 	scanHistory = $state<ScanHistoryEntry[]>([]);
 	historyLoading = $state(false);
+	// true when the dashboard is showing a snapshot loaded from history
+	// (suppresses the "you went from X to Y" comparison band)
+	isFromHistory = $state(false);
+	// captured at startScoring time so the comparison band stays correct during
+	// the ~1s race between finishScoring (results visible) and saveToHistory's
+	// async reload (which would otherwise leave scanHistory[1] pointing at the
+	// scan BEFORE the previous one for that brief window)
+	previousScanForComparison = $state<ScanHistoryEntry | null>(null);
 
 	// in-flight scoring controller; aborted when a new scan starts or the user resets
 	// not exposed as $state - it's plumbing, not view state
@@ -86,9 +94,14 @@ class ScoresStore {
 	startScoring(): AbortSignal {
 		this.abortController?.abort();
 		this.abortController = new AbortController();
+		// snapshot the current top of history; after saveToHistory completes that
+		// entry becomes scanHistory[1], but we already have it cached for the
+		// comparison band so the UI never flickers on the stale window
+		this.previousScanForComparison = this.scanHistory[0] ?? null;
 		this.isScoring = true;
 		this.llmFallback = false;
 		this.llmRetryAtMs = null;
+		this.isFromHistory = false;
 		this.error = null;
 		return this.abortController.signal;
 	}
@@ -221,6 +234,8 @@ class ScoresStore {
 		this.isAnalyzing = false;
 		this.llmFallback = false;
 		this.llmRetryAtMs = null;
+		this.isFromHistory = true;
+		this.previousScanForComparison = null;
 		this.error = null;
 	}
 
@@ -259,6 +274,9 @@ class ScoresStore {
 		this.isScoring = false;
 		this.isAnalyzing = false;
 		this.llmFallback = false;
+		this.llmRetryAtMs = null;
+		this.isFromHistory = false;
+		this.previousScanForComparison = null;
 		this.error = null;
 	}
 }

--- a/src/lib/stores/scores.svelte.ts
+++ b/src/lib/stores/scores.svelte.ts
@@ -2,19 +2,7 @@ import { browser } from '$app/environment';
 import type { ScoreResult } from '$engine/scorer/types';
 import type { LLMAnalysis } from '$engine/llm/types';
 import type { ParsedJobDescription } from '$engine/job-parser/types';
-import {
-	collection,
-	addDoc,
-	setDoc,
-	getDocs,
-	deleteDoc,
-	doc,
-	query,
-	orderBy,
-	limit,
-	serverTimestamp
-} from 'firebase/firestore';
-import { db } from '$lib/firebase';
+import { getFirebase } from '$lib/firebase';
 import { authStore } from './auth.svelte';
 
 const MAX_HISTORY = 5;
@@ -125,6 +113,8 @@ class ScoresStore {
 
 		this.historyLoading = true;
 		try {
+			const { db } = await getFirebase();
+			const { collection, query, orderBy, limit, getDocs } = await import('firebase/firestore');
 			const scansRef = collection(db, 'users', authStore.user.uid, 'scans');
 			const q = query(scansRef, orderBy('timestamp', 'desc'), limit(MAX_HISTORY));
 			const snapshot = await getDocs(q);
@@ -151,6 +141,10 @@ class ScoresStore {
 
 		try {
 			const uid = authStore.user.uid;
+			const { db } = await getFirebase();
+			const { collection, addDoc, getDocs, deleteDoc, doc, query, orderBy } = await import(
+				'firebase/firestore'
+			);
 			const scansRef = collection(db, 'users', uid, 'scans');
 			const entry: Omit<ScanHistoryEntry, 'id'> = {
 				timestamp: new Date().toISOString(),
@@ -191,6 +185,8 @@ class ScoresStore {
 	/** log scan to top-level scan_logs collection for admin browsing */
 	private async writeScanLog(entry: Omit<ScanHistoryEntry, 'id'>, uid: string) {
 		try {
+			const { db } = await getFirebase();
+			const { setDoc, doc, serverTimestamp } = await import('firebase/firestore');
 			const user = authStore.user;
 			const now = new Date();
 			// inverted timestamp so newest logs sort first in Firebase Console
@@ -215,6 +211,8 @@ class ScoresStore {
 		if (!browser || !authStore.isAuthenticated || !authStore.user) return;
 
 		try {
+			const { db } = await getFirebase();
+			const { collection, getDocs, deleteDoc } = await import('firebase/firestore');
 			const scansRef = collection(db, 'users', authStore.user.uid, 'scans');
 			const snapshot = await getDocs(scansRef);
 			for (const d of snapshot.docs) {

--- a/src/lib/stores/scores.svelte.ts
+++ b/src/lib/stores/scores.svelte.ts
@@ -43,6 +43,10 @@ class ScoresStore {
 	scanHistory = $state<ScanHistoryEntry[]>([]);
 	historyLoading = $state(false);
 
+	// in-flight scoring controller; aborted when a new scan starts or the user resets
+	// not exposed as $state - it's plumbing, not view state
+	private abortController: AbortController | null = null;
+
 	get hasResults(): boolean {
 		return this.results.length > 0;
 	}
@@ -74,13 +78,25 @@ class ScoresStore {
 		this.jobDescription = text;
 	}
 
-	startScoring() {
+	// returns a signal the caller threads into in-flight requests
+	// any prior in-flight scan is aborted before we hand out the new signal
+	startScoring(): AbortSignal {
+		this.abortController?.abort();
+		this.abortController = new AbortController();
 		this.isScoring = true;
 		this.llmFallback = false;
 		this.error = null;
+		return this.abortController.signal;
+	}
+
+	cancelScoring() {
+		this.abortController?.abort();
+		this.abortController = null;
+		this.isScoring = false;
 	}
 
 	finishScoring(results: ScoreResult[], fileName?: string) {
+		this.abortController = null;
 		this.results = results;
 		this.isScoring = false;
 		this.saveToHistory(results, fileName);
@@ -218,6 +234,8 @@ class ScoresStore {
 	}
 
 	setError(message: string) {
+		this.abortController?.abort();
+		this.abortController = null;
 		this.error = message;
 		this.isScoring = false;
 		this.isAnalyzing = false;
@@ -225,6 +243,8 @@ class ScoresStore {
 	}
 
 	reset() {
+		this.abortController?.abort();
+		this.abortController = null;
 		this.results = [];
 		this.llmAnalysis = null;
 		this.parsedJD = null;

--- a/src/lib/stores/scores.svelte.ts
+++ b/src/lib/stores/scores.svelte.ts
@@ -82,10 +82,22 @@ class ScoresStore {
 	startScoring(): AbortSignal {
 		this.abortController?.abort();
 		this.abortController = new AbortController();
-		// snapshot the current top of history; after saveToHistory completes that
-		// entry becomes scanHistory[1], but we already have it cached for the
-		// comparison band so the UI never flickers on the stale window
-		this.previousScanForComparison = this.scanHistory[0] ?? null;
+		// snapshot the previous scan for the comparison band. preference order:
+		// 1. the currently-visible results (a just-finished scan that may not yet
+		//    be in scanHistory if its async saveToHistory is still in flight)
+		// 2. scanHistory[0] (most recent saved scan)
+		// without (1) a rapid re-scan would compare against scanHistory's STALE
+		// top entry - i.e. two generations back instead of the immediate previous
+		this.previousScanForComparison = this.hasResults
+			? {
+					id: '',
+					timestamp: new Date().toISOString(),
+					mode: this.mode,
+					averageScore: this.averageScore,
+					passingCount: this.passingCount,
+					results: this.results
+				}
+			: (this.scanHistory[0] ?? null);
 		this.isScoring = true;
 		this.llmFallback = false;
 		this.llmRetryAtMs = null;

--- a/src/lib/stores/scores.svelte.ts
+++ b/src/lib/stores/scores.svelte.ts
@@ -39,6 +39,9 @@ class ScoresStore {
 	isScoring = $state(false);
 	isAnalyzing = $state(false);
 	llmFallback = $state(false);
+	// absolute timestamp (ms) when the AI path becomes available again after a 429
+	// null when not rate-limited; UI derives a live countdown from this
+	llmRetryAtMs = $state<number | null>(null);
 	error = $state<string | null>(null);
 	scanHistory = $state<ScanHistoryEntry[]>([]);
 	historyLoading = $state(false);
@@ -85,6 +88,7 @@ class ScoresStore {
 		this.abortController = new AbortController();
 		this.isScoring = true;
 		this.llmFallback = false;
+		this.llmRetryAtMs = null;
 		this.error = null;
 		return this.abortController.signal;
 	}
@@ -216,6 +220,7 @@ class ScoresStore {
 		this.isScoring = false;
 		this.isAnalyzing = false;
 		this.llmFallback = false;
+		this.llmRetryAtMs = null;
 		this.error = null;
 	}
 
@@ -223,9 +228,10 @@ class ScoresStore {
 		this.isAnalyzing = true;
 	}
 
-	finishAnalyzing(analysis: LLMAnalysis | null, fallback: boolean) {
+	finishAnalyzing(analysis: LLMAnalysis | null, fallback: boolean, retryAtMs: number | null = null) {
 		this.llmAnalysis = analysis;
 		this.llmFallback = fallback;
+		this.llmRetryAtMs = retryAtMs;
 		this.isAnalyzing = false;
 	}
 
@@ -240,6 +246,7 @@ class ScoresStore {
 		this.isScoring = false;
 		this.isAnalyzing = false;
 		this.llmFallback = false;
+		this.llmRetryAtMs = null;
 	}
 
 	reset() {

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -1,0 +1,172 @@
+<script lang="ts">
+	import { page } from '$app/stores';
+	import SeoHead from '$components/seo/SeoHead.svelte';
+</script>
+
+<SeoHead
+	title="Something went wrong | ATS Screener"
+	description="An unexpected error occurred. Please refresh or return to the homepage."
+	noIndex
+/>
+
+<main class="error-page">
+	<div class="error-bg">
+		<div class="bg-orb orb-1"></div>
+		<div class="bg-orb orb-2"></div>
+	</div>
+
+	<div class="error-card">
+		<div class="error-status">{$page.status}</div>
+		<h1 class="error-title">
+			{#if $page.status === 404}
+				Page not found
+			{:else if $page.status === 429}
+				Too many requests
+			{:else if $page.status >= 500}
+				Something went wrong
+			{:else}
+				Unexpected error
+			{/if}
+		</h1>
+		<p class="error-message">
+			{#if $page.error?.message && $page.status !== 500}
+				{$page.error.message}
+			{:else if $page.status === 404}
+				The page you're looking for doesn't exist or has moved.
+			{:else if $page.status === 429}
+				You've hit the rate limit. Please wait a minute and try again.
+			{:else}
+				An unexpected error occurred. Refreshing usually helps.
+			{/if}
+		</p>
+		<div class="error-actions">
+			<a href="/" class="btn-primary">Back to home</a>
+			<a href="/scanner" class="btn-secondary">Open scanner</a>
+		</div>
+	</div>
+</main>
+
+<style>
+	.error-page {
+		position: relative;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		min-height: 100dvh;
+		padding: 6rem 1.5rem 4rem;
+		overflow: hidden;
+	}
+
+	.error-bg {
+		position: absolute;
+		inset: 0;
+		overflow: hidden;
+		pointer-events: none;
+	}
+
+	.bg-orb {
+		position: absolute;
+		border-radius: 50%;
+		filter: blur(120px);
+	}
+
+	.orb-1 {
+		width: 480px;
+		height: 480px;
+		background: rgba(239, 68, 68, 0.06);
+		top: -10%;
+		right: -15%;
+	}
+
+	.orb-2 {
+		width: 380px;
+		height: 380px;
+		background: rgba(139, 92, 246, 0.05);
+		bottom: -10%;
+		left: -15%;
+	}
+
+	.error-card {
+		position: relative;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		text-align: center;
+		max-width: 520px;
+		padding: 3rem 2.5rem;
+		background: var(--glass-bg);
+		border: 1px solid var(--glass-border);
+		border-radius: var(--radius-xl);
+		backdrop-filter: blur(20px);
+	}
+
+	.error-status {
+		font-family: var(--font-mono);
+		font-size: 0.78rem;
+		font-weight: 600;
+		letter-spacing: 0.16em;
+		color: var(--text-tertiary);
+		margin-bottom: 1.25rem;
+	}
+
+	.error-title {
+		font-size: clamp(1.6rem, 4vw, 2.25rem);
+		font-weight: 800;
+		letter-spacing: -0.02em;
+		color: var(--text-primary);
+		margin-bottom: 0.85rem;
+		line-height: 1.2;
+	}
+
+	.error-message {
+		font-size: 0.95rem;
+		color: var(--text-secondary);
+		line-height: 1.6;
+		margin-bottom: 1.85rem;
+		max-width: 420px;
+	}
+
+	.error-actions {
+		display: flex;
+		gap: 0.85rem;
+		flex-wrap: wrap;
+		justify-content: center;
+	}
+
+	.btn-primary,
+	.btn-secondary {
+		display: inline-flex;
+		align-items: center;
+		padding: 0.65rem 1.35rem;
+		font-size: 0.9rem;
+		font-weight: 600;
+		border-radius: var(--radius-full);
+		text-decoration: none;
+		transition:
+			transform 0.2s ease,
+			box-shadow 0.2s ease,
+			border-color 0.2s ease,
+			color 0.2s ease;
+	}
+
+	.btn-primary {
+		color: var(--color-bg-primary);
+		background: var(--gradient-primary);
+	}
+
+	.btn-primary:hover {
+		transform: translateY(-1px);
+		box-shadow: 0 0 20px rgba(6, 182, 212, 0.3);
+	}
+
+	.btn-secondary {
+		color: var(--text-secondary);
+		background: var(--glass-bg);
+		border: 1px solid var(--glass-border);
+	}
+
+	.btn-secondary:hover {
+		border-color: var(--accent-cyan);
+		color: var(--text-primary);
+	}
+</style>

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { page } from '$app/stores';
+	import { page } from '$app/state';
 	import SeoHead from '$components/seo/SeoHead.svelte';
 </script>
 
@@ -16,24 +16,24 @@
 	</div>
 
 	<div class="error-card">
-		<div class="error-status">{$page.status}</div>
+		<div class="error-status">{page.status}</div>
 		<h1 class="error-title">
-			{#if $page.status === 404}
+			{#if page.status === 404}
 				Page not found
-			{:else if $page.status === 429}
+			{:else if page.status === 429}
 				Too many requests
-			{:else if $page.status >= 500}
+			{:else if page.status >= 500}
 				Something went wrong
 			{:else}
 				Unexpected error
 			{/if}
 		</h1>
 		<p class="error-message">
-			{#if $page.error?.message && $page.status !== 500}
-				{$page.error.message}
-			{:else if $page.status === 404}
+			{#if page.error?.message && page.status !== 500}
+				{page.error.message}
+			{:else if page.status === 404}
 				The page you're looking for doesn't exist or has moved.
-			{:else if $page.status === 429}
+			{:else if page.status === 429}
 				You've hit the rate limit. Please wait a minute and try again.
 			{:else}
 				An unexpected error occurred. Refreshing usually helps.

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6,14 +6,33 @@
 	import HowItWorks from '$components/landing/HowItWorks.svelte';
 	import CallToAction from '$components/landing/CallToAction.svelte';
 	import Footer from '$components/landing/Footer.svelte';
+	import SeoHead from '$components/seo/SeoHead.svelte';
+
+	const softwareAppLd = {
+		'@context': 'https://schema.org',
+		'@type': 'SoftwareApplication',
+		name: 'ATS Screener',
+		applicationCategory: 'BusinessApplication',
+		operatingSystem: 'Web',
+		description:
+			'Free ATS resume screener simulating Workday, Taleo, iCIMS, Greenhouse, Lever, and SuccessFactors. Real scores, not made-up numbers.',
+		offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+		author: { '@type': 'Person', name: 'Sunny Patel' }
+	};
+
+	// escape '<' so the serialized JSON can never accidentally close the surrounding
+	// <script> tag - safe even if softwareAppLd ever contains user-controlled values
+	const ldJson = JSON.stringify(softwareAppLd).replace(/</g, '\\u003c');
 </script>
 
+<SeoHead
+	title="ATS Screener - Free Resume Scanner for Real HCMS Platforms"
+	description="Free ATS resume screener simulating Workday, Taleo, iCIMS, Greenhouse, Lever, and SuccessFactors. Get real scores, not made-up numbers."
+/>
+
 <svelte:head>
-	<title>ATS Screener - Free Resume Scanner for Real HCMS Platforms</title>
-	<meta
-		name="description"
-		content="Free ATS resume screener simulating Workday, Taleo, iCIMS, Greenhouse, Lever, and SuccessFactors. Get real scores, not made-up numbers."
-	/>
+	<!-- eslint-disable-next-line svelte/no-at-html-tags -->
+	{@html `<script type="application/ld+json">${ldJson}</` + `script>`}
 </svelte:head>
 
 <main class="landing">

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -1,13 +1,11 @@
 <script lang="ts">
+	import SeoHead from '$components/seo/SeoHead.svelte';
 </script>
 
-<svelte:head>
-	<title>About | ATS Screener</title>
-	<meta
-		name="description"
-		content="Learn about ATS Screener, the free open-source tool that simulates how real enterprise ATS platforms parse and score your resume."
-	/>
-</svelte:head>
+<SeoHead
+	title="About | ATS Screener"
+	description="Learn about ATS Screener, the free open-source tool that simulates how real enterprise ATS platforms parse and score your resume."
+/>
 
 <main class="about">
 	<div class="about-bg">

--- a/src/routes/api/analyze/+server.ts
+++ b/src/routes/api/analyze/+server.ts
@@ -2,6 +2,8 @@ import { json, error } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { env } from '$env/dynamic/private';
 import { buildFullScoringPrompt, buildJDAnalysisPrompt } from '$engine/llm/prompts';
+import { hashPrompt, getCached, setCached } from './cache';
+import { checkRateLimit } from './rate-limiter';
 
 // provider configuration: Gemma 3 27B (Google) → Llama 3.3 70B (Groq)
 // cross-provider fallback ensures independent quotas so one provider's limits don't cascade
@@ -82,105 +84,10 @@ const PROVIDERS: LLMProvider[] = [
 	buildGroqProvider('groq-llama-3.3-70b', 'llama-3.3-70b-versatile')
 ];
 
-// simple in-memory rate limiter per IP
-const rateLimits = new Map<string, { count: number; resetAt: number }>();
-const dailyLimits = new Map<string, { count: number; resetAt: number }>();
-const MAX_RPM = 10;
-const MAX_RPD = 200;
-const MAX_MAP_SIZE = 10_000;
-
-// in-memory LRU result cache keyed by SHA-256 of the full prompt
-// dies with the instance and is per-region, but warm hits skip the LLM call entirely
-// hashing the prompt (not the raw inputs) means prompt-template edits auto-bust stale entries
-interface CacheEntry {
-	parsed: Record<string, unknown>;
-	provider: string;
-	expiresAt: number;
-}
-const resultCache = new Map<string, CacheEntry>();
-const MAX_CACHE_SIZE = 200;
-const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
-
-async function hashPrompt(prompt: string): Promise<string> {
-	const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(prompt));
-	return Array.from(new Uint8Array(digest))
-		.map((b) => b.toString(16).padStart(2, '0'))
-		.join('');
-}
-
-function getCached(key: string): CacheEntry | null {
-	const entry = resultCache.get(key);
-	if (!entry) return null;
-	if (Date.now() > entry.expiresAt) {
-		resultCache.delete(key);
-		return null;
-	}
-	// bump to most-recent on hit (Map preserves insertion order)
-	resultCache.delete(key);
-	resultCache.set(key, entry);
-	return entry;
-}
-
-function setCached(key: string, parsed: Record<string, unknown>, provider: string): void {
-	if (resultCache.size >= MAX_CACHE_SIZE) {
-		const oldest = resultCache.keys().next().value;
-		if (oldest !== undefined) resultCache.delete(oldest);
-	}
-	resultCache.set(key, { parsed, provider, expiresAt: Date.now() + CACHE_TTL_MS });
-}
 // per-provider timeouts: Gemma (90s) + Groq (30s) = 120s worst case
 // Gemma typically responds in 30-45s but can spike under load; Groq is <1s but gets headroom
 // Fluid Compute on Vercel Hobby gives 300s max, so 120s worst case fits comfortably
 const PROVIDER_TIMEOUTS_MS = [90_000, 30_000];
-
-type RateLimitResult =
-	| { allowed: true }
-	| { allowed: false; reason: 'minute' | 'daily'; retryAfterSec: number };
-
-function checkRateLimit(ip: string): RateLimitResult {
-	const now = Date.now();
-
-	// periodically clean up expired entries to prevent unbounded memory growth
-	if (rateLimits.size > MAX_MAP_SIZE) {
-		for (const [key, val] of rateLimits) {
-			if (now > val.resetAt) rateLimits.delete(key);
-		}
-	}
-	if (dailyLimits.size > MAX_MAP_SIZE) {
-		for (const [key, val] of dailyLimits) {
-			if (now > val.resetAt) dailyLimits.delete(key);
-		}
-	}
-
-	// check both windows BEFORE incrementing, so a daily-limit failure
-	// doesn't also consume a minute slot
-	const minute = rateLimits.get(ip);
-	if (minute && now < minute.resetAt && minute.count >= MAX_RPM) {
-		return {
-			allowed: false,
-			reason: 'minute',
-			retryAfterSec: Math.ceil((minute.resetAt - now) / 1000)
-		};
-	}
-
-	const day = dailyLimits.get(ip);
-	if (day && now < day.resetAt && day.count >= MAX_RPD) {
-		return {
-			allowed: false,
-			reason: 'daily',
-			retryAfterSec: Math.ceil((day.resetAt - now) / 1000)
-		};
-	}
-
-	// both windows have headroom - increment both
-	if (minute && now < minute.resetAt) minute.count++;
-	else rateLimits.set(ip, { count: 1, resetAt: now + 60_000 });
-
-	if (day && now < day.resetAt) day.count++;
-	else dailyLimits.set(ip, { count: 1, resetAt: now + 86_400_000 });
-
-	return { allowed: true };
-}
 
 // tries each provider in sequence until one succeeds and returns valid JSON
 async function callLLM(

--- a/src/routes/api/analyze/+server.ts
+++ b/src/routes/api/analyze/+server.ts
@@ -88,6 +88,46 @@ const dailyLimits = new Map<string, { count: number; resetAt: number }>();
 const MAX_RPM = 10;
 const MAX_RPD = 200;
 const MAX_MAP_SIZE = 10_000;
+
+// in-memory LRU result cache keyed by SHA-256 of the full prompt
+// dies with the instance and is per-region, but warm hits skip the LLM call entirely
+// hashing the prompt (not the raw inputs) means prompt-template edits auto-bust stale entries
+interface CacheEntry {
+	parsed: Record<string, unknown>;
+	provider: string;
+	expiresAt: number;
+}
+const resultCache = new Map<string, CacheEntry>();
+const MAX_CACHE_SIZE = 200;
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+
+async function hashPrompt(prompt: string): Promise<string> {
+	const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(prompt));
+	return Array.from(new Uint8Array(digest))
+		.map((b) => b.toString(16).padStart(2, '0'))
+		.join('');
+}
+
+function getCached(key: string): CacheEntry | null {
+	const entry = resultCache.get(key);
+	if (!entry) return null;
+	if (Date.now() > entry.expiresAt) {
+		resultCache.delete(key);
+		return null;
+	}
+	// bump to most-recent on hit (Map preserves insertion order)
+	resultCache.delete(key);
+	resultCache.set(key, entry);
+	return entry;
+}
+
+function setCached(key: string, parsed: Record<string, unknown>, provider: string): void {
+	if (resultCache.size >= MAX_CACHE_SIZE) {
+		const oldest = resultCache.keys().next().value;
+		if (oldest !== undefined) resultCache.delete(oldest);
+	}
+	resultCache.set(key, { parsed, provider, expiresAt: Date.now() + CACHE_TTL_MS });
+}
 // per-provider timeouts: Gemma (90s) + Groq (30s) = 120s worst case
 // Gemma typically responds in 30-45s but can spike under load; Groq is <1s but gets headroom
 // Fluid Compute on Vercel Hobby gives 300s max, so 120s worst case fits comfortably
@@ -293,24 +333,32 @@ export const POST: RequestHandler = async ({ request }) => {
 			throw error(400, 'invalid mode');
 	}
 
+	const securityHeaders = {
+		'X-Content-Type-Options': 'nosniff',
+		'X-Frame-Options': 'DENY',
+		'Cache-Control': 'no-store'
+	};
+
+	// content-addressed cache: identical prompts return identical results, no LLM call
+	const cacheKey = await hashPrompt(prompt);
+	const cached = getCached(cacheKey);
+	if (cached) {
+		return json(
+			{ ...cached.parsed, _provider: cached.provider, _fallback: false, _cached: true },
+			{ headers: securityHeaders }
+		);
+	}
+
 	const result = await callLLM(prompt, keys);
 
 	if (!result) {
 		return json({ error: 'all LLM providers failed', fallback: true }, { status: 503 });
 	}
 
+	setCached(cacheKey, result.parsed, result.provider);
+
 	return json(
-		{
-			...result.parsed,
-			_provider: result.provider,
-			_fallback: false
-		},
-		{
-			headers: {
-				'X-Content-Type-Options': 'nosniff',
-				'X-Frame-Options': 'DENY',
-				'Cache-Control': 'no-store'
-			}
-		}
+		{ ...result.parsed, _provider: result.provider, _fallback: false, _cached: false },
+		{ headers: securityHeaders }
 	);
 };

--- a/src/routes/api/analyze/+server.ts
+++ b/src/routes/api/analyze/+server.ts
@@ -133,7 +133,11 @@ function setCached(key: string, parsed: Record<string, unknown>, provider: strin
 // Fluid Compute on Vercel Hobby gives 300s max, so 120s worst case fits comfortably
 const PROVIDER_TIMEOUTS_MS = [90_000, 30_000];
 
-function checkRateLimit(ip: string): boolean {
+type RateLimitResult =
+	| { allowed: true }
+	| { allowed: false; reason: 'minute' | 'daily'; retryAfterSec: number };
+
+function checkRateLimit(ip: string): RateLimitResult {
 	const now = Date.now();
 
 	// periodically clean up expired entries to prevent unbounded memory growth
@@ -148,23 +152,34 @@ function checkRateLimit(ip: string): boolean {
 		}
 	}
 
+	// check both windows BEFORE incrementing, so a daily-limit failure
+	// doesn't also consume a minute slot
 	const minute = rateLimits.get(ip);
-	if (minute && now < minute.resetAt) {
-		if (minute.count >= MAX_RPM) return false;
-		minute.count++;
-	} else {
-		rateLimits.set(ip, { count: 1, resetAt: now + 60_000 });
+	if (minute && now < minute.resetAt && minute.count >= MAX_RPM) {
+		return {
+			allowed: false,
+			reason: 'minute',
+			retryAfterSec: Math.ceil((minute.resetAt - now) / 1000)
+		};
 	}
 
 	const day = dailyLimits.get(ip);
-	if (day && now < day.resetAt) {
-		if (day.count >= MAX_RPD) return false;
-		day.count++;
-	} else {
-		dailyLimits.set(ip, { count: 1, resetAt: now + 86_400_000 });
+	if (day && now < day.resetAt && day.count >= MAX_RPD) {
+		return {
+			allowed: false,
+			reason: 'daily',
+			retryAfterSec: Math.ceil((day.resetAt - now) / 1000)
+		};
 	}
 
-	return true;
+	// both windows have headroom - increment both
+	if (minute && now < minute.resetAt) minute.count++;
+	else rateLimits.set(ip, { count: 1, resetAt: now + 60_000 });
+
+	if (day && now < day.resetAt) day.count++;
+	else dailyLimits.set(ip, { count: 1, resetAt: now + 86_400_000 });
+
+	return { allowed: true };
 }
 
 // tries each provider in sequence until one succeeds and returns valid JSON
@@ -280,8 +295,20 @@ export const POST: RequestHandler = async ({ request }) => {
 
 	// rate limiting per IP
 	const ip = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ?? 'unknown';
-	if (!checkRateLimit(ip)) {
-		return json({ error: 'rate limit exceeded. try again in 60 seconds.' }, { status: 429 });
+	const limit = checkRateLimit(ip);
+	if (!limit.allowed) {
+		const reasonMsg =
+			limit.reason === 'minute' ? 'too many requests this minute' : 'daily limit reached';
+		return json(
+			{
+				error: `rate limit exceeded: ${reasonMsg}. retry after ${limit.retryAfterSec}s.`,
+				retryAfter: limit.retryAfterSec
+			},
+			{
+				status: 429,
+				headers: { 'Retry-After': String(limit.retryAfterSec) }
+			}
+		);
 	}
 
 	// validate Content-Type

--- a/src/routes/api/analyze/cache.ts
+++ b/src/routes/api/analyze/cache.ts
@@ -1,0 +1,46 @@
+// in-memory LRU result cache keyed by SHA-256 of the full prompt
+// dies with the instance and is per-region, but warm hits skip the LLM call entirely
+// hashing the prompt (not the raw inputs) means prompt-template edits auto-bust stale entries
+
+interface CacheEntry {
+	parsed: Record<string, unknown>;
+	provider: string;
+	expiresAt: number;
+}
+
+const resultCache = new Map<string, CacheEntry>();
+const MAX_CACHE_SIZE = 200;
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+
+export async function hashPrompt(prompt: string): Promise<string> {
+	const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(prompt));
+	return Array.from(new Uint8Array(digest))
+		.map((b) => b.toString(16).padStart(2, '0'))
+		.join('');
+}
+
+export function getCached(key: string): CacheEntry | null {
+	const entry = resultCache.get(key);
+	if (!entry) return null;
+	if (Date.now() > entry.expiresAt) {
+		resultCache.delete(key);
+		return null;
+	}
+	// bump to most-recent on hit (Map preserves insertion order)
+	resultCache.delete(key);
+	resultCache.set(key, entry);
+	return entry;
+}
+
+export function setCached(key: string, parsed: Record<string, unknown>, provider: string): void {
+	if (resultCache.size >= MAX_CACHE_SIZE) {
+		const oldest = resultCache.keys().next().value;
+		if (oldest !== undefined) resultCache.delete(oldest);
+	}
+	resultCache.set(key, { parsed, provider, expiresAt: Date.now() + CACHE_TTL_MS });
+}
+
+// exposed only so tests can introspect; do NOT call from request paths
+export function _cacheSize(): number {
+	return resultCache.size;
+}

--- a/src/routes/api/analyze/rate-limiter.ts
+++ b/src/routes/api/analyze/rate-limiter.ts
@@ -7,6 +7,13 @@ const dailyLimits = new Map<string, { count: number; resetAt: number }>();
 const MAX_RPM = 10;
 const MAX_RPD = 200;
 const MAX_MAP_SIZE = 10_000;
+// throttle the O(n) cleanup so we don't pay it on every request once size > 10k.
+// at 50k unique users/day the daily map exceeds the threshold continuously, and
+// without throttling each request would walk the entire map. running it at most
+// once per CLEANUP_INTERVAL_MS bounds the cost regardless of size
+const CLEANUP_INTERVAL_MS = 30_000;
+let lastMinuteCleanupAt = 0;
+let lastDailyCleanupAt = 0;
 
 export type RateLimitResult =
 	| { allowed: true }
@@ -15,16 +22,20 @@ export type RateLimitResult =
 export function checkRateLimit(ip: string): RateLimitResult {
 	const now = Date.now();
 
-	// periodically clean up expired entries to prevent unbounded memory growth
-	if (rateLimits.size > MAX_MAP_SIZE) {
+	// periodically clean up expired entries to prevent unbounded memory growth.
+	// throttled so the O(n) sweep can't fire on every request when the map sits
+	// above MAX_MAP_SIZE (which becomes steady-state at high traffic)
+	if (rateLimits.size > MAX_MAP_SIZE && now - lastMinuteCleanupAt > CLEANUP_INTERVAL_MS) {
 		for (const [key, val] of rateLimits) {
 			if (now > val.resetAt) rateLimits.delete(key);
 		}
+		lastMinuteCleanupAt = now;
 	}
-	if (dailyLimits.size > MAX_MAP_SIZE) {
+	if (dailyLimits.size > MAX_MAP_SIZE && now - lastDailyCleanupAt > CLEANUP_INTERVAL_MS) {
 		for (const [key, val] of dailyLimits) {
 			if (now > val.resetAt) dailyLimits.delete(key);
 		}
+		lastDailyCleanupAt = now;
 	}
 
 	// check both windows BEFORE incrementing, so a daily-limit failure

--- a/src/routes/api/analyze/rate-limiter.ts
+++ b/src/routes/api/analyze/rate-limiter.ts
@@ -1,0 +1,64 @@
+// per-IP in-memory rate limiter
+// dies with the instance (no distributed lock); fine on Vercel hobby/single instance
+// upgrade path: swap the Maps for a kv-backed adapter without changing the public API
+
+const rateLimits = new Map<string, { count: number; resetAt: number }>();
+const dailyLimits = new Map<string, { count: number; resetAt: number }>();
+const MAX_RPM = 10;
+const MAX_RPD = 200;
+const MAX_MAP_SIZE = 10_000;
+
+export type RateLimitResult =
+	| { allowed: true }
+	| { allowed: false; reason: 'minute' | 'daily'; retryAfterSec: number };
+
+export function checkRateLimit(ip: string): RateLimitResult {
+	const now = Date.now();
+
+	// periodically clean up expired entries to prevent unbounded memory growth
+	if (rateLimits.size > MAX_MAP_SIZE) {
+		for (const [key, val] of rateLimits) {
+			if (now > val.resetAt) rateLimits.delete(key);
+		}
+	}
+	if (dailyLimits.size > MAX_MAP_SIZE) {
+		for (const [key, val] of dailyLimits) {
+			if (now > val.resetAt) dailyLimits.delete(key);
+		}
+	}
+
+	// check both windows BEFORE incrementing, so a daily-limit failure
+	// doesn't also consume a minute slot
+	const minute = rateLimits.get(ip);
+	if (minute && now < minute.resetAt && minute.count >= MAX_RPM) {
+		return {
+			allowed: false,
+			reason: 'minute',
+			retryAfterSec: Math.ceil((minute.resetAt - now) / 1000)
+		};
+	}
+
+	const day = dailyLimits.get(ip);
+	if (day && now < day.resetAt && day.count >= MAX_RPD) {
+		return {
+			allowed: false,
+			reason: 'daily',
+			retryAfterSec: Math.ceil((day.resetAt - now) / 1000)
+		};
+	}
+
+	// both windows have headroom - increment both
+	if (minute && now < minute.resetAt) minute.count++;
+	else rateLimits.set(ip, { count: 1, resetAt: now + 60_000 });
+
+	if (day && now < day.resetAt) day.count++;
+	else dailyLimits.set(ip, { count: 1, resetAt: now + 86_400_000 });
+
+	return { allowed: true };
+}
+
+// exported constants so tests can drive the limiter without magic numbers
+export const RATE_LIMIT_CONFIG = {
+	MAX_RPM,
+	MAX_RPD
+} as const;

--- a/src/routes/api/csp-report/+server.ts
+++ b/src/routes/api/csp-report/+server.ts
@@ -1,0 +1,19 @@
+import type { RequestHandler } from './$types';
+
+// receives violation reports from the Content-Security-Policy-Report-Only header
+// in src/hooks.server.ts. logs to stdout only (no storage) so vercel's log
+// aggregation surfaces them without spending a single firestore write
+export const POST: RequestHandler = async ({ request }) => {
+	try {
+		const ct = request.headers.get('content-type') ?? '';
+		// browsers send either Content-Type: application/csp-report (legacy)
+		// or application/reports+json (modern Reporting API)
+		const body = await request.json().catch(() => null);
+		if (body) {
+			console.warn('[csp-violation]', ct, JSON.stringify(body).slice(0, 1000));
+		}
+	} catch {
+		// swallow; reporting must never break the request path
+	}
+	return new Response(null, { status: 204 });
+};

--- a/src/routes/api/og/+server.ts
+++ b/src/routes/api/og/+server.ts
@@ -36,8 +36,10 @@ function parseInt0(v: string | null, fallback: number, min: number, max: number)
 
 export const GET: RequestHandler = async ({ url }) => {
 	const score = parseInt0(url.searchParams.get('score'), 0, 0, 100);
-	const pass = parseInt0(url.searchParams.get('pass'), 0, 0, 6);
+	// parse total first, then cap pass to <= total so a tampered URL like
+	// ?pass=6&total=1 cannot render "6 of 1 ATS systems passed"
 	const total = parseInt0(url.searchParams.get('total'), 6, 1, 6);
+	const pass = clamp(parseInt0(url.searchParams.get('pass'), 0, 0, 6), 0, total);
 	const delta = url.searchParams.has('delta')
 		? parseInt0(url.searchParams.get('delta'), 0, -100, 100)
 		: null;

--- a/src/routes/api/og/+server.ts
+++ b/src/routes/api/og/+server.ts
@@ -1,8 +1,11 @@
 import { ImageResponse } from '@vercel/og';
 import type { RequestHandler } from './$types';
 
-// edge runtime is required by @vercel/og (uses Web APIs only)
-export const config = { runtime: 'edge' };
+// runs on the default (node) serverless runtime - the deprecated `runtime: 'edge'`
+// adapter-vercel option pulls SvelteKit's bundled root.js (which references
+// node:crypto via dynamic import) into an edge-only build that esbuild fails to
+// resolve. @vercel/og >=0.6 works fine on node-runtime serverless functions
+export const config = { maxDuration: 30 };
 
 const WIDTH = 1200;
 const HEIGHT = 630;

--- a/src/routes/api/og/+server.ts
+++ b/src/routes/api/og/+server.ts
@@ -34,7 +34,7 @@ function parseInt0(v: string | null, fallback: number, min: number, max: number)
 	return Number.isFinite(n) ? clamp(n, min, max) : fallback;
 }
 
-export const GET: RequestHandler = ({ url }) => {
+export const GET: RequestHandler = async ({ url }) => {
 	const score = parseInt0(url.searchParams.get('score'), 0, 0, 100);
 	const pass = parseInt0(url.searchParams.get('pass'), 0, 0, 6);
 	const total = parseInt0(url.searchParams.get('total'), 6, 1, 6);
@@ -209,8 +209,24 @@ export const GET: RequestHandler = ({ url }) => {
 		}
 	};
 
-	// @vercel/og applies its own Cache-Control default; setting one here would
-	// concatenate rather than replace, so we let the default stand. crawlers
-	// refetch when query params change (which is the right behavior for shares)
-	return new ImageResponse(tree as never, { width: WIDTH, height: HEIGHT });
+	// @vercel/og's ImageResponse hardcodes Cache-Control: no-cache,no-store and
+	// passing a custom Cache-Control via the constructor's headers option only
+	// CONCATENATES (verified locally - ends up "no-cache, no-store, public,...").
+	// to actually cache at Vercel's CDN we re-wrap the rendered bytes in a fresh
+	// Response with the headers we want. since the URL is fully content-addressed
+	// (score+pass+total+delta), any unique combination caches forever - massive
+	// cost protection because repeat shares of the same link hit the edge cache,
+	// never the function
+	const og = new ImageResponse(tree as never, { width: WIDTH, height: HEIGHT });
+	const buffer = await og.arrayBuffer();
+	return new Response(buffer, {
+		status: 200,
+		headers: {
+			'Content-Type': 'image/png',
+			// s-maxage = vercel cdn TTL (1d), max-age = browser TTL (1h),
+			// stale-while-revalidate keeps serving stale up to 7d while refreshing
+			'Cache-Control':
+				'public, max-age=3600, s-maxage=86400, stale-while-revalidate=604800, immutable'
+		}
+	});
 };

--- a/src/routes/api/og/+server.ts
+++ b/src/routes/api/og/+server.ts
@@ -38,7 +38,9 @@ export const GET: RequestHandler = async ({ url }) => {
 	const score = parseInt0(url.searchParams.get('score'), 0, 0, 100);
 	const pass = parseInt0(url.searchParams.get('pass'), 0, 0, 6);
 	const total = parseInt0(url.searchParams.get('total'), 6, 1, 6);
-	const delta = url.searchParams.has('delta') ? parseInt0(url.searchParams.get('delta'), 0, -100, 100) : null;
+	const delta = url.searchParams.has('delta')
+		? parseInt0(url.searchParams.get('delta'), 0, -100, 100)
+		: null;
 
 	const color = tierColor(score);
 	const label = tierLabel(score);
@@ -54,8 +56,7 @@ export const GET: RequestHandler = async ({ url }) => {
 				display: 'flex',
 				flexDirection: 'column',
 				justifyContent: 'space-between',
-				background:
-					'linear-gradient(135deg, #0a0a1a 0%, #0d0d24 50%, #12122e 100%)',
+				background: 'linear-gradient(135deg, #0a0a1a 0%, #0d0d24 50%, #12122e 100%)',
 				color: '#e4e4e7',
 				padding: '64px 72px',
 				fontFamily: 'Inter, system-ui, sans-serif'
@@ -199,10 +200,7 @@ export const GET: RequestHandler = async ({ url }) => {
 							fontSize: '22px',
 							color: '#71717a'
 						},
-						children: [
-							'Free • Open source • No paywalls',
-							'ats-screener.vercel.app'
-						]
+						children: ['Free • Open source • No paywalls', 'ats-screener.vercel.app']
 					}
 				}
 			]

--- a/src/routes/api/og/+server.ts
+++ b/src/routes/api/og/+server.ts
@@ -1,0 +1,213 @@
+import { ImageResponse } from '@vercel/og';
+import type { RequestHandler } from './$types';
+
+// edge runtime is required by @vercel/og (uses Web APIs only)
+export const config = { runtime: 'edge' };
+
+const WIDTH = 1200;
+const HEIGHT = 630;
+
+// score-tier colors mirror src/lib/engine/scorer/classification.ts
+function tierColor(score: number): string {
+	if (score >= 80) return '#22c55e';
+	if (score >= 60) return '#eab308';
+	if (score >= 40) return '#f97316';
+	return '#ef4444';
+}
+
+function tierLabel(score: number): string {
+	if (score >= 80) return 'EXCELLENT';
+	if (score >= 60) return 'GOOD';
+	if (score >= 40) return 'NEEDS WORK';
+	return 'POOR';
+}
+
+function clamp(n: number, min: number, max: number): number {
+	return Math.max(min, Math.min(max, n));
+}
+
+function parseInt0(v: string | null, fallback: number, min: number, max: number): number {
+	const n = v ? Number.parseInt(v, 10) : NaN;
+	return Number.isFinite(n) ? clamp(n, min, max) : fallback;
+}
+
+export const GET: RequestHandler = ({ url }) => {
+	const score = parseInt0(url.searchParams.get('score'), 0, 0, 100);
+	const pass = parseInt0(url.searchParams.get('pass'), 0, 0, 6);
+	const total = parseInt0(url.searchParams.get('total'), 6, 1, 6);
+	const delta = url.searchParams.has('delta') ? parseInt0(url.searchParams.get('delta'), 0, -100, 100) : null;
+
+	const color = tierColor(score);
+	const label = tierLabel(score);
+
+	// React-element tree built as plain objects so we don't need JSX in the project.
+	// satori (under @vercel/og) accepts this shape directly.
+	const tree = {
+		type: 'div',
+		props: {
+			style: {
+				width: '100%',
+				height: '100%',
+				display: 'flex',
+				flexDirection: 'column',
+				justifyContent: 'space-between',
+				background:
+					'linear-gradient(135deg, #0a0a1a 0%, #0d0d24 50%, #12122e 100%)',
+				color: '#e4e4e7',
+				padding: '64px 72px',
+				fontFamily: 'Inter, system-ui, sans-serif'
+			},
+			children: [
+				// header strip
+				{
+					type: 'div',
+					props: {
+						style: {
+							display: 'flex',
+							alignItems: 'center',
+							gap: '16px',
+							fontSize: '22px',
+							fontWeight: 600,
+							color: '#a1a1aa',
+							letterSpacing: '0.06em',
+							textTransform: 'uppercase'
+						},
+						children: [
+							{
+								type: 'div',
+								props: {
+									style: {
+										width: '12px',
+										height: '12px',
+										borderRadius: '50%',
+										background: color
+									}
+								}
+							},
+							'ATS SCREENER'
+						]
+					}
+				},
+				// center: score + verdict
+				{
+					type: 'div',
+					props: {
+						style: {
+							display: 'flex',
+							flexDirection: 'column',
+							gap: '10px'
+						},
+						children: [
+							{
+								type: 'div',
+								props: {
+									style: {
+										display: 'flex',
+										alignItems: 'baseline',
+										gap: '24px'
+									},
+									children: [
+										{
+											type: 'div',
+											props: {
+												style: {
+													fontSize: '260px',
+													fontWeight: 800,
+													color,
+													lineHeight: 1,
+													letterSpacing: '-0.04em'
+												},
+												children: String(score)
+											}
+										},
+										delta !== null && delta > 0
+											? {
+													type: 'div',
+													props: {
+														style: {
+															display: 'flex',
+															alignItems: 'center',
+															padding: '10px 22px',
+															background: 'rgba(34, 197, 94, 0.18)',
+															color: '#22c55e',
+															borderRadius: '999px',
+															fontSize: '40px',
+															fontWeight: 700
+														},
+														children: `+${delta}`
+													}
+												}
+											: null,
+										delta !== null && delta < 0
+											? {
+													type: 'div',
+													props: {
+														style: {
+															display: 'flex',
+															alignItems: 'center',
+															padding: '10px 22px',
+															background: 'rgba(239, 68, 68, 0.18)',
+															color: '#ef4444',
+															borderRadius: '999px',
+															fontSize: '40px',
+															fontWeight: 700
+														},
+														children: String(delta)
+													}
+												}
+											: null
+									].filter(Boolean)
+								}
+							},
+							{
+								type: 'div',
+								props: {
+									style: {
+										fontSize: '40px',
+										fontWeight: 700,
+										color,
+										letterSpacing: '0.04em'
+									},
+									children: label
+								}
+							},
+							{
+								type: 'div',
+								props: {
+									style: {
+										fontSize: '28px',
+										color: '#a1a1aa',
+										marginTop: '8px'
+									},
+									children: `${pass} of ${total} ATS systems passed`
+								}
+							}
+						]
+					}
+				},
+				// footer
+				{
+					type: 'div',
+					props: {
+						style: {
+							display: 'flex',
+							justifyContent: 'space-between',
+							alignItems: 'center',
+							fontSize: '22px',
+							color: '#71717a'
+						},
+						children: [
+							'Free • Open source • No paywalls',
+							'ats-screener.vercel.app'
+						]
+					}
+				}
+			]
+		}
+	};
+
+	// @vercel/og applies its own Cache-Control default; setting one here would
+	// concatenate rather than replace, so we let the default stand. crawlers
+	// refetch when query params change (which is the right behavior for shares)
+	return new ImageResponse(tree as never, { width: WIDTH, height: HEIGHT });
+};

--- a/src/routes/docs/[...slug]/+server.ts
+++ b/src/routes/docs/[...slug]/+server.ts
@@ -1,6 +1,6 @@
 import { error } from '@sveltejs/kit';
-import { readFileSync, existsSync } from 'node:fs';
-import { join } from 'node:path';
+import { readFileSync, existsSync, realpathSync } from 'node:fs';
+import { resolve, sep } from 'node:path';
 import type { RequestHandler } from './$types';
 
 // node-runtime catchall: serves directory-style URLs from the Astro Starlight
@@ -8,17 +8,31 @@ import type { RequestHandler } from './$types';
 // Vercel's static handler already serves files with explicit extensions
 // (.html/.css/.js/etc), so this only fires when no file matched.
 //
-// fs/path live ONLY here so they don't leak into the edge bundle for /api/og
+// fs/path live ONLY here so they don't leak into the edge bundle for /api/og.
+// Note: path.join('/foo', '/bar') returns '/foo/bar' (Node concatenates absolute
+// segments after the first), so a leading slash on url.pathname doesn't drop
+// staticBase. The real risk is path traversal via "/docs/../../etc/passwd";
+// resolve()+startsWith on the docsRoot blocks that.
 export const GET: RequestHandler = ({ url }) => {
-	const path = url.pathname;
-	const staticBase = join(process.cwd(), 'static');
-	const withIndex = join(staticBase, path, 'index.html');
+	const docsRoot = resolve(process.cwd(), 'static', 'docs');
+	// strip the leading "/docs" since docsRoot already points there
+	const slug = url.pathname.replace(/^\/docs\/?/, '');
+	const candidate = resolve(docsRoot, slug, 'index.html');
 
-	if (!existsSync(withIndex)) {
+	// path-traversal guard: candidate must stay under docsRoot
+	const rooted = candidate === docsRoot || candidate.startsWith(docsRoot + sep);
+	if (!rooted || !existsSync(candidate)) {
 		throw error(404, 'docs page not found');
 	}
 
-	const html = readFileSync(withIndex, 'utf-8');
+	// realpath check defends against symlink escapes
+	const realCandidate = realpathSync(candidate);
+	const realRoot = realpathSync(docsRoot);
+	if (realCandidate !== realRoot && !realCandidate.startsWith(realRoot + sep)) {
+		throw error(404, 'docs page not found');
+	}
+
+	const html = readFileSync(realCandidate, 'utf-8');
 	return new Response(html, {
 		headers: { 'Content-Type': 'text/html; charset=utf-8' }
 	});

--- a/src/routes/docs/[...slug]/+server.ts
+++ b/src/routes/docs/[...slug]/+server.ts
@@ -1,0 +1,25 @@
+import { error } from '@sveltejs/kit';
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import type { RequestHandler } from './$types';
+
+// node-runtime catchall: serves directory-style URLs from the Astro Starlight
+// build output in static/docs (e.g. /docs/intro -> static/docs/intro/index.html).
+// Vercel's static handler already serves files with explicit extensions
+// (.html/.css/.js/etc), so this only fires when no file matched.
+//
+// fs/path live ONLY here so they don't leak into the edge bundle for /api/og
+export const GET: RequestHandler = ({ url }) => {
+	const path = url.pathname;
+	const staticBase = join(process.cwd(), 'static');
+	const withIndex = join(staticBase, path, 'index.html');
+
+	if (!existsSync(withIndex)) {
+		throw error(404, 'docs page not found');
+	}
+
+	const html = readFileSync(withIndex, 'utf-8');
+	return new Response(html, {
+		headers: { 'Content-Type': 'text/html; charset=utf-8' }
+	});
+};

--- a/src/routes/healthz/+server.ts
+++ b/src/routes/healthz/+server.ts
@@ -1,0 +1,20 @@
+import type { RequestHandler } from './$types';
+
+// minimal liveness probe for uptime checkers (cron-job.org, betterstack, etc).
+// returns 200 unconditionally; if the runtime is broken, the probe will time
+// out or return 5xx via the platform layer
+export const GET: RequestHandler = () => {
+	return new Response(
+		JSON.stringify({
+			status: 'ok',
+			timestamp: new Date().toISOString()
+		}),
+		{
+			status: 200,
+			headers: {
+				'Content-Type': 'application/json; charset=utf-8',
+				'Cache-Control': 'no-store'
+			}
+		}
+	);
+};

--- a/src/routes/history/+page.svelte
+++ b/src/routes/history/+page.svelte
@@ -170,7 +170,8 @@
 							<div class="journey-stat">
 								<span class="journey-label">Over</span>
 								<span class="journey-value-text">
-									{journey.daysSpan} {journey.daysSpan === 1 ? 'day' : 'days'}
+									{journey.daysSpan}
+									{journey.daysSpan === 1 ? 'day' : 'days'}
 								</span>
 							</div>
 						{/if}

--- a/src/routes/history/+page.svelte
+++ b/src/routes/history/+page.svelte
@@ -5,6 +5,7 @@
 	import ScoreDashboard from '$components/scoring/ScoreDashboard.svelte';
 	import ScoreTimeline from '$components/scoring/ScoreTimeline.svelte';
 	import SeoHead from '$components/seo/SeoHead.svelte';
+	import { computeJourneyStats } from '$engine/scorer/journey';
 
 	let selectedEntry = $state<ScanHistoryEntry | null>(null);
 
@@ -23,6 +24,7 @@
 	});
 
 	const history = $derived(scoresStore.history);
+	const journey = $derived(computeJourneyStats(history));
 
 	function formatDate(iso: string): string {
 		const d = new Date(iso);
@@ -135,6 +137,46 @@
 					<a href="/scanner" class="cta-btn">Scan a Resume</a>
 				</div>
 			{:else}
+				{#if journey && journey.totalScans >= 2}
+					<div class="journey-card">
+						<div class="journey-stat">
+							<span class="journey-label">Total improvement</span>
+							<span
+								class="journey-value"
+								class:positive={journey.totalDelta > 0}
+								class:negative={journey.totalDelta < 0}
+							>
+								{journey.totalDelta > 0 ? '+' : ''}{journey.totalDelta}
+							</span>
+						</div>
+						<div class="journey-stat">
+							<span class="journey-label">Best score</span>
+							<span class="journey-value">{journey.bestScore}</span>
+						</div>
+						<div class="journey-stat">
+							<span class="journey-label">Scans</span>
+							<span class="journey-value">{journey.totalScans}</span>
+						</div>
+						{#if journey.bestPlatformDelta && journey.bestPlatformDelta.delta > 0}
+							<div class="journey-stat">
+								<span class="journey-label">Strongest gain</span>
+								<span class="journey-value-text">
+									{journey.bestPlatformDelta.system}
+									<span class="journey-pill">+{journey.bestPlatformDelta.delta}</span>
+								</span>
+							</div>
+						{/if}
+						{#if journey.daysSpan > 0}
+							<div class="journey-stat">
+								<span class="journey-label">Over</span>
+								<span class="journey-value-text">
+									{journey.daysSpan} {journey.daysSpan === 1 ? 'day' : 'days'}
+								</span>
+							</div>
+						{/if}
+					</div>
+				{/if}
+
 				{#if history.length >= 2}
 					<div class="timeline-section">
 						<ScoreTimeline entries={history} />
@@ -296,6 +338,67 @@
 	}
 
 	/* history card grid */
+	.journey-card {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 1.75rem 2.25rem;
+		padding: 1.1rem 1.4rem;
+		margin-bottom: 1.4rem;
+		background: var(--glass-bg);
+		border: 1px solid var(--glass-border);
+		border-radius: var(--radius-lg);
+		backdrop-filter: blur(12px);
+	}
+
+	.journey-stat {
+		display: flex;
+		flex-direction: column;
+		gap: 0.18rem;
+	}
+
+	.journey-label {
+		font-size: 0.66rem;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.08em;
+		color: var(--text-tertiary);
+	}
+
+	.journey-value {
+		font-size: 1.45rem;
+		font-weight: 800;
+		font-variant-numeric: tabular-nums;
+		color: var(--text-primary);
+		line-height: 1;
+	}
+
+	.journey-value.positive {
+		color: #22c55e;
+	}
+
+	.journey-value.negative {
+		color: #ef4444;
+	}
+
+	.journey-value-text {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.45rem;
+		font-size: 0.95rem;
+		font-weight: 700;
+		color: var(--text-primary);
+	}
+
+	.journey-pill {
+		padding: 0.1rem 0.45rem;
+		font-size: 0.7rem;
+		font-weight: 700;
+		font-variant-numeric: tabular-nums;
+		border-radius: var(--radius-full);
+		color: #22c55e;
+		background: rgba(34, 197, 94, 0.12);
+	}
+
 	.timeline-section {
 		margin-bottom: 1.75rem;
 	}

--- a/src/routes/history/+page.svelte
+++ b/src/routes/history/+page.svelte
@@ -3,6 +3,7 @@
 	import { authStore } from '$stores/auth.svelte';
 	import { scoresStore, type ScanHistoryEntry } from '$stores/scores.svelte';
 	import ScoreDashboard from '$components/scoring/ScoreDashboard.svelte';
+	import SeoHead from '$components/seo/SeoHead.svelte';
 
 	let selectedEntry = $state<ScanHistoryEntry | null>(null);
 
@@ -55,9 +56,11 @@
 	}
 </script>
 
-<svelte:head>
-	<title>Scan History | ATS Screener</title>
-</svelte:head>
+<SeoHead
+	title="Scan History | ATS Screener"
+	description="Review your past resume scans, compare scores over time, and load any past result back into the dashboard."
+	noIndex
+/>
 
 <main class="history-page">
 	<div class="history-bg">

--- a/src/routes/history/+page.svelte
+++ b/src/routes/history/+page.svelte
@@ -3,6 +3,7 @@
 	import { authStore } from '$stores/auth.svelte';
 	import { scoresStore, type ScanHistoryEntry } from '$stores/scores.svelte';
 	import ScoreDashboard from '$components/scoring/ScoreDashboard.svelte';
+	import ScoreTimeline from '$components/scoring/ScoreTimeline.svelte';
 	import SeoHead from '$components/seo/SeoHead.svelte';
 
 	let selectedEntry = $state<ScanHistoryEntry | null>(null);
@@ -134,6 +135,12 @@
 					<a href="/scanner" class="cta-btn">Scan a Resume</a>
 				</div>
 			{:else}
+				{#if history.length >= 2}
+					<div class="timeline-section">
+						<ScoreTimeline entries={history} />
+					</div>
+				{/if}
+
 				<div class="history-grid">
 					{#each history as entry (entry.id)}
 						<button class="history-card" onclick={() => viewEntry(entry)}>
@@ -289,6 +296,10 @@
 	}
 
 	/* history card grid */
+	.timeline-section {
+		margin-bottom: 1.75rem;
+	}
+
 	.history-grid {
 		display: flex;
 		flex-direction: column;

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
 	import { authStore } from '$stores/auth.svelte';
+	import SeoHead from '$components/seo/SeoHead.svelte';
 
 	let mode = $state<'signin' | 'signup'>('signin');
 	let email = $state('');
@@ -19,17 +20,26 @@
 		}
 	});
 
+	// firebase treats "User@Example.com" and "user@example.com" as DIFFERENT accounts;
+	// normalizing on submit prevents accidental duplicate accounts from casing/whitespace
+	function normalizeEmail(raw: string): string {
+		return raw.trim().toLowerCase();
+	}
+
 	async function handleSubmit(e: Event) {
 		e.preventDefault();
 		submitting = true;
 		authStore.clearError();
 
+		const normalizedEmail = normalizeEmail(email);
+		const normalizedDisplayName = displayName.trim().slice(0, 80);
+
 		try {
 			if (mode === 'signin') {
-				await authStore.signInWithEmail(email, password);
+				await authStore.signInWithEmail(normalizedEmail, password);
 				goto('/scanner');
 			} else {
-				await authStore.signUpWithEmail(email, password, displayName);
+				await authStore.signUpWithEmail(normalizedEmail, password, normalizedDisplayName);
 				signupDone = true;
 			}
 		} catch {
@@ -53,9 +63,10 @@
 	}
 
 	async function handlePasswordReset() {
-		if (!resetEmail.trim()) return;
+		const normalized = normalizeEmail(resetEmail);
+		if (!normalized) return;
 		try {
-			await authStore.sendPasswordReset(resetEmail);
+			await authStore.sendPasswordReset(normalized);
 			resetSent = true;
 		} catch {
 			// error is set in authStore
@@ -63,9 +74,10 @@
 	}
 </script>
 
-<svelte:head>
-	<title>Sign In | ATS Screener</title>
-</svelte:head>
+<SeoHead
+	title="Sign In | ATS Screener"
+	description="Sign in to ATS Screener to scan your resume across 6 real ATS platforms and track your score history."
+/>
 
 <div class="login-page">
 	<div class="login-card">
@@ -217,6 +229,8 @@
 							type="text"
 							bind:value={displayName}
 							placeholder="Your name"
+							maxlength="80"
+							autocomplete="name"
 							class="field-input"
 						/>
 					</label>

--- a/src/routes/robots.txt/+server.ts
+++ b/src/routes/robots.txt/+server.ts
@@ -1,0 +1,22 @@
+import type { RequestHandler } from './$types';
+
+// dynamic robots.txt so the sitemap URL tracks whatever domain we deploy to
+export const GET: RequestHandler = ({ url }) => {
+	const body = `User-agent: *
+Allow: /
+Disallow: /api/
+Disallow: /history
+Disallow: /login
+
+Sitemap: ${url.origin}/sitemap.xml
+`;
+
+	return new Response(body, {
+		headers: {
+			'Content-Type': 'text/plain; charset=utf-8',
+			'Cache-Control': 'public, max-age=3600'
+		}
+	});
+};
+
+export const prerender = true;

--- a/src/routes/robots.txt/+server.ts
+++ b/src/routes/robots.txt/+server.ts
@@ -19,4 +19,5 @@ Sitemap: ${url.origin}/sitemap.xml
 	});
 };
 
-export const prerender = true;
+// keep dynamic; prerender would bake the request origin at build time and
+// preview deploys would ship a Sitemap URL pointing at production

--- a/src/routes/scanner/+page.svelte
+++ b/src/routes/scanner/+page.svelte
@@ -5,6 +5,7 @@
 	import ScanningAnimation from '$components/scoring/ScanningAnimation.svelte';
 	import ResumeStats from '$components/scoring/ResumeStats.svelte';
 	import ScanHistory from '$components/scoring/ScanHistory.svelte';
+	import SeoHead from '$components/seo/SeoHead.svelte';
 	import { resumeStore } from '$stores/resume.svelte';
 	import { scoresStore } from '$stores/scores.svelte';
 	import { authStore } from '$stores/auth.svelte';
@@ -130,13 +131,10 @@
 	});
 </script>
 
-<svelte:head>
-	<title>Resume Scanner | ATS Screener</title>
-	<meta
-		name="description"
-		content="Upload your resume and get scored by 6 real ATS platforms. See exactly how Workday, Taleo, iCIMS, Greenhouse, Lever, and SuccessFactors parse your resume."
-	/>
-</svelte:head>
+<SeoHead
+	title="Resume Scanner | ATS Screener"
+	description="Upload your resume and get scored by 6 real ATS platforms. See exactly how Workday, Taleo, iCIMS, Greenhouse, Lever, and SuccessFactors parse your resume."
+/>
 
 <main class="scanner">
 	<!-- subtle background mesh -->

--- a/src/routes/scanner/+page.svelte
+++ b/src/routes/scanner/+page.svelte
@@ -66,11 +66,12 @@
 	}
 
 	// runs scoring: LLM-powered (primary) → rule-based (fallback)
+	// startScoring returns a signal so a rescan/reset aborts the prior in-flight request
 	async function handleScan() {
 		if (!resumeStore.isReady) return;
 
 		hasScanned = true;
-		scoresStore.startScoring();
+		const signal = scoresStore.startScoring();
 
 		try {
 			const resume = resumeStore.resume!;
@@ -78,9 +79,12 @@
 
 			// dynamic import: LLM client only loaded when scoring starts
 			const { scoreLLM } = await import('$engine/llm');
-			const llmResult = await scoreLLM(resume.rawText, jd);
+			const llmResult = await scoreLLM(resume.rawText, jd, { signal });
 
-			if (llmResult && llmResult.results.length > 0) {
+			// user cancelled mid-flight (rescan or reset) - leave state to the new handler
+			if (llmResult.status === 'cancelled' || signal.aborted) return;
+
+			if (llmResult.status === 'ok' && llmResult.results.length > 0) {
 				console.log(
 					'[scan] LLM scoring complete:',
 					llmResult.results.length,
@@ -97,10 +101,12 @@
 			const { scoreResume } = await import('$engine/scorer/engine');
 			const input = buildScoringInput();
 			const results = scoreResume(input);
+			if (signal.aborted) return;
 			console.log('[scan] rule-based scoring complete:', results.length, 'results');
 			scoresStore.finishScoring(results, resumeStore.file?.name);
 			scoresStore.finishAnalyzing(null, true);
 		} catch (err) {
+			if (signal.aborted) return;
 			const msg = err instanceof Error ? err.message : 'scoring failed';
 			scoresStore.setError(msg);
 		}

--- a/src/routes/scanner/+page.svelte
+++ b/src/routes/scanner/+page.svelte
@@ -96,7 +96,7 @@
 				return;
 			}
 
-			// all LLM providers failed, fall back to deterministic rule-based scoring
+			// all LLM providers failed (or rate-limited), fall back to deterministic rule-based scoring
 			console.log('[scan] LLM unavailable, using rule-based scoring');
 			const { scoreResume } = await import('$engine/scorer/engine');
 			const input = buildScoringInput();
@@ -104,7 +104,10 @@
 			if (signal.aborted) return;
 			console.log('[scan] rule-based scoring complete:', results.length, 'results');
 			scoresStore.finishScoring(results, resumeStore.file?.name);
-			scoresStore.finishAnalyzing(null, true);
+			// when rate-limited, surface the retry timestamp so the toast can show a countdown
+			const retryAtMs =
+				llmResult.status === 'rate_limited' ? Date.now() + llmResult.retryAfterSec * 1000 : null;
+			scoresStore.finishAnalyzing(null, true, retryAtMs);
 		} catch (err) {
 			if (signal.aborted) return;
 			const msg = err instanceof Error ? err.message : 'scoring failed';

--- a/src/routes/share/+page.svelte
+++ b/src/routes/share/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { page } from '$app/stores';
+	import { page } from '$app/state';
 	import SeoHead from '$components/seo/SeoHead.svelte';
 	import { getScoreColor, getScoreLabel } from '$engine/scorer/classification';
 
@@ -12,11 +12,13 @@
 		return Number.isFinite(n) ? clamp(n, min, max) : fallback;
 	}
 
-	const score = $derived(parseIntSafe($page.url.searchParams.get('score'), 0, 0, 100));
-	const pass = $derived(parseIntSafe($page.url.searchParams.get('pass'), 0, 0, 6));
-	const total = $derived(parseIntSafe($page.url.searchParams.get('total'), 6, 1, 6));
-	const hasDelta = $derived($page.url.searchParams.has('delta'));
-	const delta = $derived(parseIntSafe($page.url.searchParams.get('delta'), 0, -100, 100));
+	const score = $derived(parseIntSafe(page.url.searchParams.get('score'), 0, 0, 100));
+	// derive total first, then cap pass at total so a tampered URL like
+	// ?pass=6&total=1 cannot render "6 of 1 ATS systems passed"
+	const total = $derived(parseIntSafe(page.url.searchParams.get('total'), 6, 1, 6));
+	const pass = $derived(Math.min(parseIntSafe(page.url.searchParams.get('pass'), 0, 0, 6), total));
+	const hasDelta = $derived(page.url.searchParams.has('delta'));
+	const delta = $derived(parseIntSafe(page.url.searchParams.get('delta'), 0, -100, 100));
 
 	// og:image points at the dynamic edge endpoint with the same query, so when
 	// LinkedIn/Twitter fetches this page they get a per-share PNG preview
@@ -28,7 +30,7 @@
 		if (hasDelta) params.set('delta', String(delta));
 		return params.toString();
 	});
-	const ogImage = $derived(`${$page.url.origin}/api/og?${ogImageQuery}`);
+	const ogImage = $derived(`${page.url.origin}/api/og?${ogImageQuery}`);
 
 	const title = $derived(
 		hasDelta && delta > 0
@@ -67,7 +69,7 @@
 		</div>
 
 		<div class="cta">
-			<a href="/scanner" class="cta-btn">Scan your resume — free</a>
+			<a href="/scanner" class="cta-btn">Scan your resume free</a>
 		</div>
 
 		<p class="footnote">

--- a/src/routes/share/+page.svelte
+++ b/src/routes/share/+page.svelte
@@ -1,0 +1,227 @@
+<script lang="ts">
+	import { page } from '$app/stores';
+	import SeoHead from '$components/seo/SeoHead.svelte';
+	import { getScoreColor, getScoreLabel } from '$engine/scorer/classification';
+
+	function clamp(n: number, min: number, max: number): number {
+		return Math.max(min, Math.min(max, n));
+	}
+
+	function parseIntSafe(v: string | null, fallback: number, min: number, max: number): number {
+		const n = v ? Number.parseInt(v, 10) : NaN;
+		return Number.isFinite(n) ? clamp(n, min, max) : fallback;
+	}
+
+	const score = $derived(parseIntSafe($page.url.searchParams.get('score'), 0, 0, 100));
+	const pass = $derived(parseIntSafe($page.url.searchParams.get('pass'), 0, 0, 6));
+	const total = $derived(parseIntSafe($page.url.searchParams.get('total'), 6, 1, 6));
+	const hasDelta = $derived($page.url.searchParams.has('delta'));
+	const delta = $derived(parseIntSafe($page.url.searchParams.get('delta'), 0, -100, 100));
+
+	// og:image points at the dynamic edge endpoint with the same query, so when
+	// LinkedIn/Twitter fetches this page they get a per-share PNG preview
+	const ogImageQuery = $derived.by(() => {
+		const params = new URLSearchParams();
+		params.set('score', String(score));
+		params.set('pass', String(pass));
+		params.set('total', String(total));
+		if (hasDelta) params.set('delta', String(delta));
+		return params.toString();
+	});
+	const ogImage = $derived(`${$page.url.origin}/api/og?${ogImageQuery}`);
+
+	const title = $derived(
+		hasDelta && delta > 0
+			? `Improved ATS resume score by ${delta} points`
+			: `Scored ${score}/100 across 6 real ATS platforms`
+	);
+	const description = $derived(
+		`Free, open-source resume screener that simulates Workday, Taleo, iCIMS, Greenhouse, Lever, and SuccessFactors. ${pass} of ${total} systems passed.`
+	);
+
+	const color = $derived(getScoreColor(score));
+	const verdict = $derived(getScoreLabel(score));
+</script>
+
+<SeoHead {title} {description} {ogImage} ogType="article" />
+
+<main class="share-page">
+	<div class="share-bg">
+		<div class="bg-orb orb-1"></div>
+		<div class="bg-orb orb-2"></div>
+	</div>
+
+	<div class="share-card">
+		<div class="kicker">ATS Screener</div>
+		<div class="score-row">
+			<span class="score-number" style="color: {color}">{score}</span>
+			{#if hasDelta && delta > 0}
+				<span class="delta-pill positive">+{delta}</span>
+			{:else if hasDelta && delta < 0}
+				<span class="delta-pill negative">{delta}</span>
+			{/if}
+		</div>
+		<div class="verdict" style="color: {color}">{verdict}</div>
+		<div class="passing">
+			<strong>{pass}</strong> of <strong>{total}</strong> ATS systems passed
+		</div>
+
+		<div class="cta">
+			<a href="/scanner" class="cta-btn">Scan your resume — free</a>
+		</div>
+
+		<p class="footnote">
+			ATS Screener simulates Workday, Taleo, iCIMS, Greenhouse, Lever, and SuccessFactors. Open
+			source, no paywalls.
+		</p>
+	</div>
+</main>
+
+<style>
+	.share-page {
+		position: relative;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		min-height: 100dvh;
+		padding: 6rem 1.5rem 4rem;
+		overflow: hidden;
+	}
+
+	.share-bg {
+		position: absolute;
+		inset: 0;
+		overflow: hidden;
+		pointer-events: none;
+	}
+
+	.bg-orb {
+		position: absolute;
+		border-radius: 50%;
+		filter: blur(120px);
+	}
+
+	.orb-1 {
+		width: 480px;
+		height: 480px;
+		background: rgba(6, 182, 212, 0.08);
+		top: -10%;
+		right: -10%;
+	}
+
+	.orb-2 {
+		width: 380px;
+		height: 380px;
+		background: rgba(139, 92, 246, 0.06);
+		bottom: -10%;
+		left: -10%;
+	}
+
+	.share-card {
+		position: relative;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		text-align: center;
+		max-width: 600px;
+		padding: 3.25rem 2.5rem;
+		background: var(--glass-bg);
+		border: 1px solid var(--glass-border);
+		border-radius: var(--radius-xl);
+		backdrop-filter: blur(20px);
+	}
+
+	.kicker {
+		font-family: var(--font-mono);
+		font-size: 0.75rem;
+		font-weight: 600;
+		letter-spacing: 0.18em;
+		color: var(--text-tertiary);
+		margin-bottom: 1.25rem;
+		text-transform: uppercase;
+	}
+
+	.score-row {
+		display: flex;
+		align-items: center;
+		gap: 0.85rem;
+		line-height: 1;
+		margin-bottom: 0.4rem;
+	}
+
+	.score-number {
+		font-size: clamp(5rem, 14vw, 8rem);
+		font-weight: 800;
+		font-variant-numeric: tabular-nums;
+		letter-spacing: -0.04em;
+	}
+
+	.delta-pill {
+		padding: 0.4rem 1rem;
+		font-size: 1.1rem;
+		font-weight: 700;
+		font-variant-numeric: tabular-nums;
+		border-radius: var(--radius-full);
+	}
+
+	.delta-pill.positive {
+		color: #22c55e;
+		background: rgba(34, 197, 94, 0.14);
+	}
+
+	.delta-pill.negative {
+		color: #ef4444;
+		background: rgba(239, 68, 68, 0.14);
+	}
+
+	.verdict {
+		font-size: 1.1rem;
+		font-weight: 700;
+		letter-spacing: 0.06em;
+		text-transform: uppercase;
+		margin-bottom: 1.1rem;
+	}
+
+	.passing {
+		font-size: 1rem;
+		color: var(--text-secondary);
+		margin-bottom: 2.25rem;
+	}
+
+	.passing strong {
+		color: var(--text-primary);
+		font-variant-numeric: tabular-nums;
+	}
+
+	.cta {
+		margin-bottom: 1.85rem;
+	}
+
+	.cta-btn {
+		display: inline-flex;
+		align-items: center;
+		padding: 0.9rem 1.85rem;
+		font-size: 1rem;
+		font-weight: 600;
+		color: var(--color-bg-primary);
+		background: var(--gradient-primary);
+		border-radius: var(--radius-full);
+		text-decoration: none;
+		transition:
+			transform 0.2s ease,
+			box-shadow 0.2s ease;
+	}
+
+	.cta-btn:hover {
+		transform: translateY(-1px);
+		box-shadow: 0 0 24px rgba(6, 182, 212, 0.3);
+	}
+
+	.footnote {
+		font-size: 0.82rem;
+		color: var(--text-tertiary);
+		line-height: 1.6;
+		max-width: 440px;
+		margin: 0;
+	}
+</style>

--- a/src/routes/sitemap.xml/+server.ts
+++ b/src/routes/sitemap.xml/+server.ts
@@ -1,0 +1,34 @@
+import type { RequestHandler } from './$types';
+
+// public, indexable routes only - excludes auth-gated pages and API endpoints
+const ROUTES: { path: string; changefreq: string; priority: number }[] = [
+	{ path: '/', changefreq: 'weekly', priority: 1.0 },
+	{ path: '/scanner', changefreq: 'weekly', priority: 0.9 },
+	{ path: '/about', changefreq: 'monthly', priority: 0.7 }
+];
+
+export const GET: RequestHandler = ({ url }) => {
+	const lastmod = new Date().toISOString().slice(0, 10);
+
+	const urls = ROUTES.map(
+		(r) => `	<url>
+		<loc>${url.origin}${r.path}</loc>
+		<lastmod>${lastmod}</lastmod>
+		<changefreq>${r.changefreq}</changefreq>
+		<priority>${r.priority.toFixed(1)}</priority>
+	</url>`
+	).join('\n');
+
+	const body = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${urls}
+</urlset>
+`;
+
+	return new Response(body, {
+		headers: {
+			'Content-Type': 'application/xml; charset=utf-8',
+			'Cache-Control': 'public, max-age=3600'
+		}
+	});
+};

--- a/tests/unit/api/cache.test.ts
+++ b/tests/unit/api/cache.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { hashPrompt, getCached, setCached } from '../../../src/routes/api/analyze/cache';
+
+// the cache uses module-level state. tests must use unique keys to avoid
+// cross-test pollution since there's no shared reset between tests.
+let counter = 0;
+const uniqueKey = () => `test-key-${++counter}-${Date.now()}`;
+
+describe('hashPrompt', () => {
+	it('returns a 64-char lowercase hex string for SHA-256', async () => {
+		const hash = await hashPrompt('hello');
+		expect(hash).toMatch(/^[0-9a-f]{64}$/);
+	});
+
+	it('is deterministic for the same input', async () => {
+		const a = await hashPrompt('the same prompt');
+		const b = await hashPrompt('the same prompt');
+		expect(a).toBe(b);
+	});
+
+	it('produces different hashes for different inputs', async () => {
+		const a = await hashPrompt('prompt one');
+		const b = await hashPrompt('prompt two');
+		expect(a).not.toBe(b);
+	});
+
+	it('handles empty string', async () => {
+		const hash = await hashPrompt('');
+		expect(hash).toMatch(/^[0-9a-f]{64}$/);
+	});
+
+	it('handles unicode and large inputs', async () => {
+		const hash = await hashPrompt('日本語🚀'.repeat(1000));
+		expect(hash).toMatch(/^[0-9a-f]{64}$/);
+	});
+});
+
+describe('getCached / setCached', () => {
+	it('returns null for an unknown key', () => {
+		expect(getCached(uniqueKey())).toBeNull();
+	});
+
+	it('round-trips a stored entry', () => {
+		const key = uniqueKey();
+		const parsed = { results: [{ score: 80 }] };
+		setCached(key, parsed, 'gemma-3-27b');
+		const entry = getCached(key);
+		expect(entry).not.toBeNull();
+		expect(entry?.parsed).toEqual(parsed);
+		expect(entry?.provider).toBe('gemma-3-27b');
+	});
+
+	it('sets expiresAt 24h in the future', () => {
+		const key = uniqueKey();
+		const before = Date.now();
+		setCached(key, {}, 'p');
+		const entry = getCached(key);
+		const expectedMin = before + 24 * 60 * 60 * 1000 - 1000;
+		const expectedMax = Date.now() + 24 * 60 * 60 * 1000 + 1000;
+		expect(entry?.expiresAt).toBeGreaterThanOrEqual(expectedMin);
+		expect(entry?.expiresAt).toBeLessThanOrEqual(expectedMax);
+	});
+
+	it('overwrites a key on second set', () => {
+		const key = uniqueKey();
+		setCached(key, { v: 1 }, 'a');
+		setCached(key, { v: 2 }, 'b');
+		expect(getCached(key)?.parsed).toEqual({ v: 2 });
+		expect(getCached(key)?.provider).toBe('b');
+	});
+
+	it('treats stored entries as immutable from the consumer side', () => {
+		const key = uniqueKey();
+		const parsed = { value: 'x' };
+		setCached(key, parsed, 'p');
+		// mutating the source object should not change what's stored if the consumer
+		// is well-behaved; we just assert the get returns the stored value
+		const entry = getCached(key);
+		expect(entry?.parsed).toBeDefined();
+	});
+});

--- a/tests/unit/api/rate-limiter.test.ts
+++ b/tests/unit/api/rate-limiter.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import {
+	checkRateLimit,
+	RATE_LIMIT_CONFIG
+} from '../../../src/routes/api/analyze/rate-limiter';
+
+// limiter uses module-level state per-IP. tests use unique IPs so they don't
+// trip on each other across test runs.
+let ipCounter = 0;
+const uniqueIp = () => `10.0.0.${(++ipCounter % 255) + 1}-${Date.now()}`;
+
+describe('checkRateLimit: minute window', () => {
+	it('allows the first request', () => {
+		const result = checkRateLimit(uniqueIp());
+		expect(result.allowed).toBe(true);
+	});
+
+	it(`allows up to MAX_RPM (${RATE_LIMIT_CONFIG.MAX_RPM}) requests`, () => {
+		const ip = uniqueIp();
+		for (let i = 0; i < RATE_LIMIT_CONFIG.MAX_RPM; i++) {
+			expect(checkRateLimit(ip).allowed).toBe(true);
+		}
+	});
+
+	it('rejects the (MAX_RPM+1)-th request with reason "minute"', () => {
+		const ip = uniqueIp();
+		for (let i = 0; i < RATE_LIMIT_CONFIG.MAX_RPM; i++) checkRateLimit(ip);
+		const result = checkRateLimit(ip);
+		expect(result.allowed).toBe(false);
+		if (!result.allowed) {
+			expect(result.reason).toBe('minute');
+			expect(result.retryAfterSec).toBeGreaterThan(0);
+			expect(result.retryAfterSec).toBeLessThanOrEqual(60);
+		}
+	});
+
+	it('does not consume a slot when the limit was already hit', () => {
+		// after the limit is hit, repeated checks should keep returning false
+		// without further state mutation - retryAfterSec should not grow
+		const ip = uniqueIp();
+		for (let i = 0; i < RATE_LIMIT_CONFIG.MAX_RPM; i++) checkRateLimit(ip);
+		const r1 = checkRateLimit(ip);
+		const r2 = checkRateLimit(ip);
+		expect(r1.allowed).toBe(false);
+		expect(r2.allowed).toBe(false);
+	});
+});
+
+describe('checkRateLimit: independence between IPs', () => {
+	it('treats different IPs as independent', () => {
+		const a = uniqueIp();
+		const b = uniqueIp();
+		// exhaust IP a
+		for (let i = 0; i < RATE_LIMIT_CONFIG.MAX_RPM; i++) checkRateLimit(a);
+		expect(checkRateLimit(a).allowed).toBe(false);
+		// IP b should still be fresh
+		expect(checkRateLimit(b).allowed).toBe(true);
+	});
+});
+
+describe('checkRateLimit: result shape', () => {
+	it('returns retryAfterSec as a positive integer when blocked', () => {
+		const ip = uniqueIp();
+		for (let i = 0; i < RATE_LIMIT_CONFIG.MAX_RPM; i++) checkRateLimit(ip);
+		const result = checkRateLimit(ip);
+		if (!result.allowed) {
+			expect(Number.isInteger(result.retryAfterSec)).toBe(true);
+			expect(result.retryAfterSec).toBeGreaterThan(0);
+		}
+	});
+
+	it('discriminated union narrows correctly', () => {
+		const result = checkRateLimit(uniqueIp());
+		if (result.allowed) {
+			// no fields beyond allowed should be on the success branch
+			expect(result.allowed).toBe(true);
+		} else {
+			expect(['minute', 'daily']).toContain(result.reason);
+		}
+	});
+});

--- a/tests/unit/api/rate-limiter.test.ts
+++ b/tests/unit/api/rate-limiter.test.ts
@@ -1,8 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import {
-	checkRateLimit,
-	RATE_LIMIT_CONFIG
-} from '../../../src/routes/api/analyze/rate-limiter';
+import { checkRateLimit, RATE_LIMIT_CONFIG } from '../../../src/routes/api/analyze/rate-limiter';
 
 // limiter uses module-level state per-IP. tests use unique IPs so they don't
 // trip on each other across test runs.

--- a/tests/unit/llm/fallback.test.ts
+++ b/tests/unit/llm/fallback.test.ts
@@ -171,9 +171,7 @@ describe('generateFallbackAnalysis: suggestions', () => {
 
 	it('suggests more detail for very short resumes', () => {
 		const result = generateFallbackAnalysis(makePayload({ resumeText: 'Short resume.' }));
-		const hasShortSuggestion = result.suggestions.some((s) =>
-			s.toLowerCase().includes('short')
-		);
+		const hasShortSuggestion = result.suggestions.some((s) => s.toLowerCase().includes('short'));
 		expect(hasShortSuggestion).toBe(true);
 	});
 
@@ -181,9 +179,7 @@ describe('generateFallbackAnalysis: suggestions', () => {
 		const result = generateFallbackAnalysis(
 			makePayload({ jobDescription: 'senior staff engineer leading the platform team' })
 		);
-		const hasLeadership = result.suggestions.some((s) =>
-			s.toLowerCase().includes('leadership')
-		);
+		const hasLeadership = result.suggestions.some((s) => s.toLowerCase().includes('leadership'));
 		expect(hasLeadership).toBe(true);
 	});
 });

--- a/tests/unit/llm/fallback.test.ts
+++ b/tests/unit/llm/fallback.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect } from 'vitest';
+import { generateFallbackAnalysis } from '$engine/llm/fallback';
+import type { LLMRequestPayload } from '$engine/llm/types';
+
+function makePayload(over: Partial<LLMRequestPayload> = {}): LLMRequestPayload {
+	return {
+		resumeText:
+			'Software engineer with 5 years experience in JavaScript, React, Node.js. Built scalable APIs and led a team of 4 engineers.',
+		jobDescription:
+			'Looking for a senior software engineer with 7+ years experience in JavaScript, React, Node.js, AWS, and Docker.',
+		resumeSkills: ['javascript', 'react', 'node.js'],
+		mode: 'analyze-jd',
+		...over
+	};
+}
+
+describe('generateFallbackAnalysis: shape', () => {
+	it('returns a complete LLMAnalysis shape', () => {
+		const result = generateFallbackAnalysis(makePayload());
+		expect(result.extractedRequirements).toBeDefined();
+		expect(result.extractedRequirements.requiredSkills).toBeInstanceOf(Array);
+		expect(result.extractedRequirements.preferredSkills).toBeInstanceOf(Array);
+		expect(typeof result.extractedRequirements.experienceLevel).toBe('string');
+		expect(typeof result.extractedRequirements.educationRequirement).toBe('string');
+		expect(typeof result.extractedRequirements.industryContext).toBe('string');
+		expect(typeof result.extractedRequirements.roleType).toBe('string');
+		expect(result.semanticMatches).toBeInstanceOf(Array);
+		expect(result.suggestions).toBeInstanceOf(Array);
+		expect(typeof result.overallAssessment).toBe('string');
+	});
+
+	it('always references LLM unavailable in the assessment text', () => {
+		const result = generateFallbackAnalysis(makePayload());
+		expect(result.overallAssessment.toLowerCase()).toContain('llm unavailable');
+	});
+
+	it('caps requiredSkills at 10 and preferredSkills at 5', () => {
+		const longJD = Array.from({ length: 30 }, (_, i) => `customterm${i}`).join(' ');
+		const result = generateFallbackAnalysis(makePayload({ jobDescription: longJD }));
+		expect(result.extractedRequirements.requiredSkills.length).toBeLessThanOrEqual(10);
+		expect(result.extractedRequirements.preferredSkills.length).toBeLessThanOrEqual(5);
+	});
+});
+
+describe('generateFallbackAnalysis: experience level detection', () => {
+	it('detects senior from "senior" keyword', () => {
+		const result = generateFallbackAnalysis(
+			makePayload({ jobDescription: 'senior engineer with 7+ years experience' })
+		);
+		expect(result.extractedRequirements.experienceLevel).toBe('senior');
+	});
+
+	it('detects entry-level from intern/new grad keywords', () => {
+		const result = generateFallbackAnalysis(
+			makePayload({ jobDescription: 'looking for an intern or new grad' })
+		);
+		expect(result.extractedRequirements.experienceLevel).toBe('entry');
+	});
+
+	it('detects executive level from VP/director keywords', () => {
+		const result = generateFallbackAnalysis(
+			makePayload({ jobDescription: 'VP of engineering, head of platform' })
+		);
+		expect(result.extractedRequirements.experienceLevel).toBe('executive');
+	});
+
+	it('detects lead level from "principal" keyword', () => {
+		const result = generateFallbackAnalysis(
+			makePayload({ jobDescription: 'principal engineer driving architecture' })
+		);
+		expect(result.extractedRequirements.experienceLevel).toBe('lead');
+	});
+
+	it('falls back to mid level when no signal', () => {
+		const result = generateFallbackAnalysis(
+			makePayload({ jobDescription: 'we want a teammate who writes clean code' })
+		);
+		expect(result.extractedRequirements.experienceLevel).toBe('mid');
+	});
+});
+
+describe('generateFallbackAnalysis: education detection', () => {
+	it('detects PhD requirement', () => {
+		const result = generateFallbackAnalysis(
+			makePayload({ jobDescription: 'PhD in computer science required' })
+		);
+		expect(result.extractedRequirements.educationRequirement).toBe('PhD');
+	});
+
+	it("detects Master's requirement", () => {
+		const result = generateFallbackAnalysis(
+			makePayload({ jobDescription: "Master's degree or MBA preferred" })
+		);
+		expect(result.extractedRequirements.educationRequirement).toBe("Master's degree");
+	});
+
+	it("detects Bachelor's requirement", () => {
+		const result = generateFallbackAnalysis(
+			makePayload({ jobDescription: 'Bachelor of Science in CS or equivalent' })
+		);
+		expect(result.extractedRequirements.educationRequirement).toBe("Bachelor's degree");
+	});
+
+	it('returns "not specified" when JD has no education signal', () => {
+		const result = generateFallbackAnalysis(
+			makePayload({ jobDescription: 'experienced engineer needed' })
+		);
+		expect(result.extractedRequirements.educationRequirement).toBe('not specified');
+	});
+});
+
+describe('generateFallbackAnalysis: role type detection', () => {
+	it('identifies engineering roles', () => {
+		const result = generateFallbackAnalysis(
+			makePayload({ jobDescription: 'frontend developer building React apps' })
+		);
+		expect(result.extractedRequirements.roleType).toBe('engineering');
+	});
+
+	it('identifies healthcare roles', () => {
+		const result = generateFallbackAnalysis(
+			makePayload({ jobDescription: 'registered nurse with clinical experience' })
+		);
+		expect(result.extractedRequirements.roleType).toBe('healthcare');
+	});
+
+	it('identifies sales roles', () => {
+		const result = generateFallbackAnalysis(
+			makePayload({ jobDescription: 'account executive driving new business' })
+		);
+		expect(result.extractedRequirements.roleType).toBe('sales');
+	});
+
+	it('identifies design roles', () => {
+		const result = generateFallbackAnalysis(
+			makePayload({ jobDescription: 'UX designer leading product visuals' })
+		);
+		expect(result.extractedRequirements.roleType).toBe('design');
+	});
+
+	it('returns "other" for ambiguous JDs', () => {
+		const result = generateFallbackAnalysis(
+			makePayload({ jobDescription: 'we want a self-starter who gets things done' })
+		);
+		expect(result.extractedRequirements.roleType).toBe('other');
+	});
+});
+
+describe('generateFallbackAnalysis: suggestions', () => {
+	it('suggests missing JD terms when not in resume', () => {
+		const result = generateFallbackAnalysis(
+			makePayload({
+				resumeText: 'Software engineer with JavaScript experience',
+				jobDescription: 'Need experience in JavaScript, Kubernetes, Terraform, Vault'
+			})
+		);
+		const text = result.suggestions.join(' ').toLowerCase();
+		// at least one of the missing terms should be referenced
+		const hasMissing =
+			text.includes('kubernetes') || text.includes('terraform') || text.includes('vault');
+		expect(hasMissing).toBe(true);
+	});
+
+	it('suggests adding a skills section when resumeSkills is empty', () => {
+		const result = generateFallbackAnalysis(makePayload({ resumeSkills: [] }));
+		const hasSkillsSuggestion = result.suggestions.some((s) =>
+			s.toLowerCase().includes('skills section')
+		);
+		expect(hasSkillsSuggestion).toBe(true);
+	});
+
+	it('suggests more detail for very short resumes', () => {
+		const result = generateFallbackAnalysis(makePayload({ resumeText: 'Short resume.' }));
+		const hasShortSuggestion = result.suggestions.some((s) =>
+			s.toLowerCase().includes('short')
+		);
+		expect(hasShortSuggestion).toBe(true);
+	});
+
+	it('suggests leadership emphasis for senior/lead roles', () => {
+		const result = generateFallbackAnalysis(
+			makePayload({ jobDescription: 'senior staff engineer leading the platform team' })
+		);
+		const hasLeadership = result.suggestions.some((s) =>
+			s.toLowerCase().includes('leadership')
+		);
+		expect(hasLeadership).toBe(true);
+	});
+});

--- a/tests/unit/scorer/classification.test.ts
+++ b/tests/unit/scorer/classification.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import { classifyScore, getScoreLabel, getScoreColor } from '$engine/scorer/classification';
+
+describe('classifyScore tiers', () => {
+	it('returns excellent for 80+', () => {
+		expect(classifyScore(80).tier).toBe('excellent');
+		expect(classifyScore(95).tier).toBe('excellent');
+		expect(classifyScore(100).tier).toBe('excellent');
+	});
+
+	it('returns good for 60-79', () => {
+		expect(classifyScore(60).tier).toBe('good');
+		expect(classifyScore(70).tier).toBe('good');
+		expect(classifyScore(79).tier).toBe('good');
+	});
+
+	it('returns fair for 40-59', () => {
+		expect(classifyScore(40).tier).toBe('fair');
+		expect(classifyScore(50).tier).toBe('fair');
+		expect(classifyScore(59).tier).toBe('fair');
+	});
+
+	it('returns poor for below 40', () => {
+		expect(classifyScore(0).tier).toBe('poor');
+		expect(classifyScore(20).tier).toBe('poor');
+		expect(classifyScore(39).tier).toBe('poor');
+	});
+
+	it('handles boundary scores precisely (>=, not >)', () => {
+		expect(classifyScore(80).tier).toBe('excellent');
+		expect(classifyScore(79.9).tier).toBe('good');
+		expect(classifyScore(60).tier).toBe('good');
+		expect(classifyScore(59.9).tier).toBe('fair');
+		expect(classifyScore(40).tier).toBe('fair');
+		expect(classifyScore(39.9).tier).toBe('poor');
+	});
+
+	it('classifies negative scores as poor', () => {
+		expect(classifyScore(-1).tier).toBe('poor');
+		expect(classifyScore(-100).tier).toBe('poor');
+	});
+
+	it('returns labels matching tiers', () => {
+		expect(classifyScore(85).label).toBe('Excellent');
+		expect(classifyScore(70).label).toBe('Good');
+		expect(classifyScore(50).label).toBe('Needs Work');
+		expect(classifyScore(20).label).toBe('Poor');
+	});
+
+	it('returns hex colors matching tiers', () => {
+		expect(classifyScore(85).color).toBe('#22c55e');
+		expect(classifyScore(70).color).toBe('#eab308');
+		expect(classifyScore(50).color).toBe('#f97316');
+		expect(classifyScore(20).color).toBe('#ef4444');
+	});
+
+	it('always returns a hex color regardless of input', () => {
+		for (const s of [-50, 0, 39, 40, 59, 60, 79, 80, 100, 999]) {
+			expect(classifyScore(s).color).toMatch(/^#[0-9a-f]{6}$/);
+		}
+	});
+});
+
+describe('getScoreLabel', () => {
+	it('matches classifyScore.label across the range', () => {
+		for (const score of [-1, 0, 39, 40, 59, 60, 79, 80, 100]) {
+			expect(getScoreLabel(score)).toBe(classifyScore(score).label);
+		}
+	});
+});
+
+describe('getScoreColor', () => {
+	it('matches classifyScore.color across the range', () => {
+		for (const score of [-1, 0, 39, 40, 59, 60, 79, 80, 100]) {
+			expect(getScoreColor(score)).toBe(classifyScore(score).color);
+		}
+	});
+});

--- a/tests/unit/scorer/comparison.test.ts
+++ b/tests/unit/scorer/comparison.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { computeScanComparison } from '$engine/scorer/comparison';
+import type { ScoreResult } from '$engine/scorer/types';
+
+function r(system: string, score: number, passes: boolean): ScoreResult {
+	return {
+		system,
+		vendor: 'TestVendor',
+		overallScore: score,
+		passesFilter: passes,
+		breakdown: {
+			formatting: { score, issues: [], details: [] },
+			keywordMatch: { score, matched: [], missing: [], synonymMatched: [] },
+			sections: { score, present: [], missing: [] },
+			experience: {
+				score,
+				quantifiedBullets: 0,
+				totalBullets: 0,
+				actionVerbCount: 0,
+				highlights: []
+			},
+			education: { score, notes: [] }
+		},
+		suggestions: []
+	};
+}
+
+describe('computeScanComparison', () => {
+	it('returns null when either side is empty', () => {
+		expect(computeScanComparison([], [r('Workday', 80, true)])).toBeNull();
+		expect(computeScanComparison([r('Workday', 80, true)], [])).toBeNull();
+		expect(computeScanComparison([], [])).toBeNull();
+	});
+
+	it('computes deltas across matching platforms', () => {
+		const previous = [r('Workday', 70, true), r('Lever', 60, false)];
+		const current = [r('Workday', 80, true), r('Lever', 75, true)];
+		const cmp = computeScanComparison(current, previous);
+		expect(cmp).not.toBeNull();
+		expect(cmp?.previousAverage).toBe(65);
+		expect(cmp?.currentAverage).toBe(78);
+		expect(cmp?.deltaAverage).toBe(13);
+		expect(cmp?.previousPassing).toBe(1);
+		expect(cmp?.currentPassing).toBe(2);
+		expect(cmp?.deltaPassing).toBe(1);
+		expect(cmp?.improved).toBe(2);
+		expect(cmp?.regressed).toBe(0);
+		expect(cmp?.unchanged).toBe(0);
+	});
+
+	it('counts regressions and unchanged separately', () => {
+		const previous = [r('Workday', 80, true), r('Lever', 70, true), r('iCIMS', 60, false)];
+		const current = [r('Workday', 70, true), r('Lever', 70, true), r('iCIMS', 75, true)];
+		const cmp = computeScanComparison(current, previous);
+		expect(cmp?.improved).toBe(1);
+		expect(cmp?.regressed).toBe(1);
+		expect(cmp?.unchanged).toBe(1);
+	});
+
+	it('handles negative deltas without sign confusion', () => {
+		const previous = [r('Workday', 90, true)];
+		const current = [r('Workday', 70, true)];
+		const cmp = computeScanComparison(current, previous);
+		expect(cmp?.deltaAverage).toBe(-20);
+		expect(cmp?.platforms[0].delta).toBe(-20);
+		expect(cmp?.regressed).toBe(1);
+	});
+
+	it('skips platforms that do not exist in the previous scan', () => {
+		const previous = [r('Workday', 70, true)];
+		const current = [r('Workday', 80, true), r('NewPlatform', 60, false)];
+		const cmp = computeScanComparison(current, previous);
+		expect(cmp?.platforms).toHaveLength(1);
+		expect(cmp?.platforms[0].system).toBe('Workday');
+	});
+
+	it('produces stable platform order matching the current scan', () => {
+		const previous = [r('Lever', 50, false), r('Workday', 80, true)];
+		const current = [r('Workday', 85, true), r('Lever', 55, false)];
+		const cmp = computeScanComparison(current, previous);
+		expect(cmp?.platforms.map((p) => p.system)).toEqual(['Workday', 'Lever']);
+	});
+});

--- a/tests/unit/scorer/journey.test.ts
+++ b/tests/unit/scorer/journey.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { computeJourneyStats } from '$engine/scorer/journey';
+import type { ScoreResult } from '$engine/scorer/types';
+
+function r(system: string, score: number): ScoreResult {
+	return {
+		system,
+		vendor: 'V',
+		overallScore: score,
+		passesFilter: score >= 60,
+		breakdown: {
+			formatting: { score, issues: [], details: [] },
+			keywordMatch: { score, matched: [], missing: [], synonymMatched: [] },
+			sections: { score, present: [], missing: [] },
+			experience: {
+				score,
+				quantifiedBullets: 0,
+				totalBullets: 0,
+				actionVerbCount: 0,
+				highlights: []
+			},
+			education: { score, notes: [] }
+		},
+		suggestions: []
+	};
+}
+
+describe('computeJourneyStats', () => {
+	it('returns null on empty input', () => {
+		expect(computeJourneyStats([])).toBeNull();
+	});
+
+	it('handles a single scan (no delta possible)', () => {
+		const stats = computeJourneyStats([
+			{ id: '1', timestamp: '2025-01-01', averageScore: 70, results: [r('Workday', 70)] }
+		]);
+		expect(stats?.totalScans).toBe(1);
+		expect(stats?.firstScore).toBe(70);
+		expect(stats?.latestScore).toBe(70);
+		expect(stats?.totalDelta).toBe(0);
+		expect(stats?.bestPlatformDelta).toBeNull();
+	});
+
+	it('computes total delta and best-platform delta across two scans', () => {
+		const stats = computeJourneyStats([
+			{
+				id: '1',
+				timestamp: '2025-01-01',
+				averageScore: 60,
+				results: [r('Workday', 60), r('Lever', 50)]
+			},
+			{
+				id: '2',
+				timestamp: '2025-02-01',
+				averageScore: 80,
+				results: [r('Workday', 75), r('Lever', 85)]
+			}
+		]);
+		expect(stats?.totalDelta).toBe(20);
+		expect(stats?.firstScore).toBe(60);
+		expect(stats?.latestScore).toBe(80);
+		expect(stats?.bestScore).toBe(80);
+		expect(stats?.bestPlatformDelta).toEqual({ system: 'Lever', delta: 35 });
+		expect(stats?.daysSpan).toBe(31);
+	});
+
+	it('sorts ascending so input order does not matter', () => {
+		const stats = computeJourneyStats([
+			{ id: '2', timestamp: '2025-02-01', averageScore: 80, results: [r('Workday', 80)] },
+			{ id: '1', timestamp: '2025-01-01', averageScore: 60, results: [r('Workday', 60)] }
+		]);
+		expect(stats?.firstScore).toBe(60);
+		expect(stats?.latestScore).toBe(80);
+	});
+});

--- a/tests/unit/scorer/timeline.test.ts
+++ b/tests/unit/scorer/timeline.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { computeTimeline } from '$engine/scorer/timeline';
+
+function entry(id: string, timestamp: string, score: number, mode: 'general' | 'targeted' = 'general') {
+	return { id, timestamp, averageScore: score, mode };
+}
+
+describe('computeTimeline', () => {
+	it('returns null for fewer than two entries', () => {
+		expect(computeTimeline([])).toBeNull();
+		expect(computeTimeline([entry('a', '2025-01-01', 50)])).toBeNull();
+	});
+
+	it('sorts ascending so leftmost x is the oldest scan', () => {
+		const chart = computeTimeline([
+			entry('newer', '2025-03-01T00:00:00Z', 80),
+			entry('older', '2025-01-01T00:00:00Z', 60)
+		]);
+		expect(chart).not.toBeNull();
+		expect(chart?.points[0].id).toBe('older');
+		expect(chart?.points[1].id).toBe('newer');
+		expect(chart!.points[0].x).toBeLessThan(chart!.points[1].x);
+	});
+
+	it('inverts y so higher scores render visually higher', () => {
+		const chart = computeTimeline([
+			entry('a', '2025-01-01', 30),
+			entry('b', '2025-02-01', 90)
+		]);
+		// higher score = lower y in SVG coordinates
+		expect(chart!.points[1].y).toBeLessThan(chart!.points[0].y);
+	});
+
+	it('produces a path D string starting with M and using L for the rest', () => {
+		const chart = computeTimeline([
+			entry('a', '2025-01-01', 50),
+			entry('b', '2025-02-01', 60),
+			entry('c', '2025-03-01', 70)
+		]);
+		expect(chart!.pathD.startsWith('M ')).toBe(true);
+		expect(chart!.pathD.split('L').length - 1).toBe(2);
+	});
+
+	it('areaD closes the shape back to the baseline', () => {
+		const chart = computeTimeline([
+			entry('a', '2025-01-01', 50),
+			entry('b', '2025-02-01', 60)
+		]);
+		expect(chart!.areaD.endsWith(' Z')).toBe(true);
+	});
+
+	it('keeps points inside the inner padding box', () => {
+		const chart = computeTimeline([
+			entry('a', '2025-01-01', 0),
+			entry('b', '2025-02-01', 100)
+		]);
+		for (const p of chart!.points) {
+			expect(p.x).toBeGreaterThanOrEqual(chart!.innerLeft);
+			expect(p.x).toBeLessThanOrEqual(chart!.innerRight);
+			expect(p.y).toBeGreaterThanOrEqual(chart!.innerTop);
+			expect(p.y).toBeLessThanOrEqual(chart!.innerBottom);
+		}
+	});
+
+	it('respects custom viewBox dimensions', () => {
+		const chart = computeTimeline(
+			[entry('a', '2025-01-01', 50), entry('b', '2025-02-01', 60)],
+			{ width: 1200, height: 400 }
+		);
+		expect(chart!.width).toBe(1200);
+		expect(chart!.height).toBe(400);
+		expect(chart!.points[1].x).toBeLessThanOrEqual(1200);
+	});
+});

--- a/tests/unit/scorer/timeline.test.ts
+++ b/tests/unit/scorer/timeline.test.ts
@@ -58,6 +58,19 @@ describe('computeTimeline', () => {
 		}
 	});
 
+	it('clamps out-of-range averageScore so points stay inside the padding box', () => {
+		const chart = computeTimeline([entry('a', '2025-01-01', -50), entry('b', '2025-02-01', 150)]);
+		expect(chart).not.toBeNull();
+		// y must stay in [innerTop, innerBottom] regardless of input score
+		for (const p of chart!.points) {
+			expect(p.y).toBeGreaterThanOrEqual(chart!.innerTop);
+			expect(p.y).toBeLessThanOrEqual(chart!.innerBottom);
+		}
+		// the unclamped score is preserved on the point for tooltip display
+		expect(chart!.points[0].score).toBe(-50);
+		expect(chart!.points[1].score).toBe(150);
+	});
+
 	it('respects custom viewBox dimensions', () => {
 		const chart = computeTimeline([entry('a', '2025-01-01', 50), entry('b', '2025-02-01', 60)], {
 			width: 1200,

--- a/tests/unit/scorer/timeline.test.ts
+++ b/tests/unit/scorer/timeline.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect } from 'vitest';
 import { computeTimeline } from '$engine/scorer/timeline';
 
-function entry(id: string, timestamp: string, score: number, mode: 'general' | 'targeted' = 'general') {
+function entry(
+	id: string,
+	timestamp: string,
+	score: number,
+	mode: 'general' | 'targeted' = 'general'
+) {
 	return { id, timestamp, averageScore: score, mode };
 }
 
@@ -23,10 +28,7 @@ describe('computeTimeline', () => {
 	});
 
 	it('inverts y so higher scores render visually higher', () => {
-		const chart = computeTimeline([
-			entry('a', '2025-01-01', 30),
-			entry('b', '2025-02-01', 90)
-		]);
+		const chart = computeTimeline([entry('a', '2025-01-01', 30), entry('b', '2025-02-01', 90)]);
 		// higher score = lower y in SVG coordinates
 		expect(chart!.points[1].y).toBeLessThan(chart!.points[0].y);
 	});
@@ -42,18 +44,12 @@ describe('computeTimeline', () => {
 	});
 
 	it('areaD closes the shape back to the baseline', () => {
-		const chart = computeTimeline([
-			entry('a', '2025-01-01', 50),
-			entry('b', '2025-02-01', 60)
-		]);
+		const chart = computeTimeline([entry('a', '2025-01-01', 50), entry('b', '2025-02-01', 60)]);
 		expect(chart!.areaD.endsWith(' Z')).toBe(true);
 	});
 
 	it('keeps points inside the inner padding box', () => {
-		const chart = computeTimeline([
-			entry('a', '2025-01-01', 0),
-			entry('b', '2025-02-01', 100)
-		]);
+		const chart = computeTimeline([entry('a', '2025-01-01', 0), entry('b', '2025-02-01', 100)]);
 		for (const p of chart!.points) {
 			expect(p.x).toBeGreaterThanOrEqual(chart!.innerLeft);
 			expect(p.x).toBeLessThanOrEqual(chart!.innerRight);
@@ -63,10 +59,10 @@ describe('computeTimeline', () => {
 	});
 
 	it('respects custom viewBox dimensions', () => {
-		const chart = computeTimeline(
-			[entry('a', '2025-01-01', 50), entry('b', '2025-02-01', 60)],
-			{ width: 1200, height: 400 }
-		);
+		const chart = computeTimeline([entry('a', '2025-01-01', 50), entry('b', '2025-02-01', 60)], {
+			width: 1200,
+			height: 400
+		});
 		expect(chart!.width).toBe(1200);
 		expect(chart!.height).toBe(400);
 		expect(chart!.points[1].x).toBeLessThanOrEqual(1200);

--- a/tests/unit/suggestions/templates.test.ts
+++ b/tests/unit/suggestions/templates.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import { classifySuggestion, getExampleFor } from '../../../src/lib/engine/suggestions/templates';
+
+describe('classifySuggestion', () => {
+	it('detects quantification cues', () => {
+		expect(classifySuggestion('Add quantified impact to your bullets')).toBe('quantification');
+		expect(classifySuggestion('Include metrics and concrete outcomes')).toBe('quantification');
+		expect(classifySuggestion('Measure your impact with numbers')).toBe('quantification');
+	});
+
+	it('detects action-verb cues', () => {
+		expect(classifySuggestion('Use stronger action verbs')).toBe('action-verbs');
+		expect(classifySuggestion('Avoid passive voice')).toBe('action-verbs');
+	});
+
+	it('detects skills-section cues', () => {
+		expect(classifySuggestion('add a dedicated skills section')).toBe('skills-section');
+		expect(classifySuggestion('list your skills near the top')).toBe('skills-section');
+	});
+
+	it('detects missing-keyword cues', () => {
+		expect(classifySuggestion('consider adding these terms from the job description')).toBe(
+			'missing-keywords'
+		);
+		expect(classifySuggestion('Missing keyword: Docker')).toBe('missing-keywords');
+	});
+
+	it('detects short-resume cues', () => {
+		expect(classifySuggestion('your resume appears short')).toBe('short-resume');
+		expect(classifySuggestion('Add more detail about your experience')).toBe('short-resume');
+	});
+
+	it('detects sections cues', () => {
+		expect(classifySuggestion('use standard section headers')).toBe('sections');
+		expect(classifySuggestion('section header is non-standard')).toBe('sections');
+	});
+
+	it('detects format cues', () => {
+		expect(classifySuggestion('avoid multi-column layouts')).toBe('format');
+		expect(classifySuggestion('Resume contains tables which ATS systems often misread')).toBe(
+			'format'
+		);
+		expect(classifySuggestion('keep within page limit')).toBe('format');
+	});
+
+	it('returns null for ambiguous text', () => {
+		expect(classifySuggestion('Make your resume better')).toBeNull();
+		expect(classifySuggestion('')).toBeNull();
+	});
+});
+
+describe('getExampleFor', () => {
+	it('returns a fully-populated example for classified text', () => {
+		const example = getExampleFor('Add quantified impact');
+		expect(example).not.toBeNull();
+		expect(example?.type).toBe('quantification');
+		expect(example?.tip.length).toBeGreaterThan(0);
+		expect(example?.before.length).toBeGreaterThan(0);
+		expect(example?.after.length).toBeGreaterThan(0);
+	});
+
+	it('returns null for unclassifiable text', () => {
+		expect(getExampleFor('whatever')).toBeNull();
+	});
+
+	it('every type maps to a fully-populated example', () => {
+		const types = [
+			'quantification',
+			'action-verbs',
+			'skills-section',
+			'missing-keywords',
+			'short-resume',
+			'sections',
+			'format'
+		];
+		const probes = [
+			'add quantified impact',
+			'use stronger action verbs',
+			'add a skills section',
+			'missing keywords',
+			'resume is short',
+			'use standard section headers',
+			'avoid multi-column layouts'
+		];
+		for (let i = 0; i < types.length; i++) {
+			const ex = getExampleFor(probes[i]);
+			expect(ex?.type).toBe(types[i]);
+			expect(ex?.tip.length).toBeGreaterThan(10);
+			expect(ex?.before.length).toBeGreaterThan(0);
+			expect(ex?.after.length).toBeGreaterThan(0);
+		}
+	});
+});


### PR DESCRIPTION
chips at the share/og pipeline, dashboard polish, and a bunch of cost/perf wins. one render bug surfaced during local testing and is folded in. copilot review feedback is addressed in `99fc5d0`.

## share + virality

- dynamic `/api/og` PNG endpoint (via `@vercel/og`), content-addressed by `score/pass/total/delta` and CDN-cached at `s-maxage=86400`, so repeat shares of the same link cost zero function compute
- new `/share` landing page reads the same query params and emits `og:image` pointing at `/api/og`, so when LinkedIn / X / iMessage scrape a share URL the preview card renders the actual score
- ShareBadge gets "Copy share link" + "Share to X" alongside the existing LinkedIn flow; LinkedIn share-text now appends the `/share` URL so its crawler can fetch the rich preview

## comparison + history

- comparison band on the dashboard ("you went from 67 to 78 (+11)") with up/down/flat states and a Twitter share-intent on positive deltas
- per-card delta pill anchored to each ScoreCard's score ring
- per-row delta in the scan-history dropdown
- new `/history` view shows a journey stats card (total improvement, best score, strongest-gain platform, days span) and an SVG line chart of scores over time with hover tooltips
- snapshot-at-`startScoring` fixes a race where a rapid re-scan compared against the wrong "previous" entry while the firestore save was still in flight

## scanner UX

- live JD skill-extraction preview: as you type a JD the parser runs on a 400ms debounce and shows detected role/industry/level + extracted skill chips. matched skills get a green check vs the loaded resume
- before/after example templates on expanded suggestion cards (7 categories) with one-click copy on each block
- cancellable in-flight scoring (re-scan or reset aborts the prior fetch instead of leaking a stale response into state)
- live retry-after countdown in the LLM-fallback toast when `/api/analyze` returns 429

## cost / perf

- in-memory result cache on `/api/analyze`, SHA-256 keyed by full prompt; same-input requests skip the LLM entirely (verified live: 46s to 81ms, ~570x)
- response shape adds `_cached` flag (additive, non-breaking)
- rate-limit response now sends `Retry-After` header + `retryAfter` body field, distinguishes minute vs daily reason, no longer double-charges minute slots on daily failures
- firebase SDK lazy-loaded out of the root layout chunk (~488kb no longer ships to landing-page visitors who never sign in)
- `@vercel/og` response re-wrapped to actually set `Cache-Control` (the constructor's headers option concatenates rather than replaces, verified locally with curl)

## security + production-grade

- dynamic `robots.txt` + `sitemap.xml` routes (origin-tracking, no prerender)
- baseline security headers via hooks: HSTS, Referrer-Policy, Permissions-Policy, nosniff, X-Frame-Options DENY
- `Content-Security-Policy-Report-Only` header + `/api/csp-report` endpoint logging violations to vercel logs (no firestore writes, $0)
- per-route `SeoHead` component with og/twitter/canonical, plus JSON-LD `SoftwareApplication` on the landing page; `app.html` no longer ships a static `robots` tag (single source of truth)
- branded `+error.svelte` for 404/429/5xx
- `/healthz` json liveness probe
- login: email normalization (trim + lowercase) prevents the duplicate-account bug from casing/whitespace; displayName maxlength
- `/docs/[...slug]` catchall validates resolved paths stay under `static/docs` (resolve + startsWith + realpath) so traversal attempts return 404

## bug fixes

- ScoreBreakdown rendered "[object Object]" for structured suggestions because it never type-narrowed before interpolation. fixed with helpers (same pattern report.ts already used). also hardened the equivalent fallback branch in ScoreDashboard with a typeof guard
- rate-limiter cleanup throttled to once per 30s so it doesn't run O(n) on every request once the IP map exceeds threshold (real perf cliff at scale)
- moved docs serving out of `hooks.server.ts` into a `/docs/[...slug]` catchall so node-only `fs/path` imports don't pollute the shared bundle (was a real production-blocking build error otherwise)
- `/api/og` moved off the deprecated `runtime: 'edge'` config to default node runtime
- JD-preview's debounced parser now wraps the IIFE in try/catch so a transient parse failure doesn't surface as an unhandled rejection
- `firebase.ts` migrated to `$env/dynamic/public` so vercel preview builds no longer fail when `PUBLIC_FIREBASE_*` is scoped to Production only

## copilot review (`99fc5d0`)

- `pass` clamped to `<= total` in `/api/og` and `/share` so a tampered URL like `?pass=6&total=1` cannot render impossible state
- timeline y-coordinate clamped to `[0, 100]` so anomalous scores still render inside the chart padding box
- suggestion-card outer changed from `<button>` to `<div role="button">` so the inner copy `<button>`s are valid HTML; restored real `<button>` on the copy controls; widened `copyExample` event param from `MouseEvent` to `Event` (no more unsafe casts)
- migrated `$app/stores` to `$app/state` across SeoHead, Navbar, +error, /share

## quality gate

- 184 tests passing (started branch at 106, +78 across classification, fallback, cache, rate-limiter, comparison, timeline, journey, suggestion templates)
- typecheck + lint + format clean
- production build clean (`pnpm build:app`)
- end-to-end smoke tested via curl: `/healthz`, `/robots.txt`, `/sitemap.xml`, `/api/og` (PNG bytes + cache headers), `/share` (og:image), rate limiter (11th request 429 with retry-after: 60), full LLM cache-hit round-trip (46s to 81ms), pass/total clamp on tampered URLs, single robots tag in head, /docs traversal blocked

## docs

- `api/endpoints.md`: documents the `_cached` field + lists new auxiliary endpoints
- `api/rate-limits.md`: documents the new 429 body shape with `retryAfter` field + `Retry-After` header
- CHANGELOG bumped to 0.2.0 with the full feature/fix breakdown
- SECURITY documents the new defenses (security headers, CSP report-only, Retry-After, pass/total clamp, path-traversal guard, email normalization)
- `pnpm build:docs` run, `static/docs` refreshed
- package.json bumped 0.1.0 -> 0.2.0
