### PR TITLE
feat(auth): active directory (ldap) sign-in for self-hosters

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,6 +55,35 @@ GEMINI_API_KEY=
 # PUBLIC_FIREBASE_APP_ID=
 
 # -----------------------------------------------------------------------------
+# Authentication (optional self-host: Active Directory / LDAP)
+# -----------------------------------------------------------------------------
+# for self-hosters running INSIDE their own network (a domain-joined Windows
+# Server or a LAN host that can reach a domain controller). when LDAP_URL is set
+# the app switches to AD sign-in: users log in with their AD username + password,
+# the scanner sits behind that login, and history is kept per user in the browser.
+#
+# mode precedence: LDAP (LDAP_URL set) > Firebase (PUBLIC_FIREBASE_PROJECT_ID set)
+# > anonymous (neither). leave LDAP_URL unset and none of this applies. the
+# hosted instance never sets these. full guide: /docs/self-hosting/active-directory
+#
+# required when LDAP_URL is set:
+# LDAP_URL=ldaps://dc.corp.example.com:636
+# LDAP_BIND_DN=CN=svc-ats,OU=Service Accounts,DC=corp,DC=example,DC=com
+# LDAP_BIND_PASSWORD=
+# LDAP_SEARCH_BASE=DC=corp,DC=example,DC=com
+# SESSION_SECRET= # 32+ random chars, e.g. openssl rand -base64 32
+#
+# optional:
+# LDAP_USERNAME_ATTRIBUTES=sAMAccountName,userPrincipalName
+# LDAP_DEFAULT_DOMAIN=corp.example.com   # lets a bare "jdoe" resolve as a UPN
+# LDAP_ALLOWED_GROUP_DN=CN=ATS Users,OU=Groups,DC=corp,DC=example,DC=com
+# LDAP_NAME_ATTRIBUTE=displayName
+# LDAP_EMAIL_ATTRIBUTE=mail
+# LDAP_TLS_CA_PATH=/etc/ssl/certs/corp-internal-ca.pem  # for LDAPS w/ internal CA
+# LDAP_TLS_REJECT_UNAUTHORIZED=true   # set false only in a throwaway lab
+# SESSION_MAX_AGE=28800   # session lifetime in seconds (default 8h)
+
+# -----------------------------------------------------------------------------
 # Operations (optional, defaults are sane)
 # -----------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-06-02
