### PR TITLE
release: v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.2] - 2026-05-29
+
+### Added
+
+- **`OLLAMA_API_KEY` env var** (#7 follow-up). optional bearer token sent as `Authorization: Bearer {key}` on every Ollama request, so self-hosters running the daemon behind a reverse-proxy or a hosted Ollama-compatible endpoint (OpenWebUI, LiteLLM, OpenRouter's Ollama-compatible routes, Cloudflare-tunnel + service token) can authenticate. vanilla local `ollama serve` setups leave the var unset and the request shape stays identical: no header, no behaviour change. empty or whitespace-only values are treated as not set so a stray `OLLAMA_API_KEY=` line in `.env` does not produce a malformed `Authorization: Bearer ` header that the proxy would reject. self-hosting docs at `/docs/self-hosting/configuration` cover when you'd need it. 11 new unit tests cover the with-key / without-key / empty-key / whitespace-key paths plus env passthrough.
+
 ## [0.3.1] - 2026-05-04
 
 ### Added

--- a/docs/src/content/docs/self-hosting/configuration.md
+++ b/docs/src/content/docs/self-hosting/configuration.md
@@ -7,12 +7,13 @@ description: Environment variables and configuration options for self-hosted ins
 
 All configuration is done through environment variables in the `.env` file. At least one provider must be configured (Gemini, Groq, or Ollama); the route returns `503` otherwise.
 
-| Variable          | Required     | Description                                                               |
-| ----------------- | ------------ | ------------------------------------------------------------------------- |
-| `GEMINI_API_KEY`  | One of these | Google AI API key (Gemma 3 27B)                                           |
-| `GROQ_API_KEY`    | One of these | Groq API key (Llama 3.3 70B)                                              |
-| `OLLAMA_BASE_URL` | One of these | Base URL of a local Ollama daemon (e.g. `http://127.0.0.1:11434`)         |
-| `OLLAMA_MODEL`    | Optional     | Ollama model tag, defaults to `llama3.2`. Use any tag from `ollama list`. |
+| Variable          | Required     | Description                                                                                                            |
+| ----------------- | ------------ | ---------------------------------------------------------------------------------------------------------------------- |
+| `GEMINI_API_KEY`  | One of these | Google AI API key (Gemma 3 27B)                                                                                        |
+| `GROQ_API_KEY`    | One of these | Groq API key (Llama 3.3 70B)                                                                                           |
+| `OLLAMA_BASE_URL` | One of these | Base URL of a local Ollama daemon (e.g. `http://127.0.0.1:11434`)                                                      |
+| `OLLAMA_MODEL`    | Optional     | Ollama model tag, defaults to `llama3.2`. Use any tag from `ollama list`.                                              |
+| `OLLAMA_API_KEY`  | Optional     | Bearer token sent as `Authorization: Bearer {key}` on every Ollama request. Only needed if your Ollama is behind auth. |
 
 :::caution
 Never commit your `.env` file to version control. It's already in `.gitignore`, but double-check before pushing.
@@ -46,6 +47,19 @@ OLLAMA_MODEL=llama3.2
 The Ollama path uses Ollama's `format: 'json'` so the model returns strict JSON without prompt-engineering tricks. First scan is slow on commodity hardware (60-120s for `llama3.2:3b` on a typical laptop); subsequent scans of the same resume hit the in-memory result cache and return in <100ms. Bigger models produce noticeably better suggestions but take longer.
 
 The `/api/analyze` response includes `_provider: "ollama-{model}"` so you can confirm requests are landing locally and not falling back to a cloud key you forgot to remove.
+
+### Behind a reverse proxy or auth gate
+
+Vanilla `ollama serve` on `127.0.0.1` has no authentication, which is fine for a local-only setup. If your Ollama lives behind a reverse proxy that requires a bearer token, or you're pointing at a hosted Ollama-compatible endpoint (OpenWebUI, LiteLLM, OpenRouter's Ollama-compatible routes, a Cloudflare-tunneled daemon with a service token, etc.), set `OLLAMA_API_KEY` and the request will include `Authorization: Bearer {key}` on every call:
+
+```bash
+# in your .env
+OLLAMA_BASE_URL=https://ollama.your-domain.tld
+OLLAMA_MODEL=llama3.2
+OLLAMA_API_KEY=sk-your-proxy-token
+```
+
+The header is only attached when the env var is non-empty, so leaving it unset keeps the request shape identical to the local-only setup. Empty or whitespace-only values are treated as not set so a stray `OLLAMA_API_KEY=` line in `.env` does not produce a malformed `Authorization: Bearer ` header that the proxy would reject.
 
 ## Free Tier Limits
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ats-screener",
-	"version": "0.3.1",
+	"version": "0.3.2",
 	"private": true,
 	"license": "MIT",
 	"type": "module",

