### PR TITLE
feat: ollama support for self-hosters (closes #7)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,14 @@ GEMINI_API_KEY=
 # Get yours at https://console.groq.com/keys
 # GROQ_API_KEY=
 
+# Ollama (optional, self-hosters only)
+# when OLLAMA_BASE_URL is set, the local Ollama daemon prepends to the provider
+# chain so a fork running purely on local models needs no cloud keys.
+# OLLAMA_MODEL is any tag from `ollama list` and defaults to llama3.2.
+# leave both unset to keep the cloud-only chain (Gemma, Groq) used in prod.
+# OLLAMA_BASE_URL=http://127.0.0.1:11434
+# OLLAMA_MODEL=llama3.2
+
 # Firebase configuration (required)
 # Get these from Firebase Console → Project Settings → Your Apps
 PUBLIC_FIREBASE_API_KEY=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Ollama support for self-hosters** (#7). New `OLLAMA_BASE_URL` (and optional `OLLAMA_MODEL`, defaulting to `llama3.2`) env vars opt the local-Ollama daemon into the provider chain. When set, Ollama is tried first so a fork running purely on local models needs zero cloud keys; the request handler now treats Ollama as a configured provider so the `503 no LLM providers configured` path no longer fires for offline-only deployments. Hosted instances are unchanged: leave the new vars unset and the chain stays `[Gemma, Groq]` with identical request shape and 90s/30s timeouts.
+- **Provider chain extracted** to `src/routes/api/analyze/providers.ts` so chain composition is unit-testable in isolation. 18 new tests cover composition for cloud-only, Ollama-only, and all-three env, plus the Ollama request shape (`POST {base}/api/chat`, `format: "json"`, trailing-slash forgiveness, response extraction, 4-minute cold-start timeout).
+
+### Fixed
+
+- **`extractText` defensiveness** across all three providers (Google, Groq, Ollama). The runtime cast `data as { ... }` is compile-time only; a malformed response that decodes to `null` would throw `TypeError: Cannot read properties of null` before the optional-chaining could save it. Added `if (!data || typeof data !== 'object') return ''` guards on all three so a misbehaving upstream falls through to the next provider cleanly.
+
+### Changed
+
+- `LLMProvider.apiKeyName` renamed to `configKey` (Ollama uses a base URL, not an API key). Pure rename, no behavior change.
+- `PROVIDER_TIMEOUTS_MS` parallel array removed; `timeoutMs` now lives on each `LLMProvider` so dynamic chain composition can carry per-provider deadlines without index juggling.
+
 ## [0.3.0] - 2026-04-26
 
 A wide pass across security, performance, accessibility, observability, and UX. The scoring engine and ATS profiles are unchanged. The differences a returning user will notice: a dotted paste-and-scan field next to the uploader, a JD library that saves job descriptions locally, a service worker that keeps the shell available offline, a themed 404 with a thinking bitmoji, and a faster, denser dashboard on phones. Everything else is behind-the-scenes hardening that makes the app cheaper to run, safer to use, and easier to crawl.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,21 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.3.1] - 2026-05-04
 
 ### Added
 
-- **Ollama support for self-hosters** (#7). New `OLLAMA_BASE_URL` (and optional `OLLAMA_MODEL`, defaulting to `llama3.2`) env vars opt the local-Ollama daemon into the provider chain. When set, Ollama is tried first so a fork running purely on local models needs zero cloud keys; the request handler now treats Ollama as a configured provider so the `503 no LLM providers configured` path no longer fires for offline-only deployments. Hosted instances are unchanged: leave the new vars unset and the chain stays `[Gemma, Groq]` with identical request shape and 90s/30s timeouts.
-- **Provider chain extracted** to `src/routes/api/analyze/providers.ts` so chain composition is unit-testable in isolation. 18 new tests cover composition for cloud-only, Ollama-only, and all-three env, plus the Ollama request shape (`POST {base}/api/chat`, `format: "json"`, trailing-slash forgiveness, response extraction, 4-minute cold-start timeout).
+- **ollama support for self-hosters** (#7). new `OLLAMA_BASE_URL` (and optional `OLLAMA_MODEL`, defaulting to `llama3.2`) env vars opt the local ollama daemon into the provider chain. when set, ollama is tried first; a fork running purely on local models needs no cloud keys. hosted instances stay unchanged: leave the new vars unset and the chain remains `[gemma, groq]` with identical request shape and 90s/30s timeouts. self-hosting docs at `/docs/self-hosting/configuration` walk through the install + .env setup.
+- **provider chain extracted** to `src/routes/api/analyze/providers.ts` so composition is unit-testable in isolation. 18 new tests cover the cloud-only / ollama-only / all-three permutations, request shape (`POST {base}/api/chat`, `format: "json"`, trailing-slash forgiveness), response extraction, and per-provider timeouts.
 
 ### Fixed
 
-- **`extractText` defensiveness** across all three providers (Google, Groq, Ollama). The runtime cast `data as { ... }` is compile-time only; a malformed response that decodes to `null` would throw `TypeError: Cannot read properties of null` before the optional-chaining could save it. Added `if (!data || typeof data !== 'object') return ''` guards on all three so a misbehaving upstream falls through to the next provider cleanly.
+- **`extractText` null-safety** across all three providers (google, groq, ollama). a malformed upstream response that decoded to `null` would throw `TypeError: Cannot read properties of null` before optional chaining could save it. all three now guard with `if (!data || typeof data !== 'object') return ''` so a misbehaving provider falls through to the next cleanly.
 
 ### Changed
 
-- `LLMProvider.apiKeyName` renamed to `configKey` (Ollama uses a base URL, not an API key). Pure rename, no behavior change.
-- `PROVIDER_TIMEOUTS_MS` parallel array removed; `timeoutMs` now lives on each `LLMProvider` so dynamic chain composition can carry per-provider deadlines without index juggling.
+- `LLMProvider.apiKeyName` renamed to `configKey` (ollama uses a base URL, not an API key). pure rename, no behavior change.
+- `PROVIDER_TIMEOUTS_MS` parallel array removed; `timeoutMs` now lives on each `LLMProvider` so dynamic chain composition can carry per-provider deadlines without index juggling. values preserved: 90s gemma, 30s groq, 240s ollama.
 
 ## [0.3.0] - 2026-04-26
 

--- a/docs/src/content/docs/self-hosting/configuration.md
+++ b/docs/src/content/docs/self-hosting/configuration.md
@@ -5,12 +5,14 @@ description: Environment variables and configuration options for self-hosted ins
 
 ## Environment Variables
 
-All configuration is done through environment variables in the `.env` file.
+All configuration is done through environment variables in the `.env` file. At least one provider must be configured (Gemini, Groq, or Ollama); the route returns `503` otherwise.
 
-| Variable         | Required    | Description                                    |
-| ---------------- | ----------- | ---------------------------------------------- |
-| `GEMINI_API_KEY` | Yes         | Google AI API key (powers Gemma 3 27B primary) |
-| `GROQ_API_KEY`   | Recommended | Groq API key (Llama 3.3 70B fallback)          |
+| Variable          | Required     | Description                                                               |
+| ----------------- | ------------ | ------------------------------------------------------------------------- |
+| `GEMINI_API_KEY`  | One of these | Google AI API key (Gemma 3 27B)                                           |
+| `GROQ_API_KEY`    | One of these | Groq API key (Llama 3.3 70B)                                              |
+| `OLLAMA_BASE_URL` | One of these | Base URL of a local Ollama daemon (e.g. `http://127.0.0.1:11434`)         |
+| `OLLAMA_MODEL`    | Optional     | Ollama model tag, defaults to `llama3.2`. Use any tag from `ollama list`. |
 
 :::caution
 Never commit your `.env` file to version control. It's already in `.gitignore`, but double-check before pushing.
@@ -18,12 +20,32 @@ Never commit your `.env` file to version control. It's already in `.gitignore`, 
 
 ## Provider Priority
 
-The LLM fallback chain uses cross-provider redundancy so quota limits on one provider don't cascade:
+The LLM chain composes from whatever's configured in env. Ordering is fixed:
 
-1. **Gemma 3 27B** via Google (primary, `GEMINI_API_KEY`)
-2. **Llama 3.3 70B** via Groq (fallback, `GROQ_API_KEY`)
+1. **Ollama** (`OLLAMA_BASE_URL`) — local first when configured
+2. **Gemma 3 27B** via Google (`GEMINI_API_KEY`)
+3. **Llama 3.3 70B** via Groq (`GROQ_API_KEY`)
 
-If a provider fails (timeout, rate limit, malformed response), the system automatically tries the next one. Because each provider uses a separate API key, their quotas are completely independent.
+If a provider fails (timeout, rate limit, malformed response), the system automatically tries the next one. Because each provider uses a separate credential, their quotas are completely independent. Self-hosters who want a fully offline scanner should set only `OLLAMA_BASE_URL` and leave the cloud keys unset.
+
+## Running Locally with Ollama
+
+For privacy-first deployments where every byte of the resume stays on your machine:
+
+```bash
+# install ollama from https://ollama.com and pull a model
+ollama pull llama3.2
+
+# in your .env (or as shell vars before pnpm dev):
+OLLAMA_BASE_URL=http://127.0.0.1:11434
+OLLAMA_MODEL=llama3.2
+
+# leave GEMINI_API_KEY / GROQ_API_KEY unset for offline-only mode
+```
+
+The Ollama path uses Ollama's `format: 'json'` so the model returns strict JSON without prompt-engineering tricks. First scan is slow on commodity hardware (60-120s for `llama3.2:3b` on a typical laptop); subsequent scans of the same resume hit the in-memory result cache and return in <100ms. Bigger models produce noticeably better suggestions but take longer.
+
+The `/api/analyze` response includes `_provider: "ollama-{model}"` so you can confirm requests are landing locally and not falling back to a cloud key you forgot to remove.
 
 ## Free Tier Limits
 

--- a/docs/src/content/docs/self-hosting/configuration.md
+++ b/docs/src/content/docs/self-hosting/configuration.md
@@ -22,7 +22,7 @@ Never commit your `.env` file to version control. It's already in `.gitignore`, 
 
 The LLM chain composes from whatever's configured in env. Ordering is fixed:
 
-1. **Ollama** (`OLLAMA_BASE_URL`) — local first when configured
+1. **Ollama** (`OLLAMA_BASE_URL`), local first when configured
 2. **Gemma 3 27B** via Google (`GEMINI_API_KEY`)
 3. **Llama 3.3 70B** via Groq (`GROQ_API_KEY`)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ats-screener",
-	"version": "0.3.0",
+	"version": "0.3.1",
 	"private": true,
 	"license": "MIT",
 	"type": "module",

--- a/src/routes/api/analyze/+server.ts
+++ b/src/routes/api/analyze/+server.ts
@@ -5,107 +5,23 @@ import { buildFullScoringPrompt, buildJDAnalysisPrompt } from '$engine/llm/promp
 import { logger } from '$lib/log';
 import { hashPrompt, getCached, setCached } from './cache';
 import { checkRateLimit } from './rate-limiter';
-
-// provider configuration: Gemma 3 27B (Google) → Llama 3.3 70B (Groq)
-// cross-provider fallback ensures independent quotas so one provider's limits don't cascade
-interface LLMProvider {
-	name: string;
-	apiKeyName: string;
-	buildRequest: (prompt: string, apiKey: string) => { url: string; init: RequestInit };
-	extractText: (response: unknown) => string;
-}
-
-// shared extractor for all Google Generative Language API models
-const googleExtractText = (data: unknown) => {
-	const d = data as { candidates?: { content?: { parts?: { text?: string }[] } }[] };
-	return d.candidates?.[0]?.content?.parts?.[0]?.text ?? '';
-};
-
-function buildGoogleProvider(
-	name: string,
-	model: string,
-	opts?: { jsonMode?: boolean }
-): LLMProvider {
-	return {
-		name,
-		apiKeyName: 'GEMINI_API_KEY',
-		buildRequest: (prompt, apiKey) => ({
-			url: `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${apiKey}`,
-			init: {
-				method: 'POST',
-				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({
-					contents: [{ parts: [{ text: prompt }] }],
-					generationConfig: {
-						temperature: 0.3,
-						topP: 0.85,
-						maxOutputTokens: 16384,
-						...(opts?.jsonMode && { responseMimeType: 'application/json' })
-					}
-				})
-			}
-		}),
-		extractText: googleExtractText
-	};
-}
-
-function buildGroqProvider(name: string, model: string): LLMProvider {
-	return {
-		name,
-		apiKeyName: 'GROQ_API_KEY',
-		buildRequest: (prompt, apiKey) => ({
-			url: 'https://api.groq.com/openai/v1/chat/completions',
-			init: {
-				method: 'POST',
-				headers: {
-					'Content-Type': 'application/json',
-					Authorization: `Bearer ${apiKey}`
-				},
-				body: JSON.stringify({
-					model,
-					messages: [{ role: 'user', content: prompt }],
-					temperature: 0.3,
-					top_p: 0.85,
-					max_tokens: 16384,
-					response_format: { type: 'json_object' }
-				})
-			}
-		}),
-		extractText: (data: unknown) => {
-			const d = data as { choices?: { message?: { content?: string } }[] };
-			return d.choices?.[0]?.message?.content ?? '';
-		}
-	};
-}
-
-const PROVIDERS: LLMProvider[] = [
-	// primary: Gemma 3 27B via Google - 14,400 RPD, 30 RPM, 15K TPM
-	buildGoogleProvider('gemma-3-27b', 'gemma-3-27b-it'),
-	// fallback: Llama 3.3 70B via Groq - 100-600ms, native JSON mode, 1K RPD, 100K TPD
-	buildGroqProvider('groq-llama-3.3-70b', 'llama-3.3-70b-versatile')
-];
-
-// per-provider timeouts: Gemma (90s) + Groq (30s) = 120s worst case
-// Gemma typically responds in 30-45s but can spike under load; Groq is <1s but gets headroom
-// Fluid Compute on Vercel Hobby gives 300s max, so 120s worst case fits comfortably
-const PROVIDER_TIMEOUTS_MS = [90_000, 30_000];
+import { buildProviders } from './providers';
 
 // tries each provider in sequence until one succeeds and returns valid JSON
 async function callLLM(
 	prompt: string,
 	env: Record<string, string>
 ): Promise<{ parsed: Record<string, unknown>; provider: string } | null> {
-	for (let i = 0; i < PROVIDERS.length; i++) {
-		const provider = PROVIDERS[i];
-		const timeoutMs = PROVIDER_TIMEOUTS_MS[i] ?? 10_000;
-		const apiKey = env[provider.apiKeyName] ?? '';
-		if (!apiKey) continue;
+	const providers = buildProviders(env);
+	for (const provider of providers) {
+		const secret = env[provider.configKey] ?? '';
+		if (!secret) continue;
 
 		try {
-			const { url, init } = provider.buildRequest(prompt, apiKey);
+			const { url, init } = provider.buildRequest(prompt, secret);
 
 			const controller = new AbortController();
-			const timeout = setTimeout(() => controller.abort(), timeoutMs);
+			const timeout = setTimeout(() => controller.abort(), provider.timeoutMs);
 
 			const response = await fetch(url, { ...init, signal: controller.signal });
 			clearTimeout(timeout);
@@ -140,7 +56,9 @@ async function callLLM(
 			const isTimeout = err instanceof DOMException && err.name === 'AbortError';
 			logger.warn(isTimeout ? 'llm.provider_timeout' : 'llm.provider_failed', {
 				provider: provider.name,
-				...(isTimeout ? { timeoutMs } : { error: err instanceof Error ? err.message : String(err) })
+				...(isTimeout
+					? { timeoutMs: provider.timeoutMs }
+					: { error: err instanceof Error ? err.message : String(err) })
 			});
 			continue;
 		}
@@ -194,14 +112,24 @@ interface RequestBody {
 }
 
 export const POST: RequestHandler = async ({ request }) => {
-	// collect all API keys from SvelteKit $env
+	// collect provider config from SvelteKit $env. OLLAMA_BASE_URL is the
+	// presence signal for the local-Ollama path; OLLAMA_MODEL is read inside
+	// buildProviders() and defaults to llama3.2 when unset.
 	const keys: Record<string, string> = {
 		GEMINI_API_KEY: env.GEMINI_API_KEY ?? '',
-		GROQ_API_KEY: env.GROQ_API_KEY ?? ''
+		GROQ_API_KEY: env.GROQ_API_KEY ?? '',
+		OLLAMA_BASE_URL: env.OLLAMA_BASE_URL ?? '',
+		OLLAMA_MODEL: env.OLLAMA_MODEL ?? ''
 	};
 
-	const hasAnyKey = Object.values(keys).some((v) => v.length > 0);
-	if (!hasAnyKey) {
+	// at least one provider must be configured. cloud-hosted instances set
+	// GEMINI/GROQ; self-hosted forks can opt into Ollama-only by setting
+	// OLLAMA_BASE_URL with no cloud keys.
+	const hasAnyProvider =
+		keys.GEMINI_API_KEY.length > 0 ||
+		keys.GROQ_API_KEY.length > 0 ||
+		keys.OLLAMA_BASE_URL.length > 0;
+	if (!hasAnyProvider) {
 		return json({ error: 'no LLM providers configured', fallback: true }, { status: 503 });
 	}
 

--- a/src/routes/api/analyze/providers.ts
+++ b/src/routes/api/analyze/providers.ts
@@ -1,0 +1,154 @@
+// LLM provider abstraction for /api/analyze.
+//
+// cloud chain is Gemma 3 27B (Google) -> Llama 3.3 70B (Groq); cross-provider
+// fallback gives independent quotas so one provider's limits don't cascade.
+// self-hosters can prepend Ollama by setting OLLAMA_BASE_URL (and optionally
+// OLLAMA_MODEL); the request handler treats Ollama as a configured provider
+// so a fork running purely on local models doesn't need any cloud API key.
+//
+// timeoutMs lives on the provider itself (not a parallel array) so a dynamic
+// chain composed from env can carry per-provider deadlines without
+// index-juggling. extracted into its own module so the chain composition can
+// be unit-tested without mounting the whole route handler.
+
+export interface LLMProvider {
+	name: string;
+	// env var that must be non-empty for this provider to be considered "configured"
+	configKey: string;
+	timeoutMs: number;
+	buildRequest: (prompt: string, secret: string) => { url: string; init: RequestInit };
+	extractText: (response: unknown) => string;
+}
+
+// shared extractor for all Google Generative Language API models. defensive
+// against null / non-object payloads because optional chaining only saves us
+// AFTER a non-null object base; a malformed response that decodes to null
+// still throws on `.candidates` without this guard.
+const googleExtractText = (data: unknown) => {
+	if (!data || typeof data !== 'object') return '';
+	const d = data as { candidates?: { content?: { parts?: { text?: string }[] } }[] };
+	return d.candidates?.[0]?.content?.parts?.[0]?.text ?? '';
+};
+
+export function buildGoogleProvider(
+	name: string,
+	model: string,
+	opts?: { jsonMode?: boolean }
+): LLMProvider {
+	return {
+		name,
+		configKey: 'GEMINI_API_KEY',
+		// Gemma typically responds in 30-45s but can spike under load
+		timeoutMs: 90_000,
+		buildRequest: (prompt, apiKey) => ({
+			url: `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${apiKey}`,
+			init: {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					contents: [{ parts: [{ text: prompt }] }],
+					generationConfig: {
+						temperature: 0.3,
+						topP: 0.85,
+						maxOutputTokens: 16384,
+						...(opts?.jsonMode && { responseMimeType: 'application/json' })
+					}
+				})
+			}
+		}),
+		extractText: googleExtractText
+	};
+}
+
+export function buildGroqProvider(name: string, model: string): LLMProvider {
+	return {
+		name,
+		configKey: 'GROQ_API_KEY',
+		// Groq is <1s typical but gets headroom for cold path
+		timeoutMs: 30_000,
+		buildRequest: (prompt, apiKey) => ({
+			url: 'https://api.groq.com/openai/v1/chat/completions',
+			init: {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					Authorization: `Bearer ${apiKey}`
+				},
+				body: JSON.stringify({
+					model,
+					messages: [{ role: 'user', content: prompt }],
+					temperature: 0.3,
+					top_p: 0.85,
+					max_tokens: 16384,
+					response_format: { type: 'json_object' }
+				})
+			}
+		}),
+		extractText: (data: unknown) => {
+			if (!data || typeof data !== 'object') return '';
+			const d = data as { choices?: { message?: { content?: string } }[] };
+			return d.choices?.[0]?.message?.content ?? '';
+		}
+	};
+}
+
+// Ollama provider for self-hosters. local daemon, no API key. format: 'json'
+// asks the model to return strict JSON without ad-hoc prompt engineering. the
+// secret param carries the base URL so all providers share the same factory
+// signature; trailing slashes are stripped to make OLLAMA_BASE_URL= forgiving.
+export function buildOllamaProvider(name: string, model: string): LLMProvider {
+	return {
+		name,
+		configKey: 'OLLAMA_BASE_URL',
+		// local models on commodity hardware can be slow on cold start. allow up
+		// to 4 minutes for the first request; subsequent calls hit the model
+		// cache and are much faster.
+		timeoutMs: 240_000,
+		buildRequest: (prompt, baseUrl) => ({
+			url: `${baseUrl.replace(/\/+$/, '')}/api/chat`,
+			init: {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					model,
+					messages: [{ role: 'user', content: prompt }],
+					stream: false,
+					format: 'json',
+					options: {
+						temperature: 0.3,
+						top_p: 0.85,
+						// 16k context window matches the cloud providers' max_tokens.
+						// Ollama silently truncates if the model doesn't support it.
+						num_ctx: 16384
+					}
+				})
+			}
+		}),
+		extractText: (data: unknown) => {
+			if (!data || typeof data !== 'object') return '';
+			const d = data as { message?: { content?: string } };
+			return d.message?.content ?? '';
+		}
+	};
+}
+
+// composes the provider chain from whatever's configured in env. ordering is
+// intentional: when Ollama is configured we put it first so a self-hoster who
+// also has cloud keys still defaults to local. callers without any of the
+// three configured will see an empty array and the route returns 503.
+export function buildProviders(env: Record<string, string>): LLMProvider[] {
+	const providers: LLMProvider[] = [];
+	if (env.OLLAMA_BASE_URL) {
+		const model = env.OLLAMA_MODEL || 'llama3.2';
+		providers.push(buildOllamaProvider(`ollama-${model}`, model));
+	}
+	if (env.GEMINI_API_KEY) {
+		// primary cloud: Gemma 3 27B via Google - 14,400 RPD, 30 RPM, 15K TPM
+		providers.push(buildGoogleProvider('gemma-3-27b', 'gemma-3-27b-it'));
+	}
+	if (env.GROQ_API_KEY) {
+		// fallback cloud: Llama 3.3 70B via Groq - 100-600ms, native JSON mode, 1K RPD
+		providers.push(buildGroqProvider('groq-llama-3.3-70b', 'llama-3.3-70b-versatile'));
+	}
+	return providers;
+}

--- a/tests/unit/api/providers.test.ts
+++ b/tests/unit/api/providers.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest';
+import {
+	buildProviders,
+	buildOllamaProvider,
+	buildGoogleProvider,
+	buildGroqProvider
+} from '../../../src/routes/api/analyze/providers';
+
+describe('buildProviders: chain composition', () => {
+	it('returns an empty array when no env vars are set', () => {
+		expect(buildProviders({})).toEqual([]);
+	});
+
+	it('hosted-only env (Gemini + Groq) composes [gemma, groq] in that order', () => {
+		const chain = buildProviders({
+			GEMINI_API_KEY: 'fake-gemini',
+			GROQ_API_KEY: 'fake-groq'
+		});
+		expect(chain.map((p) => p.name)).toEqual(['gemma-3-27b', 'groq-llama-3.3-70b']);
+	});
+
+	it('self-hosted-only env (Ollama) composes [ollama] with default model llama3.2', () => {
+		const chain = buildProviders({
+			OLLAMA_BASE_URL: 'http://127.0.0.1:11434'
+		});
+		expect(chain).toHaveLength(1);
+		expect(chain[0].name).toBe('ollama-llama3.2');
+		expect(chain[0].configKey).toBe('OLLAMA_BASE_URL');
+	});
+
+	it('honors OLLAMA_MODEL when set', () => {
+		const chain = buildProviders({
+			OLLAMA_BASE_URL: 'http://127.0.0.1:11434',
+			OLLAMA_MODEL: 'gemma3:1b'
+		});
+		expect(chain[0].name).toBe('ollama-gemma3:1b');
+	});
+
+	it('all-three env composes [ollama, gemma, groq] - Ollama prepends', () => {
+		const chain = buildProviders({
+			OLLAMA_BASE_URL: 'http://127.0.0.1:11434',
+			OLLAMA_MODEL: 'llama3.2',
+			GEMINI_API_KEY: 'fake-gemini',
+			GROQ_API_KEY: 'fake-groq'
+		});
+		expect(chain.map((p) => p.name)).toEqual([
+			'ollama-llama3.2',
+			'gemma-3-27b',
+			'groq-llama-3.3-70b'
+		]);
+	});
+
+	it('empty-string env values are treated as "not configured"', () => {
+		expect(
+			buildProviders({
+				OLLAMA_BASE_URL: '',
+				GEMINI_API_KEY: '',
+				GROQ_API_KEY: ''
+			})
+		).toEqual([]);
+	});
+});
+
+describe('buildOllamaProvider: request shape', () => {
+	const provider = buildOllamaProvider('test', 'llama3.2');
+
+	it('builds a POST to {baseUrl}/api/chat', () => {
+		const { url, init } = provider.buildRequest('hello', 'http://127.0.0.1:11434');
+		expect(url).toBe('http://127.0.0.1:11434/api/chat');
+		expect(init.method).toBe('POST');
+	});
+
+	it('strips trailing slashes from baseUrl so OLLAMA_BASE_URL= is forgiving', () => {
+		const { url } = provider.buildRequest('hello', 'http://127.0.0.1:11434//');
+		expect(url).toBe('http://127.0.0.1:11434/api/chat');
+	});
+
+	it('sends format:"json" so the model returns strict JSON', () => {
+		const { init } = provider.buildRequest('hello', 'http://127.0.0.1:11434');
+		const body = JSON.parse(init.body as string);
+		expect(body.format).toBe('json');
+		expect(body.stream).toBe(false);
+	});
+
+	it('passes the model + a single user message in the chat schema', () => {
+		const { init } = provider.buildRequest('the prompt', 'http://127.0.0.1:11434');
+		const body = JSON.parse(init.body as string);
+		expect(body.model).toBe('llama3.2');
+		expect(body.messages).toEqual([{ role: 'user', content: 'the prompt' }]);
+	});
+
+	it('matches cloud providers on temperature + top_p', () => {
+		const { init } = provider.buildRequest('hello', 'http://127.0.0.1:11434');
+		const body = JSON.parse(init.body as string);
+		expect(body.options.temperature).toBe(0.3);
+		expect(body.options.top_p).toBe(0.85);
+	});
+
+	it('extractText reads message.content from the chat response', () => {
+		expect(provider.extractText({ message: { content: '{"ok":true}' } })).toBe('{"ok":true}');
+	});
+
+	it('extractText returns empty string on malformed payload', () => {
+		expect(provider.extractText({})).toBe('');
+		expect(provider.extractText(null)).toBe('');
+	});
+
+	it('uses a 4-minute timeout to absorb local cold-start latency', () => {
+		expect(provider.timeoutMs).toBe(240_000);
+	});
+});
+
+describe('cloud provider invariants (regression net)', () => {
+	it('google provider keeps its 90s timeout', () => {
+		expect(buildGoogleProvider('x', 'm').timeoutMs).toBe(90_000);
+	});
+
+	it('groq provider keeps its 30s timeout', () => {
+		expect(buildGroqProvider('x', 'm').timeoutMs).toBe(30_000);
+	});
+
+	it('google provider configKey is GEMINI_API_KEY', () => {
+		expect(buildGoogleProvider('x', 'm').configKey).toBe('GEMINI_API_KEY');
+	});
+
+	it('groq provider configKey is GROQ_API_KEY', () => {
+		expect(buildGroqProvider('x', 'm').configKey).toBe('GROQ_API_KEY');
+	});
+});


### PR DESCRIPTION
closes #7.

opt-in local LLM via two env vars. `OLLAMA_BASE_URL=http://127.0.0.1:11434` enables the path; `OLLAMA_MODEL` defaults to `llama3.2` and accepts any tag from `ollama list`. when set, ollama prepends to the provider chain so a fork running purely on local models needs no cloud keys. hosted instances stay unchanged: leave both unset and the chain remains `[gemma, groq]` with identical request shape and 90s/30s timeouts.

provider chain extracted to `src/routes/api/analyze/providers.ts` so composition is unit-testable. 18 new tests cover the cloud-only / ollama-only / all-three permutations, request shape (POST `{base}/api/chat`, `format: "json"`, trailing-slash forgiveness), response extraction, and timeouts. the `extractText` cast was compile-time only; added `if (!data || typeof data !== 'object') return ''` guards on all three providers so a malformed upstream falls through to the next cleanly instead of throwing on null.

dry-tested end-to-end against my local ollama (`llama3.2:latest` on `127.0.0.1:11434`): first scan 90.9s with `_provider: ollama-llama3.2`, second identical scan 89ms cache-hit. cloud chain code path is byte-identical to main; lock-in test asserts `[gemma, groq]` ordering and that gemma/groq timeouts didn't drift from 90/30s.

self-hosting docs at `/docs/self-hosting/configuration` walk through install + .env setup. `.env.example` gets the new vars commented out by default. CHANGELOG bumped to 0.3.1, package.json version bumped (so `/healthz` and `/api/version` report the new build).