+
+self-host authentication cycle: active directory / ldap sign-in (closes [#16](https://github.com/sunnypatell/ats-screener/issues/16)) and a true firebase-free self-host (closes [#13](https://github.com/sunnypatell/ats-screener/issues/13)). purely additive: the hosted firebase deployment is byte-identical, and the anonymous self-host path is unchanged.
+
+### Added
+
+- **Active Directory (LDAP) authentication as a third self-host mode.** set `LDAP_URL` (plus a read-only service-account bind and `SESSION_SECRET`) and the app authenticates users against an on-premise AD domain: users sign in with their AD username and password, the scanner and `/api/analyze` sit behind that login, and scan history is kept in `localStorage` namespaced per user. designed for self-hosters running inside their own network (a domain-joined host or any LAN box that can reach a domain controller), which is exactly where the directory is reachable. accepts UPN (`user@domain`), down-level (`DOMAIN\user`), and bare `sAMAccountName` logon formats; supports an optional group allow-list with nested-group membership; LDAPS with internal-CA trust; and maps AD account-state errors (disabled, locked, expired, must-change-password) to friendly messages while collapsing "no such user" and "bad password" into one message so the form can't enumerate accounts. the Active Directory UI only renders when `LDAP_URL` is set, so it is invisible on the public deployment. new docs page at `/docs/self-hosting/active-directory`.
+- **Three mutually-exclusive auth modes, resolved server-side** (`resolveAuthMode`): `ldap` (when `LDAP_URL` is set) > `firebase` (when `PUBLIC_FIREBASE_PROJECT_ID` is set) > `none` (anonymous). the mode plus the validated user are surfaced to the client via a new root `+layout.server.ts`, and the auth store generalizes to all three while keeping the firebase code path identical.
+- **Stateless signed session cookie** for ldap mode, signed and verified with the Web Crypto API (HMAC-SHA256) so `hooks.server.ts` stays free of node built-ins. there is no server-side session store: the signed cookie is the session, so it survives restarts and works across instances. rotating `SESSION_SECRET` invalidates every session.
+- **Pluggable server auth-provider abstraction** (`ServerAuthProvider`, mirroring the `buildProviders()` LLM pattern) so OIDC / SAML can be added later without touching the ldap path. the `ldapts` client is an `optionalDependency`, dynamically imported only on the login route, so it never reaches the client/edge bundles and forks that don't set `LDAP_URL` never load it.
+- **Per-IP failed-login lockout** for the ldap sign-in action, mirroring the analyze rate-limiter (in-memory, per-instance), plus reliance on SvelteKit's built-in form-action origin check for CSRF.
+- **Reorganized self-hosting docs** with a dedicated [Authentication](/docs/self-hosting/authentication) page (anonymous vs firebase vs active directory, with precedence and trade-offs), a README self-hosting matrix, and a `.env.example` "Authentication" group.
+
+### Fixed
+
+- **No-firebase self-host is now genuinely firebase-free (closes [#13](https://github.com/sunnypatell/ats-screener/issues/13)).** the Content-Security-Policy is mode-aware: the firebase / google-auth origins (`*.googleapis.com`, `*.firebaseio.com`, `*.firebaseapp.com`, `accounts.google.com`) appear in `connect-src` / `frame-src` only when firebase is the active auth mode, so a docker / on-prem self-host without firebase no longer serves a CSP that references firebase or reports firebase-related violations. the firebase-auth `dns-prefetch` hints also moved out of `app.html` (where they fired for every visitor) into a firebase-mode-only block in the root layout, so a no-firebase install never resolves google / firebase DNS. the hosted firebase deployment keeps both the firebase CSP origins and the dns-prefetch hints.
+
+### Tests
+
+- 381 -> 464 (+83). new suites under `tests/unit/server/`: `auth/config` (mode precedence, trim semantics, fail-closed validation, defaults), `auth/normalize` (all three logon formats, RFC 4515 filter escaping / injection, nested-group filter), `auth/errors` (AD sub-code mapping incl. 525/52e collapsing to one message), `auth/session` (sign/verify round-trip, tamper / expiry / wrong-secret rejection), `auth/login-rate-limit` (lockout + window expiry), `auth/provider` (factory inert vs configured), and `csp` (firebase origins present in firebase mode, absent in self-host mode). plus `tests/unit/stores/scores-ldap-history-namespacing.test.ts` (per-user history keys, anonymous legacy key untouched) and updated `lcp-readiness` guards for the relocated dns-prefetch hints.
+
 ## [0.3.2] - 2026-05-29
 
 self-hosting cycle. two distinct closes to two BloodyIron issues, both purely additive (hosted production behaviour is byte-identical).

--- a/README.md
+++ b/README.md
@@ -112,6 +112,18 @@ pnpm lint       # lint
 pnpm build      # production build
 ```
 
+## Self-Hosting
+
+Auth and storage adapt to whatever you configure in `.env`, so you can run it three ways without touching code:
+
+| Mode                    | Enable with                         | Sign-in                          | Scan history         |
+| ----------------------- | ----------------------------------- | -------------------------------- | -------------------- |
+| **Hosted (Firebase)**   | `PUBLIC_FIREBASE_PROJECT_ID` + keys | Google / email                   | Firestore (synced)   |
+| **Anonymous self-host** | leave Firebase + LDAP unset         | none (open scanner)              | browser localStorage |
+| **Active Directory**    | `LDAP_URL` + service account        | AD username + password (on-prem) | per user, local      |
+
+LLM providers are independent of all this: set `GEMINI_API_KEY`/`GROQ_API_KEY` for the cloud chain, or `OLLAMA_BASE_URL` to run fully local. Mode precedence is LDAP > Firebase > anonymous. See the [self-hosting docs](https://ats-screener.vercel.app/docs/self-hosting/configuration) and the [Active Directory guide](https://ats-screener.vercel.app/docs/self-hosting/active-directory).
+
 ## Project Structure
 
 ```

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -102,6 +102,8 @@ export default defineConfig({
 					items: [
 						{ label: 'Setup Guide', slug: 'self-hosting/setup' },
 						{ label: 'Configuration', slug: 'self-hosting/configuration' },
+						{ label: 'Authentication', slug: 'self-hosting/authentication' },
+						{ label: 'Active Directory (LDAP)', slug: 'self-hosting/active-directory' },
 						{ label: 'Deployment', slug: 'self-hosting/deployment' }
 					]
 				},

--- a/docs/src/content/docs/self-hosting/active-directory.md
+++ b/docs/src/content/docs/self-hosting/active-directory.md
@@ -1,0 +1,133 @@
+---
+title: Active Directory (LDAP)
+description: Sign in self-hosted ATS Screener with on-premise Active Directory accounts over LDAP.
+---
+
+ATS Screener can authenticate users against your **Active Directory** domain over LDAP. This is for self-hosters running the app **inside their own network**, on a host that can reach a domain controller (a domain-joined Windows Server, or any Linux box on the LAN). The hosted instance at `ats-screener.vercel.app` never uses this; it stays on Firebase.
+
+When Active Directory is enabled, users sign in with their normal AD username and password, the scanner sits behind that login, and each user's scan history is kept separate on their browser.
+
+## Authentication modes
+
+ATS Screener picks exactly one auth mode at startup, from the environment:
+
+| Mode         | Enabled when                        | Sign-in                         | History         |
+| ------------ | ----------------------------------- | ------------------------------- | --------------- |
+| **LDAP/AD**  | `LDAP_URL` is set                   | AD username + password (server) | per user, local |
+| **Firebase** | `PUBLIC_FIREBASE_PROJECT_ID` is set | Google / email (client)         | Firestore       |
+| **None**     | neither is set                      | anonymous (no sign-in)          | local           |
+
+If both `LDAP_URL` and Firebase are set, **LDAP wins**. Leave `LDAP_URL` unset and nothing in this page applies, the app behaves exactly as it did before.
+
+## Prerequisites
+
+- A host that can reach your domain controller over the network (LDAP `389`, or LDAPS `636`).
+- A **read-only service account** in AD. ATS Screener binds as this account to look up the person signing in, then verifies their password by binding as them. The service account needs only "read" on the user objects you want to sign in.
+- The base DN your users live under (for example `DC=corp,DC=example,DC=com`).
+- A long random `SESSION_SECRET`. Sessions are signed with it; rotating it signs everyone out.
+
+:::tip
+Use LDAPS (`ldaps://...:636`) whenever you can. A plain `ldap://` bind sends the password in clear text on the wire. See [Securing the connection](#securing-the-connection-ldaps) below.
+:::
+
+## Configuration
+
+All of these are **server-side** variables (never prefixed `PUBLIC_`, so they never reach the browser). Set them in your `.env`.
+
+| Variable                       | Required          | Default                            | Description                                                                                           |
+| ------------------------------ | ----------------- | ---------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `LDAP_URL`                     | enables LDAP mode | —                                  | `ldaps://dc.corp.example.com:636` (or `ldap://...:389`). Presence turns it on.                        |
+| `LDAP_BIND_DN`                 | yes               | —                                  | DN of the read-only service account.                                                                  |
+| `LDAP_BIND_PASSWORD`           | yes               | —                                  | Service-account password.                                                                             |
+| `LDAP_SEARCH_BASE`             | yes               | —                                  | Base DN to search for users, e.g. `DC=corp,DC=example,DC=com`.                                        |
+| `SESSION_SECRET`               | yes               | —                                  | 32+ random chars. Generate with `openssl rand -base64 32`.                                            |
+| `LDAP_USERNAME_ATTRIBUTES`     | no                | `sAMAccountName,userPrincipalName` | Attributes a username is matched against (comma-separated).                                           |
+| `LDAP_DEFAULT_DOMAIN`          | no                | —                                  | If set, a bare `jdoe` is also tried as `jdoe@<default-domain>`.                                       |
+| `LDAP_ALLOWED_GROUP_DN`        | no                | —                                  | Restrict sign-in to members of this group (see [Restricting access](#restricting-access-to-a-group)). |
+| `LDAP_NAME_ATTRIBUTE`          | no                | `displayName`                      | Attribute used for the display name.                                                                  |
+| `LDAP_EMAIL_ATTRIBUTE`         | no                | `mail`                             | Attribute used for the email.                                                                         |
+| `LDAP_TLS_CA_PATH`             | no                | —                                  | Path to your internal CA certificate (PEM) for LDAPS validation.                                      |
+| `LDAP_TLS_REJECT_UNAUTHORIZED` | no                | `true`                             | Set to `false` only in a lab to accept self-signed certs (not recommended).                           |
+| `SESSION_MAX_AGE`              | no                | `28800` (8h)                       | Session lifetime in seconds.                                                                          |
+
+:::caution
+If `LDAP_URL` is set but a required companion (`LDAP_BIND_DN`, `LDAP_BIND_PASSWORD`, `LDAP_SEARCH_BASE`, `SESSION_SECRET`) is missing or `SESSION_SECRET` is too short, sign-in fails closed with a server-side error rather than running in a half-configured state.
+:::
+
+### Minimal example
+
+```bash
+# in your .env
+LDAP_URL=ldaps://dc.corp.example.com:636
+LDAP_BIND_DN=CN=svc-ats,OU=Service Accounts,DC=corp,DC=example,DC=com
+LDAP_BIND_PASSWORD=the-service-account-password
+LDAP_SEARCH_BASE=DC=corp,DC=example,DC=com
+SESSION_SECRET=replace-with-openssl-rand-base64-32
+
+# you still need at least one LLM provider (see Configuration):
+GEMINI_API_KEY=...
+# leave all PUBLIC_FIREBASE_* unset so LDAP is the active mode
+```
+
+## How users sign in
+
+The login form accepts the three usual AD logon formats, so users can type whatever they're used to:
+
+- **UPN**: `jdoe@corp.example.com`
+- **Down-level**: `CORP\jdoe`
+- **Bare username**: `jdoe` (matched against `sAMAccountName`; if you set `LDAP_DEFAULT_DOMAIN`, it's also tried as a UPN)
+
+A wrong username and a wrong password return the **same** message on purpose, so the form can't be used to discover which accounts exist. Disabled, expired, and locked accounts get a specific message. Repeated failures from one address are rate-limited.
+
+## Restricting access to a group
+
+By default any account that can bind is allowed in. To limit sign-in to one group, set its DN:
+
+```bash
+LDAP_ALLOWED_GROUP_DN=CN=ATS Users,OU=Groups,DC=corp,DC=example,DC=com
+```
+
+Membership is evaluated **including nested groups**, so a user who belongs to a group that is itself a member of `ATS Users` is allowed in. Users outside the group get an "not authorized" message after their password is verified.
+
+## Securing the connection (LDAPS)
+
+Use `ldaps://` on port `636`. If your domain controller's certificate is issued by an internal CA that the host doesn't already trust, point ATS Screener at the CA certificate:
+
+```bash
+LDAP_URL=ldaps://dc.corp.example.com:636
+LDAP_TLS_CA_PATH=/etc/ssl/certs/corp-internal-ca.pem
+```
+
+:::caution
+`LDAP_TLS_REJECT_UNAUTHORIZED=false` turns off certificate validation entirely. Only use it on a throwaway lab domain, never in production. Trust the internal CA with `LDAP_TLS_CA_PATH` instead.
+:::
+
+## Sessions
+
+After a successful sign-in, ATS Screener sets a signed, `httpOnly` session cookie. There is no server-side session store, the cookie is self-contained, so sessions survive restarts and work across multiple instances. To force everyone to sign in again, rotate `SESSION_SECRET`. Adjust `SESSION_MAX_AGE` to change how long a session lasts.
+
+## Scan history
+
+In AD mode, scan history is stored in the browser's `localStorage`, namespaced per signed-in user so two people sharing a machine don't see each other's scans. As with the other self-host modes, history is per-browser and not synced across devices. Server-side, cross-device history would need a database; it's tracked as a possible future enhancement on the issue tracker.
+
+## Troubleshooting
+
+| Message a user sees                               | Likely cause                                                                                 |
+| ------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| Incorrect username or password                    | Wrong username, wrong password, or the user isn't under the search base.                     |
+| Your account is disabled / locked / expired       | The AD account is in that state. Fix it in AD.                                               |
+| You must reset your password                      | AD requires a password change before the next sign-in.                                       |
+| You are not authorized to access this application | `LDAP_ALLOWED_GROUP_DN` is set and the user isn't a member (directly or nested).             |
+| Cannot reach the directory server                 | `LDAP_URL` is wrong/unreachable, or LDAPS cert validation failed (check `LDAP_TLS_CA_PATH`). |
+| Server authentication is misconfigured            | `LDAP_URL` is set but a required companion var is missing, or `SESSION_SECRET` is too short. |
+| Too many attempts                                 | Failed-login rate limit; wait and try again.                                                 |
+
+## Not in scope (yet)
+
+Single-forest LDAP is what ships today. The following are intentionally out of scope and tracked as future work:
+
+- Multi-forest / cross-domain trusts and Global Catalog lookups
+- Kerberos / integrated single sign-on
+- OIDC and SAML (Entra ID, Okta, Keycloak)
+
+The sign-in layer is built around a small provider interface, so these can be added later without disturbing the LDAP path.

--- a/docs/src/content/docs/self-hosting/active-directory.md
+++ b/docs/src/content/docs/self-hosting/active-directory.md
@@ -106,6 +106,10 @@ LDAP_TLS_CA_PATH=/etc/ssl/certs/corp-internal-ca.pem
 
 After a successful sign-in, ATS Screener sets a signed, `httpOnly` session cookie. There is no server-side session store, the cookie is self-contained, so sessions survive restarts and work across multiple instances. To force everyone to sign in again, rotate `SESSION_SECRET`. Adjust `SESSION_MAX_AGE` to change how long a session lasts.
 
+:::caution
+Behind a TLS-terminating reverse proxy (nginx, Caddy, Traefik in front of the node adapter, the common AD topology), the app receives plain HTTP internally, so the session cookie's `Secure` flag depends on the proxy forwarding the original scheme. The login action honours `X-Forwarded-Proto`, but you should also tell your SvelteKit adapter to trust the proxy (for `@sveltejs/adapter-node`, set `PROTOCOL_HEADER=x-forwarded-proto` and `HOST_HEADER=x-forwarded-host`) so `Secure` is set correctly and the cookie is never sent over plain HTTP.
+:::
+
 ## Scan history
 
 In AD mode, scan history is stored in the browser's `localStorage`, namespaced per signed-in user so two people sharing a machine don't see each other's scans. As with the other self-host modes, history is per-browser and not synced across devices. Server-side, cross-device history would need a database; it's tracked as a possible future enhancement on the issue tracker.

--- a/docs/src/content/docs/self-hosting/authentication.md
+++ b/docs/src/content/docs/self-hosting/authentication.md
@@ -1,0 +1,36 @@
+---
+title: Authentication
+description: 'Choose how users sign in to your self-hosted ATS Screener: anonymous, Firebase, or Active Directory.'
+---
+
+ATS Screener picks one of three sign-in modes automatically from your environment. You don't toggle anything in code or in the UI; setting the relevant variables is what turns a mode on.
+
+| Mode                 | Turn it on with                           | Sign-in                          | Scan history           | Best for                              |
+| -------------------- | ----------------------------------------- | -------------------------------- | ---------------------- | ------------------------------------- |
+| **Anonymous**        | leave Firebase and LDAP unset             | none, the scanner is open        | browser localStorage   | personal / single-user installs       |
+| **Firebase**         | set `PUBLIC_FIREBASE_PROJECT_ID` (+ keys) | Google or email/password         | Firestore, synced      | a hosted-style instance with accounts |
+| **Active Directory** | set `LDAP_URL` (+ service account)        | AD username + password (on-prem) | per user, localStorage | a company on its own network          |
+
+If more than one is configured, the precedence is **Active Directory > Firebase > anonymous**. The public instance at `ats-screener.vercel.app` uses Firebase; it never sets `LDAP_URL`, so the Active Directory UI never appears there.
+
+## Anonymous (no sign-in)
+
+The default. Leave every `PUBLIC_FIREBASE_*` variable and `LDAP_URL` unset and the app runs fully local:
+
+- The scanner is open, no account required.
+- Scan history is saved to the browser's `localStorage` (capped at 5, newest first).
+- The Sign In button and `/login` are hidden / redirect away, and the Firebase SDK is never imported.
+
+This is the simplest way to self-host. Trade-off: history lives in one browser and isn't synced across devices.
+
+## Firebase
+
+Set the six `PUBLIC_FIREBASE_*` variables (from Firebase Console, see [Configuration](/docs/self-hosting/configuration)) to get Google and email/password sign-in plus cross-device history in Firestore. This mirrors the hosted instance. Detection is a single signal: a non-empty `PUBLIC_FIREBASE_PROJECT_ID`.
+
+## Active Directory (LDAP)
+
+For self-hosters on a corporate network: users sign in with their existing AD account, the scanner sits behind that login, and access can be restricted to a group. This is server-side and only activates when `LDAP_URL` is set. See the dedicated [Active Directory guide](/docs/self-hosting/active-directory) for setup.
+
+## What stays the same across modes
+
+The LLM provider chain (cloud Gemini/Groq, or local Ollama) is independent of which auth mode you pick. Configure providers in [Configuration](/docs/self-hosting/configuration); they work the same whether sign-in is anonymous, Firebase, or Active Directory.

--- a/docs/src/content/docs/self-hosting/configuration.md
+++ b/docs/src/content/docs/self-hosting/configuration.md
@@ -61,22 +61,18 @@ OLLAMA_API_KEY=sk-your-proxy-token
 
 The header is only attached when the env var is non-empty, so leaving it unset keeps the request shape identical to the local-only setup. Empty or whitespace-only values are treated as not set so a stray `OLLAMA_API_KEY=` line in `.env` does not produce a malformed `Authorization: Bearer ` header that the proxy would reject.
 
-## Running without Firebase
+## Authentication
 
-ATS Screener uses Firebase for sign-in and for cross-device scan history on the hosted instance. Self-hosters who don't want to run Firebase can leave every `PUBLIC_FIREBASE_*` env var unset and the app will detect this at startup and switch to a fully local mode:
+How users sign in (or whether they sign in at all) is a separate choice from the LLM provider, and it's also driven by environment variables. ATS Screener supports three modes, picked automatically:
 
-- The scanner unlocks for anonymous use (no sign-in required).
-- Scan history is persisted to the browser's `localStorage`, capped at 5 entries newest-first (same shape and cap as the Firestore-backed history).
-- The Sign In button, user menu, and `/login` route are all hidden / redirect away.
-- The Hero's "Users Served" counter is omitted from the landing page (it would have nothing to read).
-- The Firebase SDK is never imported, so the build is smaller and the page never reaches out to `googleapis.com`.
+- **Anonymous**: leave Firebase and LDAP unset. The scanner is open and history is local. This is the default.
+- **Firebase**: set the `PUBLIC_FIREBASE_*` variables for Google / email sign-in and synced history.
+- **Active Directory**: set `LDAP_URL` for on-premise AD sign-in.
 
-Detection is based on a single signal: a non-empty `PUBLIC_FIREBASE_PROJECT_ID`. Set it (along with the rest of the Firebase config) to opt into auth + cross-device sync. Leave it unset (or empty) for fully local use.
+See [Authentication](/docs/self-hosting/authentication) for the full comparison and the [Active Directory guide](/docs/self-hosting/active-directory) for AD setup. The Firebase variables are listed below.
 
 ```bash
-# self-host without firebase: leave every PUBLIC_FIREBASE_* var unset.
-# this is the default state; you don't need to add anything to .env.
-
+# self-host without firebase: leave every PUBLIC_FIREBASE_* var unset (the default).
 # self-host with firebase: set all six.
 PUBLIC_FIREBASE_API_KEY=...
 PUBLIC_FIREBASE_AUTH_DOMAIN=your-project.firebaseapp.com
@@ -85,13 +81,6 @@ PUBLIC_FIREBASE_STORAGE_BUCKET=your-project.appspot.com
 PUBLIC_FIREBASE_MESSAGING_SENDER_ID=1234567890
 PUBLIC_FIREBASE_APP_ID=1:1234567890:web:abc
 ```
-
-Trade-offs of the no-Firebase path:
-
-- **Single-device**: history lives in the current browser's `localStorage`. Clearing site data or switching browsers loses it. For cross-device sync, you need Firebase (or your own auth + database, see the issue tracker for roadmap discussion).
-- **Quota**: `localStorage` is 5-10MB per origin. With the 5-entry cap (roughly 50KB total), you're 100x under that ceiling.
-- **No password reset, no sign-out**: these features simply don't exist when auth is disabled, because there's no auth.
-- **Saved JDs**: the "Saved JDs" feature in the Job Description textarea is already `localStorage`-backed and works either way.
 
 ## Free Tier Limits
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ats-screener",
-	"version": "0.3.2",
+	"version": "0.4.0",
 	"private": true,
 	"license": "MIT",
 	"type": "module",
@@ -69,5 +69,8 @@
 			"sharp",
 			"workerd"
 		]
+	},
+	"optionalDependencies": {
+		"ldapts": "^8.1.8"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,6 +102,10 @@ importers:
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/node@22.19.11)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.31.1)
+    optionalDependencies:
+      ldapts:
+        specifier: ^8.1.8
+        version: 8.1.8
 
 packages:
 
@@ -1347,6 +1351,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@vercel/nft@1.3.1':
     resolution: {integrity: sha512-ihNT1rswiq3cy4WKQAV5kJi6UjWX1vLUzlLc+Vvq83G8CU9nMgfDWz5f1tOnSlS8LeC4Wp4qTB3+HGj/ccUrFQ==}
@@ -2110,6 +2115,10 @@ packages:
   known-css-properties@0.35.0:
     resolution: {integrity: sha512-a/RAk2BfKk+WFGhhOCAYqSiFLc34k8Mt/6NWRI4joER0EYUzXIcFivjjnoD3+XU1DggLn/tZc3DOAgke7l8a4A==}
 
+  ldapts@8.1.8:
+    resolution: {integrity: sha512-Wpdvo+/0DREIynYf2he2efHtjptr5zD7dpesSkZWJqfQdMEgSTytEIsSZVuoDSiiE1+SpXf3emZ7ewxGBTo7Pw==}
+    engines: {node: '>=20'}
+
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
@@ -2654,6 +2663,9 @@ packages:
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  strict-event-emitter-types@2.0.0:
+    resolution: {integrity: sha512-Nk/brWYpD85WlOgzw5h173aci0Teyv8YdIAEtV+N88nDB0dLlazZyJMIsN6eo1/AR61l+p6CJTG1JIyFaoNEEA==}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -5064,6 +5076,11 @@ snapshots:
 
   known-css-properties@0.35.0: {}
 
+  ldapts@8.1.8:
+    dependencies:
+      strict-event-emitter-types: 2.0.0
+    optional: true
+
   levn@0.4.1:
     dependencies:
       prelude-ls: 1.2.1
@@ -5617,6 +5634,9 @@ snapshots:
     optional: true
 
   std-env@3.10.0: {}
+
+  strict-event-emitter-types@2.0.0:
+    optional: true
 
   string-width@4.2.3:
     dependencies:

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -3,7 +3,17 @@
 declare global {
 	namespace App {
 		// interface Error {}
-		// interface Locals {}
+		// populated by hooks.server.ts ONLY in ldap self-host mode (server-side
+		// session). null in firebase/none mode and on the hosted deploy, so
+		// nothing that reads locals.user changes behaviour there.
+		interface Locals {
+			user: {
+				sub: string;
+				name: string;
+				email: string;
+				groups: string[];
+			} | null;
+		}
 		// interface PageData {}
 		// interface PageState {}
 		interface Platform {

--- a/src/app.html
+++ b/src/app.html
@@ -57,17 +57,9 @@
 			as="style"
 			href="https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600;700&family=Geist+Mono:wght@400;500&display=swap"
 		/>
-		<!-- dns-prefetch (not preconnect) for firebase auth hosts. lighter
-		     than preconnect, warms the DNS resolver for visitors who end up
-		     signing in without paying the TLS-handshake cost up front for
-		     visitors who never do. firebase auth is never needed before the
-		     first user interaction on the landing page, so the full TLS
-		     handshake cost of preconnect is not justified here. -->
-		<link rel="dns-prefetch" href="//accounts.google.com" />
-		<link rel="dns-prefetch" href="//apis.google.com" />
-		<link rel="dns-prefetch" href="//securetoken.googleapis.com" />
-		<link rel="dns-prefetch" href="//identitytoolkit.googleapis.com" />
-		<link rel="dns-prefetch" href="//firestore.googleapis.com" />
+		<!-- firebase-auth dns-prefetch hints are emitted from the root layout,
+		     gated on firebase being the active auth mode, so a self-host without
+		     firebase never resolves google / firebase DNS (see +layout.svelte). -->
 		<link
 			href="https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600;700&family=Geist+Mono:wght@400;500&display=swap"
 			rel="stylesheet"

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,7 +1,14 @@
 import type { Handle } from '@sveltejs/kit';
+import { env } from '$env/dynamic/private';
+import { env as publicEnv } from '$env/dynamic/public';
+import { resolveAuthMode } from '$lib/server/auth/config';
+import { verifySession, SESSION_COOKIE } from '$lib/server/auth/session';
+import { buildContentSecurityPolicy } from '$lib/server/csp';
 // no node built-ins here - hooks.server.ts is bundled into BOTH node and edge
 // route functions, and edge bundling fails on fs/path/node:crypto. docs serving
-// (which used fs) lives in a node-runtime catchall route at /docs/[...slug]
+// (which used fs) lives in a node-runtime catchall route at /docs/[...slug].
+// the auth-session imports above stay edge-safe on purpose: config.ts is pure
+// string work and session.ts verifies the cookie with Web Crypto (not node:crypto).
 
 // applied as defaults: routes that already set a header keep their value.
 // headers that are conditional (e.g. HSTS) are applied in applySecurityHeaders
@@ -55,26 +62,16 @@ const SECURITY_HEADERS: Record<string, string> = {
 };
 
 // CSP in report-only mode: violations are reported to /api/csp-report but
-// nothing is blocked. lets us observe what would break before enforcing.
-// directives are sized for: SvelteKit hydration (inline scripts/styles),
-// Google Fonts, Firebase Auth (popup + APIs), Firestore, and the LLM proxies
-// the api/analyze route uses (groq + gemini are server-side, not in client connect-src)
-const CSP_REPORT_ONLY = [
-	"default-src 'self'",
-	"script-src 'self' 'unsafe-inline' 'unsafe-eval'",
-	"style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
-	"font-src 'self' https://fonts.gstatic.com",
-	"img-src 'self' data: https:",
-	"connect-src 'self' https://*.googleapis.com https://*.firebaseio.com https://*.firebaseapp.com https://*.firebase.com",
-	"frame-src 'self' https://*.firebaseapp.com https://accounts.google.com",
-	"worker-src 'self' blob:",
-	"object-src 'none'",
-	"base-uri 'self'",
-	"form-action 'self'",
-	'report-uri /api/csp-report'
-].join('; ');
-
-function applySecurityHeaders(response: Response, path: string, isHttps: boolean): Response {
+// nothing is blocked. lets us observe what would break before enforcing. the
+// firebase / google-auth origins are mode-aware (see $lib/server/csp): a
+// self-host without firebase gets a CSP with zero firebase references, so the
+// directory-only or anonymous deployment never advertises firebase hosts (#13).
+function applySecurityHeaders(
+	response: Response,
+	path: string,
+	isHttps: boolean,
+	csp: string
+): Response {
 	for (const [name, value] of Object.entries(SECURITY_HEADERS)) {
 		// HSTS must only be sent on HTTPS responses. sending it on HTTP (e.g. localhost
 		// dev server) would instruct the browser to upgrade all future requests to HTTPS,
@@ -87,13 +84,38 @@ function applySecurityHeaders(response: Response, path: string, isHttps: boolean
 	// directives only on document/iframe contexts so the header is benign on
 	// JSON / image / svg responses, just unread bytes on the wire
 	if (path !== '/api/csp-report' && !response.headers.has('Content-Security-Policy-Report-Only')) {
-		response.headers.set('Content-Security-Policy-Report-Only', CSP_REPORT_ONLY);
+		response.headers.set('Content-Security-Policy-Report-Only', csp);
 	}
 	return response;
 }
 
 export const handle: Handle = async ({ event, resolve }) => {
+	// server-side session, ldap self-host mode ONLY. inert in firebase/none mode
+	// and on the hosted deploy: resolveAuthMode returns 'ldap' only when LDAP_URL
+	// is set (which the hosted instance never does), so no cookie is read and
+	// locals.user stays null - exactly as before this feature existed.
+	const mode = resolveAuthMode({ ...env, ...publicEnv });
+
+	event.locals.user = null;
+	if (mode === 'ldap') {
+		const token = event.cookies.get(SESSION_COOKIE);
+		if (token) {
+			const payload = await verifySession(token, env.SESSION_SECRET ?? '');
+			if (payload) {
+				event.locals.user = {
+					sub: payload.sub,
+					name: payload.name,
+					email: payload.email,
+					groups: payload.groups
+				};
+			}
+		}
+	}
+
+	// firebase origins appear in the CSP only when firebase is the active auth
+	// mode, so a self-host without firebase never advertises them (#13).
+	const csp = buildContentSecurityPolicy(mode === 'firebase');
 	const path = event.url.pathname;
 	const isHttps = event.url.protocol === 'https:';
-	return applySecurityHeaders(await resolve(event), path, isHttps);
+	return applySecurityHeaders(await resolve(event), path, isHttps, csp);
 };

--- a/src/lib/components/ui/Navbar.svelte
+++ b/src/lib/components/ui/Navbar.svelte
@@ -100,10 +100,10 @@
 				GitHub
 			</a>
 			<a href="/scanner" class="nav-cta"> Scan Now </a>
-			<!-- auth slot hidden entirely on self-host (firebase not configured)
-			     since there's no sign-in to offer. on hosted builds the
-			     existing UserMenu / AuthButton split applies. -->
-			{#if !authStore.disabled && !authStore.loading}
+			<!-- auth slot hidden in anonymous self-host ('none' mode) since there's
+			     no sign-in to offer. shown when auth is required (hosted firebase OR
+			     ldap self-host); the UserMenu / AuthButton split applies to both. -->
+			{#if authStore.requiresAuth && !authStore.loading}
 				{#if authStore.isAuthenticated}
 					<UserMenu />
 				{:else}

--- a/src/lib/components/ui/UserMenu.svelte
+++ b/src/lib/components/ui/UserMenu.svelte
@@ -42,7 +42,9 @@
 		<div class="dropdown">
 			<div class="dropdown-header">
 				<span class="dropdown-name">{authStore.displayName}</span>
-				<span class="dropdown-email">{authStore.email}</span>
+				{#if authStore.email}
+					<span class="dropdown-email">{authStore.email}</span>
+				{/if}
 			</div>
 			<div class="dropdown-divider"></div>
 			<a href="/scanner" class="dropdown-item" onclick={() => (open = false)}>

--- a/src/lib/server/auth/config.ts
+++ b/src/lib/server/auth/config.ts
@@ -1,0 +1,126 @@
+// auth mode + LDAP config resolution. pure: takes a plain env record so it
+// unit-tests in isolation exactly like buildProviders() in
+// api/analyze/providers.ts (pass a {} object, assert the result).
+//
+// three mutually-exclusive auth modes, resolved server-side:
+//   ldap     - LDAP_URL set: server-side AD/LDAP sign-in + signed session cookie
+//   firebase - PUBLIC_FIREBASE_PROJECT_ID set: the existing hosted client path
+//   none     - neither set: anonymous self-host (localStorage history)
+//
+// precedence is ldap > firebase > none. the hosted deploy never sets LDAP_URL,
+// so it always resolves 'firebase' and every new server-side path stays inert.
+// this is the single source of truth, mirroring the `firebaseConfigured` flag.
+
+export type AuthMode = 'ldap' | 'firebase' | 'none';
+
+export interface LdapConfig {
+	url: string;
+	bindDN: string;
+	bindCredentials: string;
+	searchBase: string;
+	// logon attributes the supplied username is matched against (OR'd in the
+	// search filter). default covers all three AD logon formats.
+	usernameAttributes: string[];
+	// when set, a bare "jdoe" is also tried as the UPN "jdoe@<defaultDomain>".
+	defaultDomain?: string;
+	nameAttribute: string;
+	emailAttribute: string;
+	// optional allow-list: only members of this group DN (incl. nested) may sign in.
+	allowedGroupDN?: string;
+	tlsRejectUnauthorized: boolean;
+	tlsCAPath?: string;
+	sessionSecret: string;
+	sessionMaxAgeSec: number;
+}
+
+// raised when LDAP_URL is set but the configuration is incomplete or unsafe.
+// the login action catches this and fails closed (500 + server log), matching
+// the ADMIN_TOKEN fail-closed precedent rather than silently degrading.
+export class LdapConfigError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = 'LdapConfigError';
+	}
+}
+
+const DEFAULT_USERNAME_ATTRIBUTES = ['sAMAccountName', 'userPrincipalName'];
+const DEFAULT_NAME_ATTRIBUTE = 'displayName';
+const DEFAULT_EMAIL_ATTRIBUTE = 'mail';
+const DEFAULT_SESSION_MAX_AGE_SEC = 28_800; // 8 hours
+const MIN_SESSION_SECRET_LENGTH = 16;
+
+type Env = Record<string, string | undefined>;
+
+// trim and treat empty / whitespace-only as unset, matching the
+// firebaseConfigured semantics so a stray `LDAP_URL= ` line reads as disabled.
+function val(env: Env, key: string): string | undefined {
+	const v = env[key];
+	if (typeof v !== 'string') return undefined;
+	const t = v.trim();
+	return t.length > 0 ? t : undefined;
+}
+
+export function resolveAuthMode(env: Env): AuthMode {
+	if (val(env, 'LDAP_URL')) return 'ldap';
+	if (val(env, 'PUBLIC_FIREBASE_PROJECT_ID')) return 'firebase';
+	return 'none';
+}
+
+// returns null when LDAP is disabled (inert signal, like an unset OLLAMA_BASE_URL).
+// when LDAP_URL is set, returns a fully-defaulted config or throws LdapConfigError
+// if a required companion var is missing / the session secret is too weak.
+export function resolveLdapConfig(env: Env): LdapConfig | null {
+	const url = val(env, 'LDAP_URL');
+	if (!url) return null;
+
+	const bindDN = val(env, 'LDAP_BIND_DN');
+	const bindCredentials = val(env, 'LDAP_BIND_PASSWORD') ?? val(env, 'LDAP_BIND_CREDENTIALS');
+	const searchBase = val(env, 'LDAP_SEARCH_BASE');
+	const sessionSecret = val(env, 'SESSION_SECRET');
+
+	const missing: string[] = [];
+	if (!bindDN) missing.push('LDAP_BIND_DN');
+	if (!bindCredentials) missing.push('LDAP_BIND_PASSWORD');
+	if (!searchBase) missing.push('LDAP_SEARCH_BASE');
+	if (!sessionSecret) missing.push('SESSION_SECRET');
+	if (missing.length > 0) {
+		throw new LdapConfigError(
+			`LDAP_URL is set but required companion vars are missing: ${missing.join(', ')}. ` +
+				`set them in your environment, or unset LDAP_URL to disable LDAP auth.`
+		);
+	}
+	if (sessionSecret!.length < MIN_SESSION_SECRET_LENGTH) {
+		throw new LdapConfigError(
+			`SESSION_SECRET must be at least ${MIN_SESSION_SECRET_LENGTH} characters ` +
+				`(32+ recommended). generate one with: openssl rand -base64 32`
+		);
+	}
+
+	const usernameAttributes = (val(env, 'LDAP_USERNAME_ATTRIBUTES') ?? '')
+		.split(',')
+		.map((s) => s.trim())
+		.filter(Boolean);
+
+	const maxAgeRaw = val(env, 'SESSION_MAX_AGE');
+	const parsedMaxAge = maxAgeRaw ? Number.parseInt(maxAgeRaw, 10) : Number.NaN;
+	const sessionMaxAgeSec =
+		Number.isFinite(parsedMaxAge) && parsedMaxAge > 0 ? parsedMaxAge : DEFAULT_SESSION_MAX_AGE_SEC;
+
+	return {
+		url,
+		bindDN: bindDN!,
+		bindCredentials: bindCredentials!,
+		searchBase: searchBase!,
+		usernameAttributes:
+			usernameAttributes.length > 0 ? usernameAttributes : DEFAULT_USERNAME_ATTRIBUTES,
+		defaultDomain: val(env, 'LDAP_DEFAULT_DOMAIN'),
+		nameAttribute: val(env, 'LDAP_NAME_ATTRIBUTE') ?? DEFAULT_NAME_ATTRIBUTE,
+		emailAttribute: val(env, 'LDAP_EMAIL_ATTRIBUTE') ?? DEFAULT_EMAIL_ATTRIBUTE,
+		allowedGroupDN: val(env, 'LDAP_ALLOWED_GROUP_DN'),
+		// rejectUnauthorized defaults to true; only an explicit "false" disables it.
+		tlsRejectUnauthorized: val(env, 'LDAP_TLS_REJECT_UNAUTHORIZED') !== 'false',
+		tlsCAPath: val(env, 'LDAP_TLS_CA_PATH'),
+		sessionSecret: sessionSecret!,
+		sessionMaxAgeSec
+	};
+}

--- a/src/lib/server/auth/errors.ts
+++ b/src/lib/server/auth/errors.ts
@@ -1,0 +1,60 @@
+// AD bind sub-error mapping. Active Directory reports authentication failures as
+// LDAP result 49 (invalidCredentials) with a "data <code>" token embedded in the
+// diagnostic message, e.g.
+//   "80090308: LdapErr: DSID-0C0903A9, comment: AcceptSecurityContext error, data 52e, v1db1"
+// we parse that token and map it to a user-facing message.
+//
+// 525 (no such user) and 52e (bad password) deliberately collapse to ONE generic
+// message so the login form cannot be used to enumerate valid usernames.
+//
+// sub-codes: https://learn.microsoft.com/en-us/troubleshoot/windows-server/active-directory/useraccountcontrol-manipulate-account-properties
+
+const AD_SUBCODE_RE = /data\s+([0-9a-f]{3,4})/i;
+const GENERIC_BAD_CREDENTIALS = 'Incorrect username or password.';
+const CONNECTION_FAILED = 'Cannot reach the directory server. Check the LDAP configuration.';
+const CONNECTION_HINT_RE =
+	/(econnrefused|enotfound|etimedout|timeout|socket|tls|ssl|certificate|self[- ]signed|getaddrinfo|connect)/i;
+
+function errorMessage(err: unknown): string {
+	if (!err) return '';
+	if (typeof err === 'string') return err;
+	if (err instanceof Error) return err.message;
+	if (typeof err === 'object') {
+		const o = err as Record<string, unknown>;
+		// ldapts errors carry .message; some AD diagnostics surface under lde_message
+		return String(o.message ?? o.lde_message ?? '');
+	}
+	return String(err);
+}
+
+export function extractAdSubCode(err: unknown): string | null {
+	const match = AD_SUBCODE_RE.exec(errorMessage(err));
+	return match ? match[1].toLowerCase() : null;
+}
+
+export function mapAdBindError(err: unknown): string {
+	switch (extractAdSubCode(err)) {
+		case '525': // user not found
+		case '52e': // invalid credentials
+			return GENERIC_BAD_CREDENTIALS;
+		case '530':
+			return 'Sign-in is not permitted at this time.';
+		case '531':
+			return 'Sign-in is not permitted from this workstation.';
+		case '532':
+			return 'Your password has expired. Contact your administrator.';
+		case '533':
+			return 'Your account is disabled. Contact your administrator.';
+		case '701':
+			return 'Your account has expired. Contact your administrator.';
+		case '773':
+			return 'You must reset your password before signing in.';
+		case '775':
+			return 'Your account is locked. Contact your administrator.';
+		default:
+			break;
+	}
+	// no AD sub-code: most likely a connection / TLS / timeout failure
+	if (CONNECTION_HINT_RE.test(errorMessage(err))) return CONNECTION_FAILED;
+	return 'Sign-in failed. Please try again.';
+}

--- a/src/lib/server/auth/ldap.ts
+++ b/src/lib/server/auth/ldap.ts
@@ -1,0 +1,193 @@
+// the ONLY module that talks to ldapts. service-account search-then-bind:
+//   1. bind as the read-only service account
+//   2. search for the user by their logon (escaped filter over the configured
+//      username attributes)
+//   3. bind AS the user with the supplied password to verify it
+//   4. optionally require membership (incl. nested groups) of an allow-list group
+//
+// ldapts is imported lazily via `await import('ldapts')` so it only loads on the
+// node login route, never in the client/edge bundles (and this module lives
+// under $lib/server, which SvelteKit forbids client code from importing at all).
+// node:fs reads the optional internal-CA PEM for LDAPS validation.
+
+import { readFileSync } from 'node:fs';
+import type { Client } from 'ldapts';
+import type { LdapConfig } from './config';
+import type { AuthResult, AuthenticatedUser } from './provider';
+import { normalizeUsername, buildUserSearchFilter, buildGroupMembershipFilter } from './normalize';
+import { mapAdBindError } from './errors';
+import { logger } from '$lib/log';
+
+const GENERIC_FAIL = 'Incorrect username or password.';
+const CONNECTION_FAIL = 'Cannot reach the directory server. Check the LDAP configuration.';
+const CLIENT_TIMEOUT_MS = 10_000;
+
+export async function authenticateAgainstLdap(
+	cfg: LdapConfig,
+	username: string,
+	password: string
+): Promise<AuthResult> {
+	// AD treats a bind with an empty password as an "unauthenticated bind" that
+	// SUCCEEDS, so an empty password must be rejected BEFORE any bind. otherwise
+	// anyone could sign in as any user by leaving the password blank.
+	if (!password) return { ok: false, message: GENERIC_FAIL };
+
+	const logon = normalizeUsername(username, {
+		usernameAttributes: cfg.usernameAttributes,
+		defaultDomain: cfg.defaultDomain
+	});
+	if (!logon) return { ok: false, message: GENERIC_FAIL };
+
+	let ClientCtor: typeof Client;
+	try {
+		({ Client: ClientCtor } = await import('ldapts'));
+	} catch (err) {
+		logger.error('ldap.module_missing', { error: errMsg(err) });
+		return { ok: false, message: 'LDAP support is not installed on this server.' };
+	}
+
+	const tlsOptions = buildTlsOptions(cfg);
+	const clientOpts = {
+		url: cfg.url,
+		timeout: CLIENT_TIMEOUT_MS,
+		connectTimeout: CLIENT_TIMEOUT_MS,
+		...(tlsOptions ? { tlsOptions } : {})
+	};
+
+	// phase 1: service bind + user search. userDN and user are assigned inside the
+	// try; the returning catch means reaching past it implies they were set.
+	const serviceClient = new ClientCtor(clientOpts);
+	let userDN: string;
+	let user: AuthenticatedUser;
+	try {
+		try {
+			await serviceClient.bind(cfg.bindDN, cfg.bindCredentials);
+		} catch (err) {
+			logger.error('ldap.service_bind_failed', { error: errMsg(err) });
+			return { ok: false, message: CONNECTION_FAIL };
+		}
+
+		const filter = buildUserSearchFilter(logon, cfg.usernameAttributes);
+		const { searchEntries } = await serviceClient.search(cfg.searchBase, {
+			scope: 'sub',
+			filter,
+			attributes: [
+				'distinguishedName',
+				cfg.nameAttribute,
+				cfg.emailAttribute,
+				'objectGUID',
+				'sAMAccountName',
+				'userPrincipalName'
+			],
+			sizeLimit: 2
+		});
+
+		// 0 = no such user; >1 = ambiguous. both collapse to the generic message
+		// so the form can't enumerate accounts.
+		if (searchEntries.length !== 1) return { ok: false, message: GENERIC_FAIL };
+
+		const entry = searchEntries[0];
+		userDN =
+			typeof entry.dn === 'string' && entry.dn ? entry.dn : firstString(entry.distinguishedName);
+		if (!userDN) return { ok: false, message: GENERIC_FAIL };
+
+		user = {
+			sub: stableSubject(entry, logon.value),
+			name:
+				firstString(entry[cfg.nameAttribute]) || firstString(entry.sAMAccountName) || logon.value,
+			email: firstString(entry[cfg.emailAttribute]),
+			groups: []
+		};
+	} catch (err) {
+		logger.error('ldap.search_failed', { error: errMsg(err) });
+		return { ok: false, message: 'Sign-in failed. Please try again.' };
+	} finally {
+		await safeUnbind(serviceClient);
+	}
+
+	// phase 2: bind AS the user to verify the password
+	const userClient = new ClientCtor(clientOpts);
+	try {
+		try {
+			await userClient.bind(userDN, password);
+		} catch (err) {
+			return { ok: false, message: mapAdBindError(err) };
+		}
+
+		// phase 3: optional group allow-list (nested via matching-rule-in-chain).
+		// checked AFTER password verification so a non-member who supplies a wrong
+		// password still only sees the generic credentials message.
+		if (cfg.allowedGroupDN) {
+			let inGroup = false;
+			try {
+				const { searchEntries } = await userClient.search(userDN, {
+					scope: 'base',
+					filter: buildGroupMembershipFilter(cfg.allowedGroupDN),
+					attributes: ['distinguishedName']
+				});
+				inGroup = searchEntries.length > 0;
+			} catch (err) {
+				logger.error('ldap.group_check_failed', { error: errMsg(err) });
+				return { ok: false, message: 'Sign-in failed during authorization. Please try again.' };
+			}
+			if (!inGroup) {
+				return { ok: false, message: 'You are not authorized to access this application.' };
+			}
+		}
+	} finally {
+		await safeUnbind(userClient);
+	}
+
+	return { ok: true, user };
+}
+
+function buildTlsOptions(
+	cfg: LdapConfig
+): { rejectUnauthorized: boolean; ca?: Buffer } | undefined {
+	const isLdaps = cfg.url.toLowerCase().startsWith('ldaps://');
+	if (!isLdaps && !cfg.tlsCAPath) return undefined;
+	const ca = cfg.tlsCAPath ? readCA(cfg.tlsCAPath) : undefined;
+	return { rejectUnauthorized: cfg.tlsRejectUnauthorized, ...(ca ? { ca } : {}) };
+}
+
+function readCA(path: string): Buffer | undefined {
+	try {
+		return readFileSync(path);
+	} catch (err) {
+		logger.error('ldap.ca_read_failed', { path, error: errMsg(err) });
+		return undefined;
+	}
+}
+
+// prefer the immutable objectGUID (binary) for a stable subject; fall back to a
+// lowercased text attribute. a string-decoded objectGUID is a lossy decode, so
+// only a Buffer/Uint8Array counts as a real GUID.
+function stableSubject(entry: Record<string, unknown>, fallback: string): string {
+	const raw = Array.isArray(entry.objectGUID) ? entry.objectGUID[0] : entry.objectGUID;
+	if (Buffer.isBuffer(raw)) return raw.toString('hex');
+	if (raw instanceof Uint8Array) return Buffer.from(raw).toString('hex');
+	return (
+		firstString(entry.userPrincipalName) ||
+		firstString(entry.sAMAccountName) ||
+		fallback
+	).toLowerCase();
+}
+
+function firstString(v: unknown): string {
+	if (Array.isArray(v)) return v.length > 0 ? firstString(v[0]) : '';
+	if (Buffer.isBuffer(v)) return v.toString('utf8');
+	if (typeof v === 'string') return v;
+	return v == null ? '' : String(v);
+}
+
+function errMsg(err: unknown): string {
+	return err instanceof Error ? err.message : String(err);
+}
+
+async function safeUnbind(client: Client): Promise<void> {
+	try {
+		await client.unbind();
+	} catch {
+		// unbind failures are non-fatal: the auth result is already decided.
+	}
+}

--- a/src/lib/server/auth/login-rate-limit.ts
+++ b/src/lib/server/auth/login-rate-limit.ts
@@ -1,0 +1,53 @@
+// per-IP failed-login lockout, mirroring api/analyze/rate-limiter.ts: in-memory
+// Map, throttled O(n) cleanup, dies with the instance. single-node self-host is
+// the target, so per-instance state is acceptable (documented). only FAILED
+// binds count toward the limit; a successful sign-in resets the counter.
+//
+// kept separate from the analyze rate-limiter so the scan hot path is untouched.
+
+const failures = new Map<string, { count: number; firstAt: number; lockedUntil: number }>();
+const MAX_FAILS = 5;
+const WINDOW_MS = 15 * 60_000; // rolling window in which failures accumulate
+const LOCKOUT_MS = 15 * 60_000; // lockout duration once MAX_FAILS is reached
+const MAX_MAP_SIZE = 10_000;
+const CLEANUP_INTERVAL_MS = 60_000;
+let lastCleanupAt = 0;
+
+export type LoginGate = { allowed: true } | { allowed: false; retryAfterSec: number };
+
+function cleanup(now: number): void {
+	if (failures.size <= MAX_MAP_SIZE || now - lastCleanupAt < CLEANUP_INTERVAL_MS) return;
+	for (const [ip, rec] of failures) {
+		if (now > rec.lockedUntil && now - rec.firstAt > WINDOW_MS) failures.delete(ip);
+	}
+	lastCleanupAt = now;
+}
+
+export function checkLoginRateLimit(ip: string): LoginGate {
+	const now = Date.now();
+	cleanup(now);
+	const rec = failures.get(ip);
+	if (rec && now < rec.lockedUntil) {
+		return { allowed: false, retryAfterSec: Math.ceil((rec.lockedUntil - now) / 1000) };
+	}
+	return { allowed: true };
+}
+
+export function recordLoginFailure(ip: string): void {
+	const now = Date.now();
+	const rec = failures.get(ip);
+	// start a fresh window if there's no record or the previous one has aged out
+	if (!rec || now - rec.firstAt > WINDOW_MS) {
+		failures.set(ip, { count: 1, firstAt: now, lockedUntil: 0 });
+		return;
+	}
+	rec.count += 1;
+	if (rec.count >= MAX_FAILS) rec.lockedUntil = now + LOCKOUT_MS;
+}
+
+export function resetLoginRateLimit(ip: string): void {
+	failures.delete(ip);
+}
+
+// exported so tests can drive the limiter without magic numbers
+export const LOGIN_RATE_LIMIT_CONFIG = { MAX_FAILS, WINDOW_MS, LOCKOUT_MS } as const;

--- a/src/lib/server/auth/normalize.ts
+++ b/src/lib/server/auth/normalize.ts
@@ -1,0 +1,99 @@
+// pure username normalization + LDAP search-filter building. no ldapts import,
+// so it unit-tests in isolation. Active Directory accepts three logon formats;
+// we normalize each to a lookup value and build an ESCAPED filter so a value
+// like "*)(uid=*" can neither broaden the search nor break out of the filter.
+//
+// escaping follows the LDAP search-filter special-character table from RFC 4515
+// and the Microsoft "Search Filter Syntax" doc:
+//   https://learn.microsoft.com/en-us/windows/win32/adsi/search-filter-syntax
+// and the OWASP LDAP Injection Prevention Cheat Sheet:
+//   https://cheatsheetseries.owasp.org/cheatsheets/LDAP_Injection_Prevention_Cheat_Sheet.html
+
+export interface NormalizedLogon {
+	format: 'upn' | 'downlevel' | 'bare';
+	// the resolved lookup value: domain stripped for down-level, UPN synthesized
+	// for bare + defaultDomain. callers escape this before putting it in a filter.
+	value: string;
+	raw: string;
+}
+
+// escape the five filter-breaking characters per RFC 4515: \ * ( ) and NUL.
+// applied to untrusted user input (the submitted username) before it enters a
+// search filter. char codes are used for NUL so the source stays printable.
+export function escapeFilterValue(value: string): string {
+	let out = '';
+	for (const ch of value) {
+		if (ch === '\\') out += '\\5c';
+		else if (ch === '*') out += '\\2a';
+		else if (ch === '(') out += '\\28';
+		else if (ch === ')') out += '\\29';
+		else if (ch.charCodeAt(0) === 0) out += '\\00';
+		else out += ch;
+	}
+	return out;
+}
+
+export function normalizeUsername(
+	input: string,
+	opts?: { usernameAttributes?: string[]; defaultDomain?: string }
+): NormalizedLogon | null {
+	const raw = (input ?? '').trim();
+	if (!raw) return null;
+	// defensive upper bound; a sane logon is never this long. also rejects
+	// payloads designed to blow up the directory server.
+	if (raw.length > 256) return null;
+	// reject embedded control characters (NUL, CR, LF, tab, etc.) outright.
+	for (const ch of raw) {
+		if (ch.charCodeAt(0) < 0x20) return null;
+	}
+
+	// UPN: user@domain.com -> match userPrincipalName
+	if (raw.includes('@')) {
+		const parts = raw.split('@');
+		if (parts.length !== 2 || !parts[0] || !parts[1]) return null;
+		return { format: 'upn', value: raw, raw };
+	}
+
+	// down-level: DOMAIN\sAMAccountName -> strip the domain, match sAMAccountName.
+	// single-forest assumption: the domain segment is informational; the user is
+	// located within searchBase.
+	if (raw.includes('\\')) {
+		const sam = raw.slice(raw.indexOf('\\') + 1);
+		if (!sam || sam.includes('\\')) return null;
+		return { format: 'downlevel', value: sam, raw };
+	}
+
+	// bare sAMAccountName, or synthesize a UPN when a default domain is configured.
+	if (opts?.defaultDomain) {
+		return { format: 'upn', value: `${raw}@${opts.defaultDomain}`, raw };
+	}
+	return { format: 'bare', value: raw, raw };
+}
+
+// build the user-lookup filter: match the (escaped) logon value against every
+// configured username attribute, OR'd together, scoped to user objects.
+export function buildUserSearchFilter(
+	logon: NormalizedLogon,
+	usernameAttributes: string[]
+): string {
+	const esc = escapeFilterValue(logon.value);
+	const attrs =
+		usernameAttributes.length > 0 ? usernameAttributes : ['sAMAccountName', 'userPrincipalName'];
+	const clauses = attrs.map((a) => `(${a}=${esc})`).join('');
+	const inner = attrs.length > 1 ? `(|${clauses})` : clauses;
+	return `(&(objectClass=user)${inner})`;
+}
+
+// membership test (incl. NESTED groups) via the matching-rule-in-chain OID
+// 1.2.840.113556.1.4.1941. per the Microsoft doc, set the search base to the
+// user's DN with scope 'base' and use this filter. spaces are NOT allowed
+// inside the rule string.
+//
+// groupDN is trusted admin config (LDAP_ALLOWED_GROUP_DN), so this only guards
+// against filter-breaking literals (e.g. a group named "App (Prod) Users").
+// backslashes are left intact so already-escaped DN components are not
+// double-encoded.
+export function buildGroupMembershipFilter(groupDN: string): string {
+	const safe = groupDN.replace(/\*/g, '\\2a').replace(/\(/g, '\\28').replace(/\)/g, '\\29');
+	return `(memberOf:1.2.840.113556.1.4.1941:=${safe})`;
+}

--- a/src/lib/server/auth/provider.ts
+++ b/src/lib/server/auth/provider.ts
@@ -1,0 +1,37 @@
+// pluggable server-side auth provider abstraction, mirroring the LLMProvider /
+// buildProviders() pattern in api/analyze/providers.ts. today only LDAP is
+// implemented; OIDC / SAML can be added as additional providers later without
+// changing any caller. importing this module is cheap: the heavy ldapts client
+// is loaded lazily inside the LDAP provider's authenticate() (see ./ldap), never
+// at module-eval time.
+
+import { resolveLdapConfig } from './config';
+import { authenticateAgainstLdap } from './ldap';
+
+export interface AuthenticatedUser {
+	sub: string; // stable id used as the session subject + history namespace key
+	name: string;
+	email: string;
+	groups: string[];
+}
+
+export type AuthResult = { ok: true; user: AuthenticatedUser } | { ok: false; message: string };
+
+export interface ServerAuthProvider {
+	id: 'ldap';
+	authenticate(username: string, password: string): Promise<AuthResult>;
+}
+
+// returns null when no server-auth provider is configured (inert signal, like an
+// unset OLLAMA_BASE_URL). throws LdapConfigError when LDAP_URL is set but the
+// config is incomplete (the caller fails closed).
+export function buildServerAuthProvider(
+	env: Record<string, string | undefined>
+): ServerAuthProvider | null {
+	const cfg = resolveLdapConfig(env);
+	if (!cfg) return null;
+	return {
+		id: 'ldap',
+		authenticate: (username, password) => authenticateAgainstLdap(cfg, username, password)
+	};
+}

--- a/src/lib/server/auth/session.ts
+++ b/src/lib/server/auth/session.ts
@@ -1,0 +1,144 @@
+// stateless session cookie signed with HMAC-SHA256 via the Web Crypto API
+// (globalThis.crypto.subtle), which is available in every runtime SvelteKit
+// targets (node serverless, edge, workerd). using Web Crypto rather than
+// node:crypto keeps hooks.server.ts free of node built-ins, so the long-standing
+// "no node built-ins in hooks" invariant (it could be bundled for edge) holds.
+//
+// there is NO server-side session store: the signed payload IS the session.
+// it survives restarts/deploys and needs no shared state on multi-instance
+// setups. rotating SESSION_SECRET invalidates every outstanding session.
+// the token is `base64url(JSON payload).base64url(HMAC)`.
+
+export const SESSION_COOKIE = 'ats_session';
+
+export interface SessionPayload {
+	sub: string; // stable user id (objectGUID hex, or a logon attribute fallback)
+	name: string;
+	email: string;
+	groups: string[];
+	iat: number; // issued-at (epoch seconds)
+	exp: number; // expiry (epoch seconds)
+}
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+function bytesToBase64Url(bytes: Uint8Array): string {
+	let binary = '';
+	for (const b of bytes) binary += String.fromCharCode(b);
+	return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function stringToBase64Url(s: string): string {
+	return bytesToBase64Url(encoder.encode(s));
+}
+
+function base64UrlToBytes(s: string): Uint8Array {
+	const padded = s.length % 4 === 0 ? s : s + '='.repeat(4 - (s.length % 4));
+	const binary = atob(padded.replace(/-/g, '+').replace(/_/g, '/'));
+	const out = new Uint8Array(binary.length);
+	for (let i = 0; i < binary.length; i++) out[i] = binary.charCodeAt(i);
+	return out;
+}
+
+async function importHmacKey(secret: string): Promise<CryptoKey> {
+	return crypto.subtle.importKey(
+		'raw',
+		encoder.encode(secret),
+		{ name: 'HMAC', hash: 'SHA-256' },
+		false,
+		['sign', 'verify']
+	);
+}
+
+export async function signSession(payload: SessionPayload, secret: string): Promise<string> {
+	if (!secret) throw new Error('a session secret is required to sign a session');
+	const body = stringToBase64Url(JSON.stringify(payload));
+	const key = await importHmacKey(secret);
+	const sig = await crypto.subtle.sign('HMAC', key, encoder.encode(body));
+	return `${body}.${bytesToBase64Url(new Uint8Array(sig))}`;
+}
+
+// returns the payload only if the signature verifies AND the token has not
+// expired. crypto.subtle.verify is constant-time, so no manual comparison.
+export async function verifySession(token: string, secret: string): Promise<SessionPayload | null> {
+	if (!token || !secret) return null;
+	const dot = token.indexOf('.');
+	if (dot <= 0 || dot >= token.length - 1) return null;
+
+	const body = token.slice(0, dot);
+	const sigPart = token.slice(dot + 1);
+
+	let signature: Uint8Array;
+	try {
+		signature = base64UrlToBytes(sigPart);
+	} catch {
+		return null;
+	}
+
+	let verified: boolean;
+	try {
+		const key = await importHmacKey(secret);
+		// cast to BufferSource: TS 5.7's lib types the param as
+		// ArrayBufferView<ArrayBuffer>, but a decoded Uint8Array is structurally a
+		// valid BufferSource at runtime.
+		verified = await crypto.subtle.verify(
+			'HMAC',
+			key,
+			signature as BufferSource,
+			encoder.encode(body)
+		);
+	} catch {
+		return null;
+	}
+	if (!verified) return null;
+
+	let payload: unknown;
+	try {
+		payload = JSON.parse(decoder.decode(base64UrlToBytes(body)));
+	} catch {
+		return null;
+	}
+	if (!isSessionPayload(payload)) return null;
+	if (payload.exp <= Math.floor(Date.now() / 1000)) return null;
+
+	return payload;
+}
+
+function isSessionPayload(v: unknown): v is SessionPayload {
+	if (typeof v !== 'object' || v === null) return false;
+	const p = v as Record<string, unknown>;
+	return (
+		typeof p.sub === 'string' &&
+		typeof p.name === 'string' &&
+		typeof p.email === 'string' &&
+		Array.isArray(p.groups) &&
+		typeof p.iat === 'number' &&
+		typeof p.exp === 'number'
+	);
+}
+
+export function makeSessionPayload(
+	user: { sub: string; name: string; email: string; groups: string[] },
+	maxAgeSec: number,
+	nowSec: number = Math.floor(Date.now() / 1000)
+): SessionPayload {
+	return {
+		sub: user.sub,
+		name: user.name,
+		email: user.email,
+		groups: user.groups,
+		iat: nowSec,
+		exp: nowSec + maxAgeSec
+	};
+}
+
+export function sessionCookieOptions(maxAgeSec: number, secure: boolean) {
+	return {
+		httpOnly: true as const,
+		secure,
+		sameSite: 'lax' as const,
+		path: '/',
+		maxAge: maxAgeSec
+	};
+}

--- a/src/lib/server/csp.ts
+++ b/src/lib/server/csp.ts
@@ -1,0 +1,37 @@
+// Content-Security-Policy builder. pure (no env, no node built-ins) so it stays
+// edge-safe for hooks.server.ts and unit-testable in isolation.
+//
+// the firebase / google-auth origins are only needed when firebase auth is the
+// active mode. a self-hoster who runs without firebase (the ldap or anonymous
+// modes) gets a CSP with NO firebase references at all, so the directory-only
+// deployment never advertises or reports firebase hosts (closes #13). google
+// fonts stay in every mode because the Geist typeface loads from there
+// regardless of auth.
+
+const FIREBASE_CONNECT_SRC = [
+	'https://*.googleapis.com',
+	'https://*.firebaseio.com',
+	'https://*.firebaseapp.com',
+	'https://*.firebase.com'
+];
+const FIREBASE_FRAME_SRC = ['https://*.firebaseapp.com', 'https://accounts.google.com'];
+
+export function buildContentSecurityPolicy(allowFirebase: boolean): string {
+	const connectSrc = ["'self'", ...(allowFirebase ? FIREBASE_CONNECT_SRC : [])];
+	const frameSrc = ["'self'", ...(allowFirebase ? FIREBASE_FRAME_SRC : [])];
+
+	return [
+		"default-src 'self'",
+		"script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+		"style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+		"font-src 'self' https://fonts.gstatic.com",
+		"img-src 'self' data: https:",
+		`connect-src ${connectSrc.join(' ')}`,
+		`frame-src ${frameSrc.join(' ')}`,
+		"worker-src 'self' blob:",
+		"object-src 'none'",
+		"base-uri 'self'",
+		"form-action 'self'",
+		'report-uri /api/csp-report'
+	].join('; ');
+}

--- a/src/lib/stores/auth.svelte.ts
+++ b/src/lib/stores/auth.svelte.ts
@@ -3,31 +3,74 @@ import type { User } from 'firebase/auth';
 import { firebaseConfigured, getFirebase } from '$lib/firebase';
 import { logger } from '$lib/log';
 
+// three mutually-exclusive auth modes, resolved server-side and surfaced via the
+// root +layout.server.ts (see resolveAuthMode in $lib/server/auth/config). the
+// type is duplicated here (not imported) because that module is server-only.
+type AuthMode = 'ldap' | 'firebase' | 'none';
+
+// the ldap session user shape mirrors App.Locals['user'] in app.d.ts.
+interface LdapSessionUser {
+	sub: string;
+	name: string;
+	email: string;
+	groups: string[];
+}
+
 class AuthStore {
+	// firebase user (firebase mode only); ldapUser (ldap mode only). kept separate
+	// so the firebase code path is byte-for-byte unchanged.
 	user = $state<User | null>(null);
+	ldapUser = $state<LdapSessionUser | null>(null);
 	loading = $state(true);
 	error = $state<string | null>(null);
 
-	// self-host mode: when firebase is not configured the store reports
-	// `disabled = true`, never attempts a network call, and the rest of the
-	// app treats the user as having full access (no auth gate, no firestore).
-	// hosted production with firebase set up sees `disabled = false` and
-	// the existing behaviour is unchanged.
-	readonly disabled: boolean = !firebaseConfigured;
+	// the active auth mode. seeded from firebaseConfigured in the constructor so
+	// first paint matches the pre-feature behaviour exactly, then upgraded to
+	// 'ldap' by hydrateFromServer() when the server says so (ldap is server-only
+	// knowledge the client can't see at construction time).
+	mode = $state<AuthMode>('none');
+
+	// self-host 'none' mode reports disabled = true: no auth gate, no firestore,
+	// anonymous localStorage history. firebase and ldap both report false.
+	// preserved as a getter so every existing `authStore.disabled` reader keeps
+	// working unchanged.
+	get disabled(): boolean {
+		return this.mode === 'none';
+	}
+
+	// true when the app should require sign-in (firebase OR ldap). the inverse of
+	// disabled; used by the navbar auth slot and the scanner gate.
+	get requiresAuth(): boolean {
+		return this.mode !== 'none';
+	}
+
+	// stable subject for the signed-in ldap user (objectGUID), used to namespace
+	// localStorage scan history per AD user. null outside ldap mode.
+	get ldapSub(): string | null {
+		return this.mode === 'ldap' ? (this.ldapUser?.sub ?? null) : null;
+	}
 
 	get isAuthenticated(): boolean {
+		if (this.mode === 'ldap') return this.ldapUser !== null;
+		if (this.mode === 'none') return false;
 		return this.user !== null;
 	}
 
 	get displayName(): string {
+		if (this.mode === 'ldap') {
+			return this.ldapUser?.name ?? this.ldapUser?.email?.split('@')[0] ?? '';
+		}
 		return this.user?.displayName ?? this.user?.email?.split('@')[0] ?? '';
 	}
 
 	get photoURL(): string | null {
+		// ldap users have no avatar; UserMenu falls back to initials.
+		if (this.mode === 'ldap') return null;
 		return this.user?.photoURL ?? null;
 	}
 
 	get email(): string {
+		if (this.mode === 'ldap') return this.ldapUser?.email ?? '';
 		return this.user?.email ?? '';
 	}
 
@@ -40,15 +83,16 @@ class AuthStore {
 	}
 
 	constructor() {
+		// ldap is server-only knowledge, so at construction we only know firebase
+		// vs none. hydrateFromServer() upgrades to 'ldap' once the layout data lands.
+		this.mode = firebaseConfigured ? 'firebase' : 'none';
 		if (browser) {
-			// self-host mode short-circuits the firebase listener entirely. flip
-			// loading off so the auth gate render path completes, and leave
-			// user=null. the disabled getter is read directly downstream;
-			// canScan returns true because disabled is true.
-			if (this.disabled) {
-				this.loading = false;
-			} else {
+			if (this.mode === 'firebase') {
 				void this.setupAuthListener();
+			} else {
+				// none mode (and the pre-hydration state of ldap) has no client
+				// listener. flip loading off so the render path completes.
+				this.loading = false;
 			}
 		}
 		// on SSR, loading stays true so the server renders the loading spinner.
@@ -58,6 +102,18 @@ class AuthStore {
 		// the hydration_mismatch warning that occurred when SSR rendered the
 		// auth-gate (loading=false, user=null) while the client rendered the
 		// loading spinner (loading=true).
+	}
+
+	// bridge the root +layout.server.ts data into the singleton. called from
+	// +layout.svelte on both SSR and client so the resolved mode + ldap user are
+	// reflected before first paint. idempotent. firebase/none modes leave the
+	// firebase listener (and its loading/user) untouched.
+	hydrateFromServer(data: { authMode: AuthMode; user: LdapSessionUser | null }): void {
+		this.mode = data.authMode;
+		if (data.authMode === 'ldap') {
+			this.ldapUser = data.user;
+			this.loading = false;
+		}
 	}
 
 	private async setupAuthListener() {
@@ -172,6 +228,19 @@ class AuthStore {
 
 	async signOut() {
 		this.error = null;
+		// ldap: clear the server session cookie, then drop the local user so the
+		// UI updates immediately. the caller (UserMenu) navigates afterwards.
+		if (this.mode === 'ldap') {
+			try {
+				await fetch('/logout', { method: 'POST' });
+			} catch (err) {
+				logger.warn('auth.ldap_logout_failed', {
+					error: err instanceof Error ? err.message : String(err)
+				});
+			}
+			this.ldapUser = null;
+			return;
+		}
 		const { auth } = await getFirebase();
 		const { signOut: firebaseSignOut } = await import('firebase/auth');
 		try {

--- a/src/lib/stores/auth.svelte.ts
+++ b/src/lib/stores/auth.svelte.ts
@@ -109,11 +109,20 @@ class AuthStore {
 	// reflected before first paint. idempotent. firebase/none modes leave the
 	// firebase listener (and its loading/user) untouched.
 	hydrateFromServer(data: { authMode: AuthMode; user: LdapSessionUser | null }): void {
+		// browser-only: never write per-request server data into this module-level
+		// singleton during SSR, or one request's identity could bleed into another
+		// request's rendered html. on the server the store stays at its constructor
+		// defaults and the client hydrates after mount; the firebase dns-prefetch
+		// gate still works because the constructor seeds `mode` from firebaseConfigured.
+		if (!browser) return;
 		this.mode = data.authMode;
-		if (data.authMode === 'ldap') {
-			this.ldapUser = data.user;
-			this.loading = false;
-		}
+		// always clear ldapUser outside the ldap branch so no stale identity
+		// survives a mode transition (the getters guard on mode anyway).
+		this.ldapUser = data.authMode === 'ldap' ? data.user : null;
+		// ldap/none have no async listener, so resolve loading here. firebase
+		// leaves loading to onAuthStateChanged (flipping it early would flash the
+		// Sign In button before a logged-in user's session resolves).
+		if (data.authMode !== 'firebase') this.loading = false;
 	}
 
 	private async setupAuthListener() {

--- a/src/lib/stores/scores.svelte.ts
+++ b/src/lib/stores/scores.svelte.ts
@@ -18,10 +18,21 @@ const MAX_HISTORY = 5;
 // fit per `jd-library.svelte.ts` precedent and best-practice guidance.
 const LOCAL_HISTORY_KEY = 'ats_local_scan_history_v1';
 
+// in ldap self-host mode the local bucket is namespaced by the signed-in AD
+// user's stable subject (objectGUID) so two users sharing a browser don't see
+// each other's history. anonymous 'none' mode keeps the bare legacy key, so the
+// existing self-host behaviour (and any stored data) is untouched.
+function localHistoryKey(): string {
+	if (authStore.mode === 'ldap' && authStore.ldapSub) {
+		return `${LOCAL_HISTORY_KEY}__${authStore.ldapSub}`;
+	}
+	return LOCAL_HISTORY_KEY;
+}
+
 function readLocalHistory(): ScanHistoryEntry[] {
 	if (!browser) return [];
 	try {
-		const raw = localStorage.getItem(LOCAL_HISTORY_KEY);
+		const raw = localStorage.getItem(localHistoryKey());
 		if (!raw) return [];
 		const parsed = JSON.parse(raw);
 		return Array.isArray(parsed) ? parsed : [];
@@ -36,7 +47,7 @@ function readLocalHistory(): ScanHistoryEntry[] {
 function writeLocalHistory(entries: ScanHistoryEntry[]): void {
 	if (!browser) return;
 	try {
-		localStorage.setItem(LOCAL_HISTORY_KEY, JSON.stringify(entries));
+		localStorage.setItem(localHistoryKey(), JSON.stringify(entries));
 	} catch (err) {
 		// quota exceeded or storage disabled (incognito, sandboxed iframes).
 		// in-memory history still works for the current session, we just
@@ -50,7 +61,7 @@ function writeLocalHistory(entries: ScanHistoryEntry[]): void {
 function clearLocalHistory(): void {
 	if (!browser) return;
 	try {
-		localStorage.removeItem(LOCAL_HISTORY_KEY);
+		localStorage.removeItem(localHistoryKey());
 	} catch {
 		// removeItem rarely throws but defend against pathological storage.
 	}

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -1,0 +1,15 @@
+import type { LayoutServerLoad } from './$types';
+import { env } from '$env/dynamic/private';
+import { env as publicEnv } from '$env/dynamic/public';
+import { resolveAuthMode } from '$lib/server/auth/config';
+
+// surface the resolved auth mode + the server-validated user (ldap mode only)
+// to the whole client tree. in firebase/none mode `user` is null and the client
+// ignores it: firebase keeps using its client SDK, none stays anonymous. nothing
+// in the app is prerendered, so reading locals here introduces no build conflict.
+export const load: LayoutServerLoad = async ({ locals }) => {
+	return {
+		authMode: resolveAuthMode({ ...env, ...publicEnv }),
+		user: locals.user
+	};
+};

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,12 +1,23 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
+	import { onMount, untrack } from 'svelte';
 	import '../app.css';
 	import Navbar from '$components/ui/Navbar.svelte';
+	import { authStore } from '$stores/auth.svelte';
 	import { installErrorReporter } from '$lib/error-reporter';
 	import { installWebVitals } from '$lib/web-vitals';
 	import { logger } from '$lib/log';
 
-	let { children } = $props();
+	let { children, data } = $props();
+
+	// bridge the server-resolved auth mode + ldap user into the auth store. the
+	// untracked call runs on SSR and on first client paint so SSR and hydration
+	// render the same auth state (no flash / hydration mismatch); the $effect
+	// keeps it in sync across client navigations. inert for firebase/none modes
+	// (re-confirms the mode the constructor already set).
+	untrack(() => authStore.hydrateFromServer(data));
+	$effect(() => {
+		authStore.hydrateFromServer(data);
+	});
 
 	// install the sampled client-side error reporter and the web-vitals
 	// collector once per page lifetime. both run in the browser only; ssr
@@ -36,6 +47,17 @@
 
 <svelte:head>
 	<title>ATS Screener</title>
+	{#if authStore.mode === 'firebase'}
+		<!-- dns-prefetch for firebase auth hosts, emitted only when firebase is the
+		     active auth mode so a self-host without firebase never resolves these.
+		     lighter than preconnect: warms DNS for visitors who end up signing in,
+		     without the TLS-handshake cost for those who never do. -->
+		<link rel="dns-prefetch" href="//accounts.google.com" />
+		<link rel="dns-prefetch" href="//apis.google.com" />
+		<link rel="dns-prefetch" href="//securetoken.googleapis.com" />
+		<link rel="dns-prefetch" href="//identitytoolkit.googleapis.com" />
+		<link rel="dns-prefetch" href="//firestore.googleapis.com" />
+	{/if}
 </svelte:head>
 
 <!--

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { onMount, untrack } from 'svelte';
+	import { onMount } from 'svelte';
 	import '../app.css';
 	import Navbar from '$components/ui/Navbar.svelte';
 	import { authStore } from '$stores/auth.svelte';
@@ -9,12 +9,11 @@
 
 	let { children, data } = $props();
 
-	// bridge the server-resolved auth mode + ldap user into the auth store. the
-	// untracked call runs on SSR and on first client paint so SSR and hydration
-	// render the same auth state (no flash / hydration mismatch); the $effect
-	// keeps it in sync across client navigations. inert for firebase/none modes
-	// (re-confirms the mode the constructor already set).
-	untrack(() => authStore.hydrateFromServer(data));
+	// bridge the server-resolved auth mode + ldap user into the auth store on the
+	// CLIENT only. hydrateFromServer is a no-op during SSR by design: writing
+	// per-request user data into a module-level singleton on the server could leak
+	// one request's identity into another's html. the $effect re-runs on client
+	// navigation; SSR renders from the store's constructor defaults.
 	$effect(() => {
 		authStore.hydrateFromServer(data);
 	});

--- a/src/routes/api/analyze/+server.ts
+++ b/src/routes/api/analyze/+server.ts
@@ -6,6 +6,7 @@ import { logger } from '$lib/log';
 import { hashPrompt, getCached, setCached } from './cache';
 import { checkRateLimit } from './rate-limiter';
 import { buildProviders } from './providers';
+import { resolveAuthMode } from '$lib/server/auth/config';
 
 // tries each provider in sequence until one succeeds and returns valid JSON
 async function callLLM(
@@ -111,7 +112,15 @@ interface RequestBody {
 	jobDescription?: string;
 }
 
-export const POST: RequestHandler = async ({ request }) => {
+export const POST: RequestHandler = async ({ request, locals }) => {
+	// in ldap self-host mode the scanner sits behind a login, so the analyze API
+	// requires a valid session too (defense in depth). public and unchanged in
+	// the hosted firebase deploy and anonymous self-host (resolveAuthMode is
+	// 'ldap' only when LDAP_URL is set, which neither of those configures).
+	if (resolveAuthMode(env) === 'ldap' && !locals.user) {
+		return json({ error: 'authentication required' }, { status: 401 });
+	}
+
 	// collect provider config from SvelteKit $env. OLLAMA_BASE_URL is the
 	// presence signal for the local-Ollama path; OLLAMA_MODEL is read inside
 	// buildProviders() and defaults to llama3.2 when unset; OLLAMA_API_KEY is

--- a/src/routes/history/+page.server.ts
+++ b/src/routes/history/+page.server.ts
@@ -1,0 +1,15 @@
+import type { PageServerLoad } from './$types';
+import { redirect } from '@sveltejs/kit';
+import { env } from '$env/dynamic/private';
+import { env as publicEnv } from '$env/dynamic/public';
+import { resolveAuthMode } from '$lib/server/auth/config';
+
+// server-side guard for ldap self-host mode: unauthenticated visitors are sent
+// to /login before the page renders. no-op in firebase/none mode (history there
+// is client-gated exactly as before).
+export const load: PageServerLoad = async ({ locals }) => {
+	if (resolveAuthMode({ ...env, ...publicEnv }) === 'ldap' && !locals.user) {
+		throw redirect(303, '/login');
+	}
+	return {};
+};

--- a/src/routes/login/+page.server.ts
+++ b/src/routes/login/+page.server.ts
@@ -69,11 +69,14 @@ export const actions: Actions = {
 			makeSessionPayload(result.user, cfg.sessionMaxAgeSec),
 			cfg.sessionSecret
 		);
-		cookies.set(
-			SESSION_COOKIE,
-			token,
-			sessionCookieOptions(cfg.sessionMaxAgeSec, url.protocol === 'https:')
-		);
+		// mark the cookie Secure when the *original* request was https. behind a
+		// TLS-terminating reverse proxy (the common ad self-host topology) the
+		// internal request is http, so prefer x-forwarded-proto and fall back to
+		// url.protocol for a direct connection. (the AD guide also documents
+		// setting the adapter's proxy-trust env vars.)
+		const forwardedProto = request.headers.get('x-forwarded-proto')?.split(',')[0]?.trim();
+		const secure = forwardedProto ? forwardedProto === 'https' : url.protocol === 'https:';
+		cookies.set(SESSION_COOKIE, token, sessionCookieOptions(cfg.sessionMaxAgeSec, secure));
 		logger.info('ldap.login_success', { sub: result.user.sub });
 		throw redirect(303, '/scanner');
 	}

--- a/src/routes/login/+page.server.ts
+++ b/src/routes/login/+page.server.ts
@@ -1,0 +1,80 @@
+import type { Actions } from './$types';
+import { fail, redirect } from '@sveltejs/kit';
+import { env } from '$env/dynamic/private';
+import { env as publicEnv } from '$env/dynamic/public';
+import { resolveAuthMode, resolveLdapConfig } from '$lib/server/auth/config';
+import { buildServerAuthProvider } from '$lib/server/auth/provider';
+import {
+	signSession,
+	makeSessionPayload,
+	sessionCookieOptions,
+	SESSION_COOKIE
+} from '$lib/server/auth/session';
+import {
+	checkLoginRateLimit,
+	recordLoginFailure,
+	resetLoginRateLimit
+} from '$lib/server/auth/login-rate-limit';
+import { logger } from '$lib/log';
+
+// the LDAP sign-in action. firebase/none sign-in is client-side, so a POST here
+// in those modes just bounces to the scanner. SvelteKit's built-in form-action
+// origin check (csrf.checkOrigin, default true) covers CSRF.
+export const actions: Actions = {
+	default: async ({ request, cookies, getClientAddress, url }) => {
+		const merged = { ...env, ...publicEnv };
+		if (resolveAuthMode(merged) !== 'ldap') throw redirect(303, '/scanner');
+
+		const ip = getClientAddress();
+		const gate = checkLoginRateLimit(ip);
+		if (!gate.allowed) {
+			return fail(429, {
+				message: `Too many attempts. Try again in ${gate.retryAfterSec}s.`,
+				username: ''
+			});
+		}
+
+		const form = await request.formData();
+		const username = String(form.get('username') ?? '').trim();
+		const password = String(form.get('password') ?? '');
+		if (!username || !password) {
+			return fail(400, { message: 'Enter your username and password.', username });
+		}
+
+		let provider;
+		try {
+			provider = buildServerAuthProvider(merged);
+		} catch (err) {
+			// resolveLdapConfig throws on misconfig (missing companion var / weak
+			// secret). fail closed with a server-side log; don't leak details.
+			logger.error('ldap.misconfigured', {
+				error: err instanceof Error ? err.message : String(err)
+			});
+			return fail(500, {
+				message: 'Server authentication is misconfigured. Contact your administrator.',
+				username
+			});
+		}
+		if (!provider) throw redirect(303, '/scanner');
+
+		const result = await provider.authenticate(username, password);
+		if (!result.ok) {
+			recordLoginFailure(ip);
+			return fail(401, { message: result.message, username });
+		}
+
+		resetLoginRateLimit(ip);
+		const cfg = resolveLdapConfig(merged)!;
+		const token = await signSession(
+			makeSessionPayload(result.user, cfg.sessionMaxAgeSec),
+			cfg.sessionSecret
+		);
+		cookies.set(
+			SESSION_COOKIE,
+			token,
+			sessionCookieOptions(cfg.sessionMaxAgeSec, url.protocol === 'https:')
+		);
+		logger.info('ldap.login_success', { sub: result.user.sub });
+		throw redirect(303, '/scanner');
+	}
+};

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -1,7 +1,18 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
+	import { enhance } from '$app/forms';
 	import { authStore } from '$stores/auth.svelte';
 	import SeoHead from '$components/seo/SeoHead.svelte';
+	import type { PageData, ActionData } from './$types';
+
+	// data.authMode comes from the root +layout.server.ts. firebase mode keeps the
+	// existing client-side firebase UI; ldap mode renders the AD username/password
+	// form that posts to the +page.server.ts action. `form` carries action errors.
+	let { data, form }: { data: PageData; form: ActionData } = $props();
+
+	// ldap submit state, driven by the enhance lifecycle (the firebase paths use
+	// their own `submitting` below).
+	let ldapSubmitting = $state(false);
 
 	let mode = $state<'signin' | 'signup'>('signin');
 	let email = $state('');
@@ -87,205 +98,262 @@
 
 <div class="login-page">
 	<div class="login-card">
-		<!-- header -->
-		<div class="card-header">
-			<h1 class="card-title">
-				{#if showReset}
-					Reset Password
-				{:else if signupDone}
-					You're In!
-				{:else if mode === 'signin'}
-					Welcome Back
-				{:else}
-					Create Account
-				{/if}
-			</h1>
-			<p class="card-subtitle">
-				{#if showReset}
-					Enter your email to receive a password reset link.
-				{:else if signupDone}
-					Check your email to verify your account.
-				{:else if mode === 'signin'}
-					Sign in to scan your resume across 6 ATS platforms.
-				{:else}
-					Create a free account to get started.
-				{/if}
-			</p>
-		</div>
-
-		{#if authStore.error}
-			<div class="error-banner">{authStore.error}</div>
-		{/if}
-
-		{#if showReset}
-			<!-- password reset form -->
-			<div class="form-body">
-				{#if resetSent}
-					<div class="success-banner">Password reset email sent! Check your inbox.</div>
-					<p class="spam-hint">Don't see it? Check your spam or junk folder.</p>
-					<button
-						class="link-btn"
-						onclick={() => {
-							showReset = false;
-							resetSent = false;
-							authStore.clearError();
-						}}
-					>
-						Back to sign in
-					</button>
-				{:else}
-					<form
-						onsubmit={(e) => {
-							e.preventDefault();
-							handlePasswordReset();
-						}}
-					>
-						<label class="field">
-							<span class="field-label">Email</span>
-							<input
-								type="email"
-								bind:value={resetEmail}
-								placeholder="you@example.com"
-								required
-								class="field-input"
-							/>
-						</label>
-						<button type="submit" class="submit-btn" disabled={submitting}>
-							Send Reset Link
-						</button>
-					</form>
-					<button
-						class="link-btn"
-						onclick={() => {
-							showReset = false;
-							authStore.clearError();
-						}}
-					>
-						Back to sign in
-					</button>
-				{/if}
-			</div>
-		{:else if signupDone}
-			<!-- signup success: verification email sent -->
-			<div class="form-body">
-				<div class="success-banner">
-					Account created! We sent a verification email to <strong>{email}</strong>.
-				</div>
-				<p class="spam-hint">Don't see it? Check your spam or junk folder.</p>
-				<button class="submit-btn" onclick={() => goto('/scanner')}> Continue to Scanner </button>
-			</div>
-		{:else}
-			<!-- mode tabs -->
-			<div class="mode-tabs">
-				<button
-					class="mode-tab"
-					class:active={mode === 'signin'}
-					onclick={() => {
-						mode = 'signin';
-						authStore.clearError();
-					}}
-				>
-					Sign In
-				</button>
-				<button
-					class="mode-tab"
-					class:active={mode === 'signup'}
-					onclick={() => {
-						mode = 'signup';
-						authStore.clearError();
-					}}
-				>
-					Create Account
-				</button>
+		{#if data.authMode === 'ldap'}
+			<!-- active directory / ldap sign-in (self-host). posts to the
+			     +page.server.ts action; progressively enhanced. -->
+			<div class="card-header">
+				<h1 class="card-title">Sign In</h1>
+				<p class="card-subtitle">Sign in with your organization (Active Directory) account.</p>
 			</div>
 
-			<!-- google sign-in -->
-			<button class="google-btn" onclick={handleGoogle} disabled={submitting}>
-				<svg width="18" height="18" viewBox="0 0 24 24">
-					<path
-						d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
-						fill="#4285F4"
-					/>
-					<path
-						d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
-						fill="#34A853"
-					/>
-					<path
-						d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
-						fill="#FBBC05"
-					/>
-					<path
-						d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
-						fill="#EA4335"
-					/>
-				</svg>
-				Continue with Google
-			</button>
+			{#if form?.message}
+				<div class="error-banner">{form.message}</div>
+			{/if}
 
-			<div class="divider">
-				<span>or</span>
-			</div>
-
-			<!-- email/password form -->
-			<form class="form-body" onsubmit={handleSubmit}>
-				{#if mode === 'signup'}
-					<label class="field">
-						<span class="field-label">Name</span>
-						<input
-							type="text"
-							bind:value={displayName}
-							placeholder="Your name"
-							maxlength="80"
-							autocomplete="name"
-							class="field-input"
-						/>
-					</label>
-				{/if}
-
+			<form
+				class="form-body"
+				method="POST"
+				use:enhance={() => {
+					ldapSubmitting = true;
+					return async ({ update }) => {
+						await update();
+						ldapSubmitting = false;
+					};
+				}}
+			>
 				<label class="field">
-					<span class="field-label">Email</span>
+					<span class="field-label">Username</span>
 					<input
-						type="email"
-						bind:value={email}
-						placeholder="you@example.com"
+						type="text"
+						name="username"
+						value={form?.username ?? ''}
+						placeholder={'DOMAIN\\username or you@domain.com'}
 						required
+						autocomplete="username"
+						autocapitalize="none"
+						spellcheck="false"
 						class="field-input"
 					/>
 				</label>
-
 				<label class="field">
 					<span class="field-label">Password</span>
 					<input
 						type="password"
-						bind:value={password}
-						placeholder={mode === 'signup' ? 'At least 6 characters' : 'Your password'}
+						name="password"
+						placeholder="Your password"
 						required
-						minlength={6}
+						autocomplete="current-password"
 						class="field-input"
 					/>
 				</label>
+				<button type="submit" class="submit-btn" disabled={ldapSubmitting}>
+					{#if ldapSubmitting}
+						<span class="spinner"></span>
+					{/if}
+					Sign In
+				</button>
+			</form>
+		{:else}
+			<!-- header -->
+			<div class="card-header">
+				<h1 class="card-title">
+					{#if showReset}
+						Reset Password
+					{:else if signupDone}
+						You're In!
+					{:else if mode === 'signin'}
+						Welcome Back
+					{:else}
+						Create Account
+					{/if}
+				</h1>
+				<p class="card-subtitle">
+					{#if showReset}
+						Enter your email to receive a password reset link.
+					{:else if signupDone}
+						Check your email to verify your account.
+					{:else if mode === 'signin'}
+						Sign in to scan your resume across 6 ATS platforms.
+					{:else}
+						Create a free account to get started.
+					{/if}
+				</p>
+			</div>
 
-				{#if mode === 'signin'}
+			{#if authStore.error}
+				<div class="error-banner">{authStore.error}</div>
+			{/if}
+
+			{#if showReset}
+				<!-- password reset form -->
+				<div class="form-body">
+					{#if resetSent}
+						<div class="success-banner">Password reset email sent! Check your inbox.</div>
+						<p class="spam-hint">Don't see it? Check your spam or junk folder.</p>
+						<button
+							class="link-btn"
+							onclick={() => {
+								showReset = false;
+								resetSent = false;
+								authStore.clearError();
+							}}
+						>
+							Back to sign in
+						</button>
+					{:else}
+						<form
+							onsubmit={(e) => {
+								e.preventDefault();
+								handlePasswordReset();
+							}}
+						>
+							<label class="field">
+								<span class="field-label">Email</span>
+								<input
+									type="email"
+									bind:value={resetEmail}
+									placeholder="you@example.com"
+									required
+									class="field-input"
+								/>
+							</label>
+							<button type="submit" class="submit-btn" disabled={submitting}>
+								Send Reset Link
+							</button>
+						</form>
+						<button
+							class="link-btn"
+							onclick={() => {
+								showReset = false;
+								authStore.clearError();
+							}}
+						>
+							Back to sign in
+						</button>
+					{/if}
+				</div>
+			{:else if signupDone}
+				<!-- signup success: verification email sent -->
+				<div class="form-body">
+					<div class="success-banner">
+						Account created! We sent a verification email to <strong>{email}</strong>.
+					</div>
+					<p class="spam-hint">Don't see it? Check your spam or junk folder.</p>
+					<button class="submit-btn" onclick={() => goto('/scanner')}> Continue to Scanner </button>
+				</div>
+			{:else}
+				<!-- mode tabs -->
+				<div class="mode-tabs">
 					<button
-						type="button"
-						class="forgot-btn"
+						class="mode-tab"
+						class:active={mode === 'signin'}
 						onclick={() => {
-							showReset = true;
-							resetEmail = email;
+							mode = 'signin';
 							authStore.clearError();
 						}}
 					>
-						Forgot password?
+						Sign In
 					</button>
-				{/if}
+					<button
+						class="mode-tab"
+						class:active={mode === 'signup'}
+						onclick={() => {
+							mode = 'signup';
+							authStore.clearError();
+						}}
+					>
+						Create Account
+					</button>
+				</div>
 
-				<button type="submit" class="submit-btn" disabled={submitting}>
-					{#if submitting}
-						<span class="spinner"></span>
-					{/if}
-					{mode === 'signin' ? 'Sign In' : 'Create Account'}
+				<!-- google sign-in -->
+				<button class="google-btn" onclick={handleGoogle} disabled={submitting}>
+					<svg width="18" height="18" viewBox="0 0 24 24">
+						<path
+							d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
+							fill="#4285F4"
+						/>
+						<path
+							d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+							fill="#34A853"
+						/>
+						<path
+							d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+							fill="#FBBC05"
+						/>
+						<path
+							d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+							fill="#EA4335"
+						/>
+					</svg>
+					Continue with Google
 				</button>
-			</form>
+
+				<div class="divider">
+					<span>or</span>
+				</div>
+
+				<!-- email/password form -->
+				<form class="form-body" onsubmit={handleSubmit}>
+					{#if mode === 'signup'}
+						<label class="field">
+							<span class="field-label">Name</span>
+							<input
+								type="text"
+								bind:value={displayName}
+								placeholder="Your name"
+								maxlength="80"
+								autocomplete="name"
+								class="field-input"
+							/>
+						</label>
+					{/if}
+
+					<label class="field">
+						<span class="field-label">Email</span>
+						<input
+							type="email"
+							bind:value={email}
+							placeholder="you@example.com"
+							required
+							class="field-input"
+						/>
+					</label>
+
+					<label class="field">
+						<span class="field-label">Password</span>
+						<input
+							type="password"
+							bind:value={password}
+							placeholder={mode === 'signup' ? 'At least 6 characters' : 'Your password'}
+							required
+							minlength={6}
+							class="field-input"
+						/>
+					</label>
+
+					{#if mode === 'signin'}
+						<button
+							type="button"
+							class="forgot-btn"
+							onclick={() => {
+								showReset = true;
+								resetEmail = email;
+								authStore.clearError();
+							}}
+						>
+							Forgot password?
+						</button>
+					{/if}
+
+					<button type="submit" class="submit-btn" disabled={submitting}>
+						{#if submitting}
+							<span class="spinner"></span>
+						{/if}
+						{mode === 'signin' ? 'Sign In' : 'Create Account'}
+					</button>
+				</form>
+			{/if}
 		{/if}
 	</div>
 </div>

--- a/src/routes/logout/+server.ts
+++ b/src/routes/logout/+server.ts
@@ -1,0 +1,10 @@
+import type { RequestHandler } from './$types';
+import { SESSION_COOKIE } from '$lib/server/auth/session';
+
+// POST-only so a prefetch, <img>, or cross-site GET can never force a sign-out.
+// clears the session cookie; the client then navigates. inert in firebase/none
+// mode (no such cookie is ever set there).
+export const POST: RequestHandler = async ({ cookies }) => {
+	cookies.delete(SESSION_COOKIE, { path: '/' });
+	return new Response(null, { status: 204 });
+};

--- a/src/routes/scanner/+page.server.ts
+++ b/src/routes/scanner/+page.server.ts
@@ -1,0 +1,15 @@
+import type { PageServerLoad } from './$types';
+import { redirect } from '@sveltejs/kit';
+import { env } from '$env/dynamic/private';
+import { env as publicEnv } from '$env/dynamic/public';
+import { resolveAuthMode } from '$lib/server/auth/config';
+
+// server-side guard for ldap self-host mode: unauthenticated visitors are sent
+// to /login before the page renders. no-op in firebase/none mode (the client
+// auth gate handles those, exactly as before).
+export const load: PageServerLoad = async ({ locals }) => {
+	if (resolveAuthMode({ ...env, ...publicEnv }) === 'ldap' && !locals.user) {
+		throw redirect(303, '/login');
+	}
+	return {};
+};

--- a/tests/unit/perf/lcp-readiness.test.ts
+++ b/tests/unit/perf/lcp-readiness.test.ts
@@ -21,6 +21,7 @@ import { describe, expect, it } from 'vitest';
 const PROJECT_ROOT = process.cwd();
 const SRC_ROOT = join(PROJECT_ROOT, 'src');
 const APP_HTML = join(PROJECT_ROOT, 'src', 'app.html');
+const LAYOUT_PATH = join(PROJECT_ROOT, 'src', 'routes', '+layout.svelte');
 
 // extensions to scan for img tags
 const SCAN_EXTS = ['.svelte', '.html'];
@@ -54,8 +55,13 @@ describe('lcp/cls readiness guards', () => {
 		expect(html).not.toMatch(/@import\s+url\s*\(\s*https:/i);
 	});
 
-	it('app.html retains dns-prefetch hints for firebase auth hosts', () => {
-		const html = readFileSync(APP_HTML, 'utf-8');
+	it('root layout retains dns-prefetch hints for firebase auth hosts (firebase mode only)', () => {
+		// the hints moved out of app.html (where they fired for every visitor,
+		// including no-firebase self-hosters, see #13) into a firebase-mode-gated
+		// block in the root layout. they must still be present there so the firebase
+		// deployment keeps the optimization.
+		const layout = readFileSync(LAYOUT_PATH, 'utf-8');
+		expect(layout).toMatch(/authStore\.mode === 'firebase'/);
 		const requiredHosts = [
 			'//accounts.google.com',
 			'//apis.google.com',
@@ -64,8 +70,14 @@ describe('lcp/cls readiness guards', () => {
 			'//firestore.googleapis.com'
 		];
 		for (const host of requiredHosts) {
-			expect(html, `missing dns-prefetch for ${host}`).toContain(host);
+			expect(layout, `missing dns-prefetch for ${host}`).toContain(host);
 		}
+	});
+
+	it('app.html no longer hard-codes firebase dns-prefetch (no-firebase self-host stays firebase-free)', () => {
+		const html = readFileSync(APP_HTML, 'utf-8');
+		expect(html).not.toContain('//identitytoolkit.googleapis.com');
+		expect(html).not.toContain('//firestore.googleapis.com');
 	});
 
 	it('app.html retains preconnect to fonts.googleapis.com and fonts.gstatic.com', () => {

--- a/tests/unit/server/auth/config.test.ts
+++ b/tests/unit/server/auth/config.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from 'vitest';
+import {
+	resolveAuthMode,
+	resolveLdapConfig,
+	LdapConfigError
+} from '../../../../src/lib/server/auth/config';
+
+// fully-populated ldap env, the minimum that resolveLdapConfig accepts.
+const FULL = {
+	LDAP_URL: 'ldaps://dc.corp.local:636',
+	LDAP_BIND_DN: 'CN=svc-ats,OU=Service,DC=corp,DC=local',
+	LDAP_BIND_PASSWORD: 'service-account-password',
+	LDAP_SEARCH_BASE: 'DC=corp,DC=local',
+	SESSION_SECRET: 'a-very-long-session-secret-0123456789'
+};
+
+describe('resolveAuthMode: precedence', () => {
+	it('returns none when nothing is configured', () => {
+		expect(resolveAuthMode({})).toBe('none');
+	});
+
+	it('returns firebase when PUBLIC_FIREBASE_PROJECT_ID is set', () => {
+		expect(resolveAuthMode({ PUBLIC_FIREBASE_PROJECT_ID: 'my-project' })).toBe('firebase');
+	});
+
+	it('returns ldap when LDAP_URL is set', () => {
+		expect(resolveAuthMode({ LDAP_URL: 'ldaps://dc.corp.local:636' })).toBe('ldap');
+	});
+
+	it('ldap takes precedence over firebase when both are set', () => {
+		expect(
+			resolveAuthMode({ LDAP_URL: 'ldaps://dc.corp.local:636', PUBLIC_FIREBASE_PROJECT_ID: 'p' })
+		).toBe('ldap');
+	});
+
+	it('treats whitespace-only LDAP_URL as unset (matches firebaseConfigured trim semantics)', () => {
+		expect(resolveAuthMode({ LDAP_URL: '   \t ' })).toBe('none');
+	});
+
+	it('treats whitespace-only project id as unset', () => {
+		expect(resolveAuthMode({ PUBLIC_FIREBASE_PROJECT_ID: '  \n ' })).toBe('none');
+	});
+});
+
+describe('resolveLdapConfig: inert + defaults', () => {
+	it('returns null when LDAP_URL is unset (LDAP disabled)', () => {
+		expect(resolveLdapConfig({})).toBeNull();
+	});
+
+	it('returns null when LDAP_URL is whitespace-only', () => {
+		expect(resolveLdapConfig({ LDAP_URL: '   ' })).toBeNull();
+	});
+
+	it('returns a fully-defaulted config when the required vars are present', () => {
+		const cfg = resolveLdapConfig(FULL)!;
+		expect(cfg.url).toBe(FULL.LDAP_URL);
+		expect(cfg.bindDN).toBe(FULL.LDAP_BIND_DN);
+		expect(cfg.bindCredentials).toBe(FULL.LDAP_BIND_PASSWORD);
+		expect(cfg.searchBase).toBe(FULL.LDAP_SEARCH_BASE);
+		expect(cfg.usernameAttributes).toEqual(['sAMAccountName', 'userPrincipalName']);
+		expect(cfg.nameAttribute).toBe('displayName');
+		expect(cfg.emailAttribute).toBe('mail');
+		expect(cfg.allowedGroupDN).toBeUndefined();
+		expect(cfg.tlsRejectUnauthorized).toBe(true);
+		expect(cfg.tlsCAPath).toBeUndefined();
+		expect(cfg.sessionMaxAgeSec).toBe(28_800);
+	});
+});
+
+describe('resolveLdapConfig: fail-closed validation', () => {
+	it('throws LdapConfigError when LDAP_URL is set but companions are missing', () => {
+		expect(() => resolveLdapConfig({ LDAP_URL: 'ldaps://dc.corp.local:636' })).toThrow(
+			LdapConfigError
+		);
+	});
+
+	it('names every missing companion var in the error message', () => {
+		try {
+			resolveLdapConfig({ LDAP_URL: 'ldaps://dc.corp.local:636' });
+			throw new Error('expected resolveLdapConfig to throw');
+		} catch (err) {
+			const msg = (err as Error).message;
+			expect(msg).toMatch(/LDAP_BIND_DN/);
+			expect(msg).toMatch(/LDAP_BIND_PASSWORD/);
+			expect(msg).toMatch(/LDAP_SEARCH_BASE/);
+			expect(msg).toMatch(/SESSION_SECRET/);
+		}
+	});
+
+	it('throws when SESSION_SECRET is shorter than 16 characters', () => {
+		expect(() => resolveLdapConfig({ ...FULL, SESSION_SECRET: 'too-short' })).toThrow(
+			/at least 16/
+		);
+	});
+});
+
+describe('resolveLdapConfig: optional overrides', () => {
+	it('accepts LDAP_BIND_CREDENTIALS as an alias for LDAP_BIND_PASSWORD', () => {
+		const { LDAP_BIND_PASSWORD: _omit, ...rest } = FULL;
+		void _omit;
+		const cfg = resolveLdapConfig({ ...rest, LDAP_BIND_CREDENTIALS: 'aliased-secret' })!;
+		expect(cfg.bindCredentials).toBe('aliased-secret');
+	});
+
+	it('parses LDAP_USERNAME_ATTRIBUTES as a trimmed CSV', () => {
+		const cfg = resolveLdapConfig({
+			...FULL,
+			LDAP_USERNAME_ATTRIBUTES: ' sAMAccountName , mail '
+		})!;
+		expect(cfg.usernameAttributes).toEqual(['sAMAccountName', 'mail']);
+	});
+
+	it('honors group allow-list, default domain, and custom name/email attributes', () => {
+		const cfg = resolveLdapConfig({
+			...FULL,
+			LDAP_ALLOWED_GROUP_DN: 'CN=ATS Users,OU=Groups,DC=corp,DC=local',
+			LDAP_DEFAULT_DOMAIN: 'corp.local',
+			LDAP_NAME_ATTRIBUTE: 'cn',
+			LDAP_EMAIL_ATTRIBUTE: 'userPrincipalName'
+		})!;
+		expect(cfg.allowedGroupDN).toBe('CN=ATS Users,OU=Groups,DC=corp,DC=local');
+		expect(cfg.defaultDomain).toBe('corp.local');
+		expect(cfg.nameAttribute).toBe('cn');
+		expect(cfg.emailAttribute).toBe('userPrincipalName');
+	});
+
+	it('only an explicit "false" disables TLS cert verification', () => {
+		expect(
+			resolveLdapConfig({ ...FULL, LDAP_TLS_REJECT_UNAUTHORIZED: 'false' })!.tlsRejectUnauthorized
+		).toBe(false);
+		expect(
+			resolveLdapConfig({ ...FULL, LDAP_TLS_REJECT_UNAUTHORIZED: 'true' })!.tlsRejectUnauthorized
+		).toBe(true);
+		expect(
+			resolveLdapConfig({ ...FULL, LDAP_TLS_REJECT_UNAUTHORIZED: '0' })!.tlsRejectUnauthorized
+		).toBe(true);
+	});
+
+	it('parses a valid SESSION_MAX_AGE and falls back to the default otherwise', () => {
+		expect(resolveLdapConfig({ ...FULL, SESSION_MAX_AGE: '3600' })!.sessionMaxAgeSec).toBe(3600);
+		expect(resolveLdapConfig({ ...FULL, SESSION_MAX_AGE: 'not-a-number' })!.sessionMaxAgeSec).toBe(
+			28_800
+		);
+		expect(resolveLdapConfig({ ...FULL, SESSION_MAX_AGE: '-5' })!.sessionMaxAgeSec).toBe(28_800);
+	});
+});

--- a/tests/unit/server/auth/errors.test.ts
+++ b/tests/unit/server/auth/errors.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { extractAdSubCode, mapAdBindError } from '../../../../src/lib/server/auth/errors';
+
+// representative AcceptSecurityContext diagnostic AD returns on a failed bind.
+function adError(subCode: string): Error {
+	return new Error(
+		`80090308: LdapErr: DSID-0C0903A9, comment: AcceptSecurityContext error, data ${subCode}, v1db1`
+	);
+}
+
+describe('extractAdSubCode', () => {
+	it('parses the "data <code>" token out of an AD error 49 message', () => {
+		expect(extractAdSubCode(adError('52e'))).toBe('52e');
+		expect(extractAdSubCode(adError('525'))).toBe('525');
+	});
+
+	it('reads the message off an ldapts-style error object', () => {
+		expect(extractAdSubCode({ message: 'comment: ..., data 533, v1db1' })).toBe('533');
+	});
+
+	it('returns null when there is no sub-code', () => {
+		expect(extractAdSubCode(new Error('ECONNREFUSED 10.0.0.1:636'))).toBeNull();
+		expect(extractAdSubCode(null)).toBeNull();
+	});
+});
+
+describe('mapAdBindError: anti-enumeration', () => {
+	it('maps both 525 (no such user) and 52e (bad password) to the SAME generic message', () => {
+		const generic = mapAdBindError(adError('52e'));
+		expect(mapAdBindError(adError('525'))).toBe(generic);
+		expect(generic).toMatch(/incorrect username or password/i);
+	});
+});
+
+describe('mapAdBindError: account-state messages', () => {
+	const cases: Array<[string, RegExp]> = [
+		['530', /not permitted at this time/i],
+		['531', /not permitted from this workstation/i],
+		['532', /password has expired/i],
+		['533', /account is disabled/i],
+		['701', /account has expired/i],
+		['773', /must reset your password/i],
+		['775', /account is locked/i]
+	];
+	for (const [code, pattern] of cases) {
+		it(`maps sub-code ${code} to its specific message`, () => {
+			expect(mapAdBindError(adError(code))).toMatch(pattern);
+		});
+	}
+});
+
+describe('mapAdBindError: fallbacks', () => {
+	it('maps connection / TLS failures to the reachability message', () => {
+		expect(mapAdBindError(new Error('connect ECONNREFUSED 10.0.0.1:636'))).toMatch(
+			/cannot reach the directory server/i
+		);
+		expect(mapAdBindError(new Error('unable to verify the first certificate'))).toMatch(
+			/cannot reach the directory server/i
+		);
+	});
+
+	it('falls back to a generic retry message for unknown errors', () => {
+		expect(mapAdBindError(new Error('something unexpected'))).toMatch(/sign-in failed/i);
+	});
+});

--- a/tests/unit/server/auth/login-rate-limit.test.ts
+++ b/tests/unit/server/auth/login-rate-limit.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+	checkLoginRateLimit,
+	recordLoginFailure,
+	resetLoginRateLimit,
+	LOGIN_RATE_LIMIT_CONFIG
+} from '../../../../src/lib/server/auth/login-rate-limit';
+
+// the limiter holds module-level state keyed by ip; each test uses a distinct ip
+// so they don't interfere (mirrors the analyze rate-limiter test approach).
+let ipCounter = 0;
+function freshIp(): string {
+	ipCounter += 1;
+	return `10.0.0.${ipCounter}`;
+}
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+describe('checkLoginRateLimit', () => {
+	it('allows a brand-new ip', () => {
+		expect(checkLoginRateLimit(freshIp())).toEqual({ allowed: true });
+	});
+
+	it('allows up to MAX_FAILS failures, then blocks', () => {
+		const ip = freshIp();
+		for (let i = 0; i < LOGIN_RATE_LIMIT_CONFIG.MAX_FAILS - 1; i++) {
+			recordLoginFailure(ip);
+			expect(checkLoginRateLimit(ip).allowed).toBe(true);
+		}
+		// the MAX_FAILS-th failure trips the lockout
+		recordLoginFailure(ip);
+		const gate = checkLoginRateLimit(ip);
+		expect(gate.allowed).toBe(false);
+		if (!gate.allowed) expect(gate.retryAfterSec).toBeGreaterThan(0);
+	});
+
+	it('reset clears the lockout', () => {
+		const ip = freshIp();
+		for (let i = 0; i < LOGIN_RATE_LIMIT_CONFIG.MAX_FAILS; i++) recordLoginFailure(ip);
+		expect(checkLoginRateLimit(ip).allowed).toBe(false);
+		resetLoginRateLimit(ip);
+		expect(checkLoginRateLimit(ip).allowed).toBe(true);
+	});
+
+	it('keeps distinct ips independent', () => {
+		const a = freshIp();
+		const b = freshIp();
+		for (let i = 0; i < LOGIN_RATE_LIMIT_CONFIG.MAX_FAILS; i++) recordLoginFailure(a);
+		expect(checkLoginRateLimit(a).allowed).toBe(false);
+		expect(checkLoginRateLimit(b).allowed).toBe(true);
+	});
+});
+
+describe('lockout expiry', () => {
+	it('clears the lockout after LOCKOUT_MS elapses', () => {
+		vi.useFakeTimers();
+		const ip = freshIp();
+		for (let i = 0; i < LOGIN_RATE_LIMIT_CONFIG.MAX_FAILS; i++) recordLoginFailure(ip);
+		expect(checkLoginRateLimit(ip).allowed).toBe(false);
+
+		vi.advanceTimersByTime(LOGIN_RATE_LIMIT_CONFIG.LOCKOUT_MS + 1000);
+		expect(checkLoginRateLimit(ip).allowed).toBe(true);
+	});
+
+	it('starts a fresh window once the rolling window passes', () => {
+		vi.useFakeTimers();
+		const ip = freshIp();
+		// a couple of failures, then let the window age out
+		recordLoginFailure(ip);
+		recordLoginFailure(ip);
+		vi.advanceTimersByTime(LOGIN_RATE_LIMIT_CONFIG.WINDOW_MS + 1000);
+		// these failures count against a fresh window, so we're still under the cap
+		recordLoginFailure(ip);
+		expect(checkLoginRateLimit(ip).allowed).toBe(true);
+	});
+});

--- a/tests/unit/server/auth/normalize.test.ts
+++ b/tests/unit/server/auth/normalize.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest';
+import {
+	normalizeUsername,
+	escapeFilterValue,
+	buildUserSearchFilter,
+	buildGroupMembershipFilter
+} from '../../../../src/lib/server/auth/normalize';
+
+const NUL = String.fromCharCode(0);
+
+describe('normalizeUsername: logon formats', () => {
+	it('UPN (user@domain) keeps the full value, format upn', () => {
+		expect(normalizeUsername('jdoe@corp.local')).toEqual({
+			format: 'upn',
+			value: 'jdoe@corp.local',
+			raw: 'jdoe@corp.local'
+		});
+	});
+
+	it('down-level (DOMAIN\\user) strips the domain, format downlevel', () => {
+		expect(normalizeUsername('CORP\\jdoe')).toEqual({
+			format: 'downlevel',
+			value: 'jdoe',
+			raw: 'CORP\\jdoe'
+		});
+	});
+
+	it('bare username stays as-is, format bare', () => {
+		expect(normalizeUsername('jdoe')).toEqual({ format: 'bare', value: 'jdoe', raw: 'jdoe' });
+	});
+
+	it('bare username synthesizes a UPN when a default domain is configured', () => {
+		expect(normalizeUsername('jdoe', { defaultDomain: 'corp.local' })).toEqual({
+			format: 'upn',
+			value: 'jdoe@corp.local',
+			raw: 'jdoe'
+		});
+	});
+
+	it('trims surrounding whitespace before classifying', () => {
+		expect(normalizeUsername('  jdoe@corp.local  ')?.value).toBe('jdoe@corp.local');
+	});
+});
+
+describe('normalizeUsername: rejected input', () => {
+	it('returns null for empty / whitespace-only input', () => {
+		expect(normalizeUsername('')).toBeNull();
+		expect(normalizeUsername('   ')).toBeNull();
+	});
+
+	it('returns null for a malformed UPN (empty local or domain part)', () => {
+		expect(normalizeUsername('@corp.local')).toBeNull();
+		expect(normalizeUsername('jdoe@')).toBeNull();
+	});
+
+	it('returns null for a UPN with more than one @', () => {
+		expect(normalizeUsername('a@b@corp.local')).toBeNull();
+	});
+
+	it('returns null for a down-level value with an empty sAMAccountName', () => {
+		expect(normalizeUsername('CORP\\')).toBeNull();
+	});
+
+	it('returns null when control characters are embedded', () => {
+		expect(normalizeUsername(`jdoe${NUL}`)).toBeNull();
+		expect(normalizeUsername('jd\noe')).toBeNull();
+	});
+
+	it('returns null for absurdly long input', () => {
+		expect(normalizeUsername('a'.repeat(257))).toBeNull();
+	});
+});
+
+describe('escapeFilterValue: RFC 4515 special characters', () => {
+	it('escapes the five filter-breaking characters', () => {
+		expect(escapeFilterValue('\\')).toBe('\\5c');
+		expect(escapeFilterValue('*')).toBe('\\2a');
+		expect(escapeFilterValue('(')).toBe('\\28');
+		expect(escapeFilterValue(')')).toBe('\\29');
+		expect(escapeFilterValue(NUL)).toBe('\\00');
+	});
+
+	it('neutralizes an injection payload so it cannot broaden the filter', () => {
+		expect(escapeFilterValue('*)(uid=*')).toBe('\\2a\\29\\28uid=\\2a');
+	});
+
+	it('leaves ordinary characters untouched', () => {
+		expect(escapeFilterValue('jdoe@corp.local')).toBe('jdoe@corp.local');
+	});
+});
+
+describe('buildUserSearchFilter', () => {
+	it('ORs the escaped value across multiple username attributes, scoped to users', () => {
+		const logon = normalizeUsername('jdoe')!;
+		expect(buildUserSearchFilter(logon, ['sAMAccountName', 'userPrincipalName'])).toBe(
+			'(&(objectClass=user)(|(sAMAccountName=jdoe)(userPrincipalName=jdoe)))'
+		);
+	});
+
+	it('omits the OR wrapper for a single username attribute', () => {
+		const logon = normalizeUsername('jdoe')!;
+		expect(buildUserSearchFilter(logon, ['sAMAccountName'])).toBe(
+			'(&(objectClass=user)(sAMAccountName=jdoe))'
+		);
+	});
+
+	it('escapes the value so an injection payload cannot break out of the filter', () => {
+		const logon = normalizeUsername('CORP\\*)(uid=*')!; // down-level -> value "*)(uid=*"
+		const filter = buildUserSearchFilter(logon, ['sAMAccountName']);
+		expect(filter).toBe('(&(objectClass=user)(sAMAccountName=\\2a\\29\\28uid=\\2a))');
+		expect(filter).not.toContain('*)(');
+	});
+});
+
+describe('buildGroupMembershipFilter', () => {
+	it('uses the matching-rule-in-chain OID for nested-group membership', () => {
+		expect(buildGroupMembershipFilter('CN=ATS Users,OU=Groups,DC=corp,DC=local')).toBe(
+			'(memberOf:1.2.840.113556.1.4.1941:=CN=ATS Users,OU=Groups,DC=corp,DC=local)'
+		);
+	});
+
+	it('escapes parentheses in a group name so the filter still parses', () => {
+		expect(buildGroupMembershipFilter('CN=App (Prod),DC=corp,DC=local')).toBe(
+			'(memberOf:1.2.840.113556.1.4.1941:=CN=App \\28Prod\\29,DC=corp,DC=local)'
+		);
+	});
+});

--- a/tests/unit/server/auth/provider.test.ts
+++ b/tests/unit/server/auth/provider.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest';
+import { buildServerAuthProvider } from '../../../../src/lib/server/auth/provider';
+
+// provider.ts -> ldap.ts statically imports $lib/log (which reads
+// $app/environment). mock it so the test stays a pure factory check; the live
+// ldapts bind is exercised by manual integration, not unit tests (mirroring how
+// the analyze route's actual HTTP calls aren't unit-tested, only buildProviders).
+vi.mock('$lib/log', () => ({
+	logger: { debug() {}, info() {}, warn() {}, error() {} },
+	log() {}
+}));
+
+const FULL = {
+	LDAP_URL: 'ldaps://dc.corp.local:636',
+	LDAP_BIND_DN: 'CN=svc-ats,OU=Service,DC=corp,DC=local',
+	LDAP_BIND_PASSWORD: 'service-account-password',
+	LDAP_SEARCH_BASE: 'DC=corp,DC=local',
+	SESSION_SECRET: 'a-very-long-session-secret-0123456789'
+};
+
+describe('buildServerAuthProvider', () => {
+	it('returns null when nothing is configured (inert)', () => {
+		expect(buildServerAuthProvider({})).toBeNull();
+	});
+
+	it('returns null when only firebase is configured', () => {
+		expect(buildServerAuthProvider({ PUBLIC_FIREBASE_PROJECT_ID: 'my-project' })).toBeNull();
+	});
+
+	it('builds an ldap provider when fully configured', () => {
+		const provider = buildServerAuthProvider(FULL);
+		expect(provider).not.toBeNull();
+		expect(provider!.id).toBe('ldap');
+		expect(typeof provider!.authenticate).toBe('function');
+	});
+
+	it('propagates the config error when LDAP_URL is set but incomplete', () => {
+		expect(() => buildServerAuthProvider({ LDAP_URL: 'ldaps://dc.corp.local:636' })).toThrow();
+	});
+});

--- a/tests/unit/server/auth/session.test.ts
+++ b/tests/unit/server/auth/session.test.ts
@@ -1,0 +1,113 @@
+// @vitest-environment node
+// uses Node's webcrypto (globalThis.crypto.subtle); the node environment avoids
+// any jsdom crypto-shim differences.
+import { describe, expect, it } from 'vitest';
+import {
+	signSession,
+	verifySession,
+	makeSessionPayload,
+	sessionCookieOptions,
+	SESSION_COOKIE,
+	type SessionPayload
+} from '../../../../src/lib/server/auth/session';
+
+const SECRET = 'a-very-long-session-secret-0123456789';
+const USER = {
+	sub: 'guid-abc-123',
+	name: 'Jane Doe',
+	email: 'jane@corp.local',
+	groups: ['cn=ats']
+};
+
+describe('signSession + verifySession: round-trip', () => {
+	it('verifies a freshly signed token and returns the exact payload', async () => {
+		const payload = makeSessionPayload(USER, 3600);
+		const token = await signSession(payload, SECRET);
+		expect(await verifySession(token, SECRET)).toEqual(payload);
+	});
+
+	it('produces a two-part base64url token', () => {
+		// shape check is synchronous-friendly via the payload roundtrip above;
+		// here just assert the dot-separated structure.
+		return signSession(makeSessionPayload(USER, 3600), SECRET).then((token) => {
+			expect(token.split('.')).toHaveLength(2);
+			expect(token).not.toMatch(/[+/=]/); // base64url, no standard-base64 chars
+		});
+	});
+});
+
+describe('verifySession: rejection paths', () => {
+	it('rejects a tampered payload', async () => {
+		const token = await signSession(makeSessionPayload(USER, 3600), SECRET);
+		const [body, sig] = token.split('.');
+		const tampered = `${body}x.${sig}`;
+		expect(await verifySession(tampered, SECRET)).toBeNull();
+	});
+
+	it('rejects a tampered signature', async () => {
+		const token = await signSession(makeSessionPayload(USER, 3600), SECRET);
+		const [body, sig] = token.split('.');
+		const flipped = sig[0] === 'a' ? `b${sig.slice(1)}` : `a${sig.slice(1)}`;
+		expect(await verifySession(`${body}.${flipped}`, SECRET)).toBeNull();
+	});
+
+	it('rejects a token signed with a different secret', async () => {
+		const token = await signSession(makeSessionPayload(USER, 3600), SECRET);
+		expect(await verifySession(token, 'a-different-but-long-enough-secret-xyz')).toBeNull();
+	});
+
+	it('rejects an expired token', async () => {
+		// nowSec far in the past so exp is also in the past
+		const expired = makeSessionPayload(USER, 60, 1000);
+		const token = await signSession(expired, SECRET);
+		expect(await verifySession(token, SECRET)).toBeNull();
+	});
+
+	it('rejects when the secret is blank', async () => {
+		const token = await signSession(makeSessionPayload(USER, 3600), SECRET);
+		expect(await verifySession(token, '')).toBeNull();
+	});
+
+	it('rejects malformed tokens', async () => {
+		expect(await verifySession('', SECRET)).toBeNull();
+		expect(await verifySession('no-dot-here', SECRET)).toBeNull();
+		expect(await verifySession('.onlysig', SECRET)).toBeNull();
+		expect(await verifySession('onlybody.', SECRET)).toBeNull();
+	});
+});
+
+describe('signSession: input guards', () => {
+	it('throws when no secret is provided', async () => {
+		await expect(signSession(makeSessionPayload(USER, 3600), '')).rejects.toThrow();
+	});
+});
+
+describe('makeSessionPayload', () => {
+	it('sets exp = iat + maxAgeSec', () => {
+		const p: SessionPayload = makeSessionPayload(USER, 3600, 1_000_000);
+		expect(p.iat).toBe(1_000_000);
+		expect(p.exp).toBe(1_003_600);
+		expect(p.sub).toBe(USER.sub);
+		expect(p.groups).toEqual(USER.groups);
+	});
+});
+
+describe('sessionCookieOptions', () => {
+	it('is httpOnly, sameSite=lax, path=/ and carries maxAge', () => {
+		expect(sessionCookieOptions(3600, true)).toEqual({
+			httpOnly: true,
+			secure: true,
+			sameSite: 'lax',
+			path: '/',
+			maxAge: 3600
+		});
+	});
+
+	it('passes secure through (false on plain-http dev)', () => {
+		expect(sessionCookieOptions(3600, false).secure).toBe(false);
+	});
+
+	it('exposes a stable cookie name', () => {
+		expect(SESSION_COOKIE).toBe('ats_session');
+	});
+});

--- a/tests/unit/server/csp.test.ts
+++ b/tests/unit/server/csp.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { buildContentSecurityPolicy } from '../../../src/lib/server/csp';
+
+const FIREBASE_TOKENS = [
+	'*.googleapis.com',
+	'*.firebaseio.com',
+	'*.firebaseapp.com',
+	'*.firebase.com',
+	'accounts.google.com'
+];
+
+describe('buildContentSecurityPolicy: firebase mode', () => {
+	const csp = buildContentSecurityPolicy(true);
+
+	it('includes the firebase / google-auth origins in connect-src and frame-src', () => {
+		expect(csp).toContain('https://*.googleapis.com');
+		expect(csp).toContain('https://*.firebaseio.com');
+		expect(csp).toContain('https://*.firebaseapp.com');
+		expect(csp).toContain('https://accounts.google.com');
+	});
+});
+
+describe('buildContentSecurityPolicy: no-firebase self-host (#13)', () => {
+	const csp = buildContentSecurityPolicy(false);
+
+	it('contains ZERO firebase / google-auth references', () => {
+		for (const token of FIREBASE_TOKENS) {
+			expect(csp, `CSP should not mention ${token} in non-firebase mode`).not.toContain(token);
+		}
+	});
+
+	it('keeps connect-src and frame-src locked to self', () => {
+		expect(csp).toContain("connect-src 'self';");
+		expect(csp).toContain("frame-src 'self';");
+	});
+});
+
+describe('buildContentSecurityPolicy: invariants in every mode', () => {
+	for (const allowFirebase of [true, false]) {
+		const csp = buildContentSecurityPolicy(allowFirebase);
+		const label = allowFirebase ? 'firebase' : 'self-host';
+
+		it(`(${label}) keeps the report-uri, object-src none, and form-action self`, () => {
+			expect(csp).toContain('report-uri /api/csp-report');
+			expect(csp).toContain("object-src 'none'");
+			expect(csp).toContain("form-action 'self'");
+		});
+
+		it(`(${label}) keeps google fonts (Geist loads from there regardless of auth)`, () => {
+			expect(csp).toContain('https://fonts.googleapis.com');
+			expect(csp).toContain('https://fonts.gstatic.com');
+		});
+	}
+});

--- a/tests/unit/stores/scores-ldap-history-namespacing.test.ts
+++ b/tests/unit/stores/scores-ldap-history-namespacing.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ldap self-host mode reuses the localStorage history path (firebase is not
+// configured) but namespaces the bucket by the signed-in AD user's stable
+// subject. mocks mirror scores-local-history.test.ts.
+
+vi.mock('$app/environment', () => ({ browser: true }));
+
+vi.mock('../../../src/lib/log', () => ({
+	logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+}));
+
+vi.mock('$env/dynamic/public', () => ({ env: {} }));
+
+const BARE_KEY = 'ats_local_scan_history_v1';
+const SUB = 'guid-deadbeef';
+const NS_KEY = `${BARE_KEY}__${SUB}`;
+
+type StubResult = { system: string; overallScore: number; passesFilter: boolean };
+function stubResult(score: number, passes: boolean): StubResult {
+	return { system: 'Workday', overallScore: score, passesFilter: passes };
+}
+
+function readKey(key: string): unknown[] {
+	const raw = localStorage.getItem(key);
+	if (!raw) return [];
+	try {
+		const parsed = JSON.parse(raw);
+		return Array.isArray(parsed) ? parsed : [];
+	} catch {
+		return [];
+	}
+}
+
+async function freshGraph() {
+	vi.resetModules();
+	const { authStore } = await import('../../../src/lib/stores/auth.svelte');
+	const { scoresStore } = await import('../../../src/lib/stores/scores.svelte');
+	return { authStore, scoresStore };
+}
+
+beforeEach(() => {
+	localStorage.clear();
+});
+
+afterEach(() => {
+	localStorage.clear();
+});
+
+describe('ldap mode: scan history namespaced by AD subject', () => {
+	it('writes history under a per-user key, leaving the anonymous bucket untouched', async () => {
+		const { authStore, scoresStore } = await freshGraph();
+		authStore.hydrateFromServer({
+			authMode: 'ldap',
+			user: { sub: SUB, name: 'Jane Doe', email: 'jane@corp.local', groups: [] }
+		});
+		scoresStore.finishScoring([stubResult(82, true)] as never, 'resume.pdf');
+		await Promise.resolve();
+
+		expect(readKey(NS_KEY)).toHaveLength(1);
+		expect(readKey(BARE_KEY)).toEqual([]);
+	});
+
+	it('keeps two AD users on the same browser in separate buckets', async () => {
+		const { authStore, scoresStore } = await freshGraph();
+
+		authStore.hydrateFromServer({
+			authMode: 'ldap',
+			user: { sub: 'guid-aaa', name: 'A', email: '', groups: [] }
+		});
+		scoresStore.finishScoring([stubResult(70, true)] as never, 'a.pdf');
+		await Promise.resolve();
+
+		authStore.hydrateFromServer({
+			authMode: 'ldap',
+			user: { sub: 'guid-bbb', name: 'B', email: '', groups: [] }
+		});
+		scoresStore.finishScoring([stubResult(90, true)] as never, 'b.pdf');
+		await Promise.resolve();
+
+		expect(readKey(`${BARE_KEY}__guid-aaa`)).toHaveLength(1);
+		expect(readKey(`${BARE_KEY}__guid-bbb`)).toHaveLength(1);
+		expect(readKey(BARE_KEY)).toEqual([]);
+	});
+
+	it('anonymous (none) mode still uses the bare legacy key', async () => {
+		const { authStore, scoresStore } = await freshGraph();
+		expect(authStore.mode).toBe('none');
+		scoresStore.finishScoring([stubResult(65, true)] as never, 'anon.pdf');
+		await Promise.resolve();
+
+		expect(readKey(BARE_KEY)).toHaveLength(1);
+	});
+});


### PR DESCRIPTION
resolves the first ask in #16 (ldap / active directory sign-in) and fixes #13 (self-hosting without firebase still tripped firebase csp errors). both ship together as the 0.4.0 self-host auth cycle. the hosted deployment is behaviorally byte-identical: every new path is gated on the auth mode, which only becomes `ldap` when `LDAP_URL` is set, and production never sets it.

**why**

#16 asked for external auth, ldap/ad first. the realistic target is a self-hoster running inside their own network where a domain controller is reachable, so this is a server-side, env-flag self-host feature in the same shape as the existing ollama and firebase-optional flags. while in there, #13 surfaced: a no-firebase self-host still served a csp that referenced firebase and shipped firebase dns-prefetch hints, so it was never truly firebase-free.

**what changed**

- one auth mode resolved server-side: `ldap` > `firebase` > `none`. surfaced to the client via a root `+layout.server.ts`; the auth store generalizes to all three with the firebase path left untouched.
- ad/ldap: service-account search-then-bind, upn / `DOMAIN\user` / bare logon formats, optional nested-group allow-list, ldaps + internal-ca trust, friendly account-state errors, anti-enumeration on bad credentials, per-ip lockout.
- stateless hmac session cookie via web crypto (no server store, no node built-ins in hooks, survives restarts).
- pluggable `ServerAuthProvider` so oidc/saml can drop in later; `ldapts` is an optional, lazily-imported dependency that never reaches the client or edge bundles.
- the active directory login ui renders only when ldap is active, so it stays invisible on the public deployment.
- #13: the csp is mode-aware (firebase origins only in firebase mode) and the firebase dns-prefetch moved into a firebase-only layout block, so a no-firebase install serves and resolves zero firebase references.
- docs reorganized for the various self-host options: a new Authentication hub, an Active Directory guide, a slimmer Configuration, a readme matrix, and an `.env.example` group.

**prod safety**

hosted firebase deploy verified unchanged: ad ui absent, firebase login + firebase csp + firebase dns-prefetch all present. ldapts is never bundled into the client/edge output and never loads unless `LDAP_URL` is set.

**testing**

- 381 -> 464 unit tests: auth config/normalize/errors/session/rate-limit/provider, csp mode-awareness, per-user history namespacing, updated lcp guards.
- end-to-end smoke test against a throwaway local ldap server (no domain join): service bind, user search, user bind, all three logon formats, wrong-password error, rate-limit lockout at the 5th attempt, session cookie issue + verify, `/scanner` guard, `/api/analyze` 401 without a session and pass-through with one, logout clearing the cookie. confirmed the served csp is firebase-free in ldap/none mode and firebase-present in firebase mode, and that the login page shows the ad form only in ldap mode.
- `pnpm check`, `pnpm lint`, `pnpm test`, `pnpm build` (including the astro docs build) all green.

ref:
- #16 additional auth methods (ldap/ad first), #13 self-host without firebase
- ldap matching-rule-in-chain oid `1.2.840.113556.1.4.1941` for nested group membership

docs:
- sveltekit hooks: https://svelte.dev/docs/kit/hooks
- sveltekit form actions: https://svelte.dev/docs/kit/form-actions
- sveltekit server-only modules: https://svelte.dev/docs/kit/server-only-modules
- sveltekit csrf.checkOrigin: https://svelte.dev/docs/kit/configuration
- ldapts: https://github.com/ldapts/ldapts
- owasp ldap injection prevention: https://cheatsheetseries.owasp.org/cheatsheets/LDAP_Injection_Prevention_Cheat_Sheet.html
- ms search filter syntax (matching rule in chain): https://learn.microsoft.com/en-us/windows/win32/adsi/search-filter-syntax
- ms useraccountcontrol flags: https://learn.microsoft.com/en-us/troubleshoot/windows-server/active-directory/useraccountcontrol-manipulate-account-properties

closes #16
closes #13