--- a/src/routes/api/analyze/+server.ts
+++ b/src/routes/api/analyze/+server.ts
@@ -114,12 +114,15 @@ interface RequestBody {
 export const POST: RequestHandler = async ({ request }) => {
 	// collect provider config from SvelteKit $env. OLLAMA_BASE_URL is the
 	// presence signal for the local-Ollama path; OLLAMA_MODEL is read inside
-	// buildProviders() and defaults to llama3.2 when unset.
+	// buildProviders() and defaults to llama3.2 when unset; OLLAMA_API_KEY is
+	// optional and, when set, attaches Authorization: Bearer {key} for forks
+	// running Ollama behind a reverse-proxy or hosted Ollama-compatible API.
 	const keys: Record<string, string> = {
 		GEMINI_API_KEY: env.GEMINI_API_KEY ?? '',
 		GROQ_API_KEY: env.GROQ_API_KEY ?? '',
 		OLLAMA_BASE_URL: env.OLLAMA_BASE_URL ?? '',
-		OLLAMA_MODEL: env.OLLAMA_MODEL ?? ''
+		OLLAMA_MODEL: env.OLLAMA_MODEL ?? '',
+		OLLAMA_API_KEY: env.OLLAMA_API_KEY ?? ''
 	};
 
 	// at least one provider must be configured. cloud-hosted instances set

--- a/src/routes/api/analyze/providers.ts
+++ b/src/routes/api/analyze/providers.ts
@@ -3,8 +3,9 @@
 // cloud chain is Gemma 3 27B (Google) -> Llama 3.3 70B (Groq); cross-provider
 // fallback gives independent quotas so one provider's limits don't cascade.
 // self-hosters can prepend Ollama by setting OLLAMA_BASE_URL (and optionally
-// OLLAMA_MODEL); the request handler treats Ollama as a configured provider
-// so a fork running purely on local models doesn't need any cloud API key.
+// OLLAMA_MODEL, plus OLLAMA_API_KEY for proxied / auth-gated daemons); the
+// request handler treats Ollama as a configured provider so a fork running
+// purely on local models doesn't need any cloud API key.
 //
 // timeoutMs lives on the provider itself (not a parallel array) so a dynamic
 // chain composed from env can carry per-provider deadlines without
@@ -92,11 +93,23 @@ export function buildGroqProvider(name: string, model: string): LLMProvider {
 	};
 }
 
-// Ollama provider for self-hosters. local daemon, no API key. format: 'json'
-// asks the model to return strict JSON without ad-hoc prompt engineering. the
-// secret param carries the base URL so all providers share the same factory
+// Ollama provider for self-hosters. local daemon by default needs no key;
+// reverse-proxied or hosted Ollama-compatible endpoints (OpenWebUI, LiteLLM,
+// Caddy + bearer auth, Cloudflare-tunnel + service token, etc.) take an
+// optional bearer token via opts.apiKey, which is attached as
+// `Authorization: Bearer {key}` on every request. format: 'json' asks the
+// model to return strict JSON without ad-hoc prompt engineering. the secret
+// param carries the base URL so all providers share the same factory
 // signature; trailing slashes are stripped to make OLLAMA_BASE_URL= forgiving.
-export function buildOllamaProvider(name: string, model: string): LLMProvider {
+export function buildOllamaProvider(
+	name: string,
+	model: string,
+	opts?: { apiKey?: string }
+): LLMProvider {
+	// trim and treat empty / whitespace-only as not set so a stray
+	// OLLAMA_API_KEY= line in .env does not produce a bogus
+	// `Authorization: Bearer ` header that the proxy would reject as malformed.
+	const apiKey = opts?.apiKey?.trim() ?? '';
 	return {
 		name,
 		configKey: 'OLLAMA_BASE_URL',
@@ -108,7 +121,10 @@ export function buildOllamaProvider(name: string, model: string): LLMProvider {
 			url: `${baseUrl.replace(/\/+$/, '')}/api/chat`,
 			init: {
 				method: 'POST',
-				headers: { 'Content-Type': 'application/json' },
+				headers: {
+					'Content-Type': 'application/json',
+					...(apiKey && { Authorization: `Bearer ${apiKey}` })
+				},
 				body: JSON.stringify({
 					model,
 					messages: [{ role: 'user', content: prompt }],
@@ -140,7 +156,12 @@ export function buildProviders(env: Record<string, string>): LLMProvider[] {
 	const providers: LLMProvider[] = [];
 	if (env.OLLAMA_BASE_URL) {
 		const model = env.OLLAMA_MODEL || 'llama3.2';
-		providers.push(buildOllamaProvider(`ollama-${model}`, model));
+		// OLLAMA_API_KEY is optional. when set we attach Authorization: Bearer
+		// {key} so the request gets through a reverse-proxy or hosted endpoint
+		// that gates the daemon (OpenWebUI, LiteLLM, Caddy bearer auth, etc.).
+		// vanilla localhost ollama leaves this unset and behaves as before.
+		const apiKey = env.OLLAMA_API_KEY || undefined;
+		providers.push(buildOllamaProvider(`ollama-${model}`, model, { apiKey }));
 	}
 	if (env.GEMINI_API_KEY) {
 		// primary cloud: Gemma 3 27B via Google - 14,400 RPD, 30 RPM, 15K TPM

--- a/tests/unit/api/providers.test.ts
+++ b/tests/unit/api/providers.test.ts
@@ -127,3 +127,97 @@ describe('cloud provider invariants (regression net)', () => {
 		expect(buildGroqProvider('x', 'm').configKey).toBe('GROQ_API_KEY');
 	});
 });
+
+// helper because headers init is HeadersInit (object literal in our case);
+// indexing it requires narrowing to Record<string, string> first.
+function headersOf(init: RequestInit): Record<string, string> {
+	return init.headers as Record<string, string>;
+}
+
+describe('buildOllamaProvider: optional bearer auth for proxied endpoints', () => {
+	it('omits Authorization header when no apiKey is given (vanilla local ollama)', () => {
+		const provider = buildOllamaProvider('test', 'llama3.2');
+		const { init } = provider.buildRequest('hello', 'http://127.0.0.1:11434');
+		expect(headersOf(init).Authorization).toBeUndefined();
+	});
+
+	it('sets Authorization: Bearer {key} when apiKey is provided', () => {
+		const provider = buildOllamaProvider('test', 'llama3.2', { apiKey: 'sk-secret-xyz' });
+		const { init } = provider.buildRequest('hello', 'http://127.0.0.1:11434');
+		expect(headersOf(init).Authorization).toBe('Bearer sk-secret-xyz');
+	});
+
+	it('treats empty-string apiKey as not set (no Authorization header)', () => {
+		const provider = buildOllamaProvider('test', 'llama3.2', { apiKey: '' });
+		const { init } = provider.buildRequest('hello', 'http://127.0.0.1:11434');
+		expect(headersOf(init).Authorization).toBeUndefined();
+	});
+
+	it('treats whitespace-only apiKey as not set (no Authorization header)', () => {
+		const provider = buildOllamaProvider('test', 'llama3.2', { apiKey: '   \n\t' });
+		const { init } = provider.buildRequest('hello', 'http://127.0.0.1:11434');
+		expect(headersOf(init).Authorization).toBeUndefined();
+	});
+
+	it('trims surrounding whitespace from apiKey before composing the header', () => {
+		const provider = buildOllamaProvider('test', 'llama3.2', { apiKey: '  sk-secret-xyz\n' });
+		const { init } = provider.buildRequest('hello', 'http://127.0.0.1:11434');
+		expect(headersOf(init).Authorization).toBe('Bearer sk-secret-xyz');
+	});
+
+	it('preserves Content-Type: application/json alongside Authorization', () => {
+		const provider = buildOllamaProvider('test', 'llama3.2', { apiKey: 'sk-secret' });
+		const { init } = provider.buildRequest('hello', 'http://127.0.0.1:11434');
+		const headers = headersOf(init);
+		expect(headers['Content-Type']).toBe('application/json');
+		expect(headers.Authorization).toBe('Bearer sk-secret');
+	});
+
+	it('does not mutate the request body or URL when apiKey is attached', () => {
+		const noKey = buildOllamaProvider('test', 'llama3.2').buildRequest(
+			'prompt',
+			'http://127.0.0.1:11434'
+		);
+		const withKey = buildOllamaProvider('test', 'llama3.2', {
+			apiKey: 'sk-secret'
+		}).buildRequest('prompt', 'http://127.0.0.1:11434');
+		expect(withKey.url).toBe(noKey.url);
+		expect(withKey.init.body).toBe(noKey.init.body);
+	});
+});
+
+describe('buildProviders: OLLAMA_API_KEY passthrough', () => {
+	it('passes OLLAMA_API_KEY through to the ollama provider when set', () => {
+		const chain = buildProviders({
+			OLLAMA_BASE_URL: 'http://127.0.0.1:11434',
+			OLLAMA_API_KEY: 'sk-proxy-token'
+		});
+		expect(chain).toHaveLength(1);
+		const { init } = chain[0].buildRequest('hello', 'http://127.0.0.1:11434');
+		expect(headersOf(init).Authorization).toBe('Bearer sk-proxy-token');
+	});
+
+	it('does not attach Authorization when OLLAMA_API_KEY is unset', () => {
+		const chain = buildProviders({
+			OLLAMA_BASE_URL: 'http://127.0.0.1:11434'
+		});
+		const { init } = chain[0].buildRequest('hello', 'http://127.0.0.1:11434');
+		expect(headersOf(init).Authorization).toBeUndefined();
+	});
+
+	it('does not attach Authorization when OLLAMA_API_KEY is empty string', () => {
+		const chain = buildProviders({
+			OLLAMA_BASE_URL: 'http://127.0.0.1:11434',
+			OLLAMA_API_KEY: ''
+		});
+		const { init } = chain[0].buildRequest('hello', 'http://127.0.0.1:11434');
+		expect(headersOf(init).Authorization).toBeUndefined();
+	});
+
+	it('OLLAMA_API_KEY alone (no OLLAMA_BASE_URL) does not produce an ollama provider', () => {
+		const chain = buildProviders({
+			OLLAMA_API_KEY: 'sk-stranded'
+		});
+		expect(chain).toEqual([]);
+	});
+});


### PR DESCRIPTION
patch release. closes the [#7](https://github.com/sunnypatell/ats-screener/issues/7) follow-up where BloodyIron asked about auth.

adds optional `OLLAMA_API_KEY` env var. when set, Ollama requests include `Authorization: Bearer {key}`. vanilla localhost ollama leaves it unset and behaves exactly as before. full details in [CHANGELOG.md](https://github.com/sunnypatell/ats-screener/blob/main/CHANGELOG.md) and the new "Behind a reverse proxy or auth gate" subsection at [/docs/self-hosting/configuration](https://ats-screener.vercel.app/docs/self-hosting/configuration#behind-a-reverse-proxy-or-auth-gate).

11 new tests, 365 total. squash merge with `release: v0.3.2 (#NN)` as the squash subject.