### PR TITLE
feat: deterministic scoring, PT-BR/EN parser, OCR and Gupy-like profile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: ci
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main, dev, 'feat/**']
   pull_request:
     branches: [main, dev]
 
@@ -12,7 +12,6 @@ jobs:
     strategy:
       matrix:
         node-version: [20]
-
     env:
       PUBLIC_FIREBASE_API_KEY: ci-placeholder
       PUBLIC_FIREBASE_AUTH_DOMAIN: ci-placeholder.firebaseapp.com
@@ -20,31 +19,45 @@ jobs:
       PUBLIC_FIREBASE_STORAGE_BUCKET: ci-placeholder.appspot.com
       PUBLIC_FIREBASE_MESSAGING_SENDER_ID: '000000000000'
       PUBLIC_FIREBASE_APP_ID: '1:000000000000:web:0000000000000000'
-
     steps:
       - uses: actions/checkout@v4
-
       - uses: pnpm/action-setup@v4
-
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'
-
       - name: install dependencies
         run: pnpm install --frozen-lockfile
-
       - name: type check
         run: pnpm check
-
       - name: lint
         run: pnpm lint
-
       - name: format check
         run: pnpm format:check
-
       - name: unit tests
         run: pnpm test
-
       - name: build
         run: pnpm build
+
+  e2e:
+    needs: validate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm exec playwright install --with-deps chromium
+      - name: deterministic scanner e2e
+        run: pnpm exec playwright test tests/e2e/deterministic-scanner.spec.ts --project=chromium
+
+  docker-build:
+    needs: validate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: build production OCR image
+        run: docker build --tag ats-screener:test .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+FROM node:22-bookworm-slim AS builder
+
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+
+RUN corepack enable && corepack prepare pnpm@10.32.1 --activate
+
+WORKDIR /app
+
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+
+COPY . .
+
+# Dokploy runs a persistent Node server, so replace the Vercel adapter at build time.
+RUN pnpm add -D @sveltejs/adapter-node@5.5.7 \
+    && sed -i "s#@sveltejs/adapter-vercel#@sveltejs/adapter-node#" svelte.config.js
+
+RUN pnpm build:app
+RUN pnpm prune --prod
+
+FROM node:22-bookworm-slim AS runner
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV HOST=0.0.0.0
+ENV PORT=3000
+
+COPY --from=builder /app/build ./build
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/package.json ./package.json
+
+EXPOSE 3000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+  CMD node -e "fetch('http://127.0.0.1:3000/').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
+
+CMD ["node", "build"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,11 +21,21 @@ RUN pnpm prune --prod
 
 FROM node:22-bookworm-slim AS runner
 
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+       poppler-utils \
+       tesseract-ocr \
+       tesseract-ocr-eng \
+       tesseract-ocr-por \
+    && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 
 ENV NODE_ENV=production
 ENV HOST=0.0.0.0
 ENV PORT=3000
+ENV OCR_ENABLED=true
+ENV PUBLIC_DETERMINISTIC_ONLY=true
 
 COPY --from=builder /app/build ./build
 COPY --from=builder /app/node_modules ./node_modules
@@ -33,7 +43,7 @@ COPY --from=builder /app/package.json ./package.json
 
 EXPOSE 3000
 
-HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
   CMD node -e "fetch('http://127.0.0.1:3000/').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
 
 CMD ["node", "build"]

--- a/docs/DETERMINISTIC_ATS_BRASIL.md
+++ b/docs/DETERMINISTIC_ATS_BRASIL.md
@@ -1,0 +1,104 @@
+# Deterministic ATS Brasil
+
+## Objetivo
+
+Este modo analisa currículos sem LLM, sem API de IA e sem custo por documento. O pipeline é explicável: cada campo e cada nota deriva de extração de texto, OCR próprio, taxonomias locais e regras versionadas.
+
+## Pipeline
+
+```text
+PDF/DOCX
+  -> camada textual e geometria
+  -> medição de qualidade
+  -> OCR Tesseract por+eng somente quando necessário
+  -> normalização Unicode
+  -> contato, seções, experiências, formação, projetos e competências
+  -> descrição da vaga estruturada
+  -> pontuação por perfil ATS
+  -> evidências e recomendações
+```
+
+### Extração
+
+- PDF: `pdfjs-dist`, reconstrução por coordenadas e espaçamento adaptativo.
+- DOCX: `mammoth`, preservando parágrafos/listas e detectando tabelas/imagens.
+- OCR: Poppler + Tesseract `por+eng` no próprio container.
+- Limites OCR: 10 MB, seis páginas e duas tarefas simultâneas.
+- Idiomas: português brasileiro e inglês.
+
+### Campos estruturados
+
+- contato;
+- resumo;
+- competências;
+- experiências, cargos, empresas, períodos e tópicos;
+- formação, instituição, área e período;
+- projetos e certificações;
+- metadados de leitura e confiança.
+
+## Pontuação
+
+Os perfis Workday, Taleo, SuccessFactors, iCIMS, Greenhouse e Lever são simulações determinísticas baseadas em diferenças documentadas de parsing, formatação e correspondência de termos. Não são integrações oficiais nem cópias dos algoritmos proprietários.
+
+### Gupy-like
+
+O perfil `Gupy-like` é uma simulação transparente baseada somente nas orientações públicas da Gupy para pessoas candidatas. Ele dá mais peso a:
+
+- experiências estruturadas;
+- competências obrigatórias e desejáveis da vaga;
+- tempo mínimo de experiência;
+- aderência entre cargos/descrições e área da vaga;
+- formação exigida.
+
+Nome, e-mail, telefone e outros dados de contato não entram no corpus de aderência do perfil Gupy-like.
+
+Sem descrição da vaga, a dimensão de palavras-chave é removida e os demais pesos são normalizados. Portanto, o sistema não atribui mais `100` artificial nessa dimensão.
+
+## Confiança
+
+A interface separa:
+
+- qualidade da extração;
+- compatibilidade de formato;
+- completude das seções;
+- qualidade das experiências;
+- formação;
+- aderência à vaga, quando uma vaga é fornecida.
+
+## Variáveis de ambiente
+
+```env
+NODE_ENV=production
+HOST=0.0.0.0
+PORT=3000
+OCR_ENABLED=true
+PUBLIC_DETERMINISTIC_ONLY=true
+ORIGIN=https://ats.seudominio.com
+```
+
+Não são necessárias chaves Gemini, Groq, OpenAI ou qualquer outro provedor.
+
+## Testes
+
+A suíte cobre:
+
+- currículos equivalentes em PT-BR e inglês;
+- títulos com emojis;
+- telefone brasileiro quebrado entre linhas;
+- cinco experiências, incluindo entradas compactas e datas quebradas;
+- duas formações;
+- competências canônicas;
+- ausência de pontuação falsa sem vaga;
+- sete perfis ATS;
+- requisitos obrigatórios/desejáveis;
+- períodos de trabalho sobrepostos sem dupla contagem;
+- isolamento de nome/e-mail no Gupy-like;
+- fluxo E2E por texto colado;
+- build da imagem Docker com OCR.
+
+## Limitações honestas
+
+- OCR pode errar documentos com baixa resolução, manuscritos ou fontes decorativas.
+- Os perfis de plataformas são aproximações públicas, não algoritmos internos.
+- Perguntas eliminatórias configuradas pela empresa não podem ser inferidas apenas pelo currículo.
+- A nota deve ser interpretada junto com as evidências, nunca como garantia de aprovação.

--- a/src/lib/components/scoring/ResumeStats.svelte
+++ b/src/lib/components/scoring/ResumeStats.svelte
@@ -1,484 +1,246 @@
 <script lang="ts">
+	import { localeStore } from '$stores/locale.svelte';
 	import { resumeStore } from '$stores/resume.svelte';
 
 	const resume = $derived(resumeStore.resume);
-	let skillsExpanded = $state(false);
+	let showAllSkills = $state(false);
+
+	function methodLabel(method: string): string {
+		const pt = localeStore.locale === 'pt-BR';
+		const labels: Record<string, [string, string]> = {
+			'text-layer': ['Camada de texto', 'Text layer'],
+			ocr: ['OCR Tesseract por+eng', 'Tesseract OCR por+eng'],
+			docx: ['Estrutura DOCX', 'DOCX structure'],
+			'pasted-text': ['Texto colado', 'Pasted text']
+		};
+		return labels[method]?.[pt ? 0 : 1] ?? method;
+	}
+
+	function confidenceClass(value: number): string {
+		if (value >= 85) return 'high';
+		if (value >= 65) return 'medium';
+		return 'low';
+	}
 </script>
 
 {#if resume}
-	<div class="resume-stats">
-		<div class="stats-header">
-			<svg
-				width="18"
-				height="18"
-				viewBox="0 0 24 24"
-				fill="none"
-				stroke="currentColor"
-				stroke-width="2"
-			>
-				<path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
-				<polyline points="14,2 14,8 20,8" />
-			</svg>
-			<h3>Resume Overview</h3>
+	<section class="overview">
+		<header>
+			<div>
+				<p class="eyebrow">{localeStore.t('overview.title')}</p>
+				<h3>{methodLabel(resume.metadata.extractionMethod)}</h3>
+			</div>
+			<div class="confidence {confidenceClass(resume.metadata.extractionQuality)}">
+				<strong>{resume.metadata.extractionQuality}%</strong>
+				<span>{localeStore.t('overview.confidence')}</span>
+			</div>
+		</header>
+
+		<div class="stats">
+			<div><strong>{resume.metadata.wordCount}</strong><span>{localeStore.t('overview.words')}</span></div>
+			<div><strong>{resume.metadata.pageCount}</strong><span>{localeStore.t('overview.pages')}</span></div>
+			<div><strong>{resume.sections.filter((section) => section.type !== 'unknown').length}</strong><span>{localeStore.t('overview.sections')}</span></div>
+			<div><strong>{resume.skills.length}</strong><span>{localeStore.t('overview.skills')}</span></div>
+			<div><strong>{resume.experience.length}</strong><span>{localeStore.t('overview.positions')}</span></div>
+			<div><strong>{resume.education.length}</strong><span>{localeStore.t('overview.education')}</span></div>
 		</div>
 
-		<!-- quick stats grid -->
-		<div class="stats-grid">
-			<div class="stat-item">
-				<span class="stat-value">{resume.metadata.wordCount}</span>
-				<span class="stat-label">Words</span>
-			</div>
-			<div class="stat-item">
-				<span class="stat-value">{resume.metadata.pageCount}</span>
-				<span class="stat-label">{resume.metadata.pageCount === 1 ? 'Page' : 'Pages'}</span>
-			</div>
-			<div class="stat-item">
-				<span class="stat-value">{resume.sections.length}</span>
-				<span class="stat-label">Sections</span>
-			</div>
-			<div class="stat-item">
-				<span class="stat-value">{resume.skills.length}</span>
-				<span class="stat-label">Skills Found</span>
-			</div>
-			<div class="stat-item">
-				<span class="stat-value">{resume.experience.length}</span>
-				<span class="stat-label">Positions</span>
-			</div>
-			<div class="stat-item">
-				<span class="stat-value">{resume.education.length}</span>
-				<span class="stat-label">Education</span>
-			</div>
-		</div>
-
-		<!-- detected sections -->
-		<div class="section-detail">
-			<h4>Detected Sections</h4>
-			<div class="section-chips">
-				{#each resume.sections as section}
-					<span class="section-chip">
-						<svg
-							width="12"
-							height="12"
-							viewBox="0 0 24 24"
-							fill="none"
-							stroke="currentColor"
-							stroke-width="2.5"
-						>
-							<polyline points="20,6 9,17 4,12" />
-						</svg>
-						{section.type}
-					</span>
+		<div class="detail">
+			<h4>{localeStore.t('overview.detectedSections')}</h4>
+			<div class="chips">
+				{#each resume.sections.filter((section) => section.type !== 'unknown') as section}
+					<span>✓ {section.type}</span>
 				{/each}
 			</div>
 		</div>
 
-		<!-- extracted skills -->
 		{#if resume.skills.length > 0}
-			<div class="section-detail">
-				<h4>Extracted Skills ({resume.skills.length})</h4>
-				<div class="skill-chips">
-					{#each skillsExpanded ? resume.skills : resume.skills.slice(0, 30) as skill}
-						<span class="skill-chip">{skill}</span>
+			<div class="detail">
+				<h4>{localeStore.t('overview.extractedSkills')} ({resume.skills.length})</h4>
+				<div class="chips skills">
+					{#each showAllSkills ? resume.skills : resume.skills.slice(0, 30) as skill}
+						<span>{skill}</span>
 					{/each}
-					{#if !skillsExpanded && resume.skills.length > 30}
-						<button class="skill-chip more" onclick={() => (skillsExpanded = true)}
-							>+{resume.skills.length - 30} more</button
-						>
-					{/if}
-					{#if skillsExpanded && resume.skills.length > 30}
-						<button class="skill-chip more" onclick={() => (skillsExpanded = false)}
-							>show less</button
-						>
+					{#if resume.skills.length > 30}
+						<button type="button" onclick={() => (showAllSkills = !showAllSkills)}>
+							{showAllSkills
+								? localeStore.locale === 'pt-BR' ? 'mostrar menos' : 'show less'
+								: `+${resume.skills.length - 30}`}
+						</button>
 					{/if}
 				</div>
 			</div>
 		{/if}
 
-		<!-- contact info -->
-		{#if resume.contact}
-			<div class="section-detail">
-				<h4>Contact Info</h4>
-				<div class="contact-items">
-					{#if resume.contact.name}
-						<div class="contact-item">
-							<svg
-								width="14"
-								height="14"
-								viewBox="0 0 24 24"
-								fill="none"
-								stroke="currentColor"
-								stroke-width="2"
-							>
-								<path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
-								<circle cx="12" cy="7" r="4" />
-							</svg>
-							<span>{resume.contact.name}</span>
-						</div>
-					{/if}
-					{#if resume.contact.email}
-						<a class="contact-item contact-link" href="mailto:{resume.contact.email}">
-							<svg
-								width="14"
-								height="14"
-								viewBox="0 0 24 24"
-								fill="none"
-								stroke="currentColor"
-								stroke-width="2"
-							>
-								<path
-									d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"
-								/>
-								<polyline points="22,6 12,13 2,6" />
-							</svg>
-							<span>{resume.contact.email}</span>
-						</a>
-					{/if}
-					{#if resume.contact.phone}
-						<a
-							class="contact-item contact-link"
-							href="tel:{resume.contact.phone.replace(/[\s()-]/g, '')}"
-						>
-							<svg
-								width="14"
-								height="14"
-								viewBox="0 0 24 24"
-								fill="none"
-								stroke="currentColor"
-								stroke-width="2"
-							>
-								<path
-									d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72c.127.96.362 1.903.7 2.81a2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45c.907.338 1.85.573 2.81.7A2 2 0 0 1 22 16.92z"
-								/>
-							</svg>
-							<span>{resume.contact.phone}</span>
-						</a>
-					{/if}
-					{#if resume.contact.linkedin}
-						<a
-							class="contact-item contact-link"
-							href={resume.contact.linkedin.startsWith('http')
-								? resume.contact.linkedin
-								: `https://${resume.contact.linkedin}`}
-							target="_blank"
-							rel="noopener noreferrer"
-						>
-							<svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
-								<path
-									d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"
-								/>
-							</svg>
-							<span>{resume.contact.linkedin}</span>
-						</a>
-					{/if}
-					{#if resume.contact.github}
-						<a
-							class="contact-item contact-link"
-							href={resume.contact.github.startsWith('http')
-								? resume.contact.github
-								: `https://${resume.contact.github}`}
-							target="_blank"
-							rel="noopener noreferrer"
-						>
-							<svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
-								<path
-									d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"
-								/>
-							</svg>
-							<span>{resume.contact.github}</span>
-						</a>
-					{/if}
-					{#if resume.contact.website}
-						<a
-							class="contact-item contact-link"
-							href={resume.contact.website.startsWith('http')
-								? resume.contact.website
-								: `https://${resume.contact.website}`}
-							target="_blank"
-							rel="noopener noreferrer"
-						>
-							<svg
-								width="14"
-								height="14"
-								viewBox="0 0 24 24"
-								fill="none"
-								stroke="currentColor"
-								stroke-width="2"
-							>
-								<circle cx="12" cy="12" r="10" />
-								<line x1="2" y1="12" x2="22" y2="12" />
-								<path
-									d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"
-								/>
-							</svg>
-							<span>{resume.contact.website}</span>
-						</a>
-					{/if}
-				</div>
+		<div class="columns">
+			<div class="detail contact">
+				<h4>{localeStore.t('overview.contact')}</h4>
+				{#if resume.contact.name}<p>◉ {resume.contact.name}</p>{/if}
+				{#if resume.contact.email}<p>✉ {resume.contact.email}</p>{/if}
+				{#if resume.contact.phone}<p>☎ {resume.contact.phone}</p>{/if}
+				{#if resume.contact.location}<p>⌖ {resume.contact.location}</p>{/if}
+				{#if resume.contact.linkedin}<p>in {resume.contact.linkedin}</p>{/if}
+				{#if resume.contact.github}<p>⌘ {resume.contact.github}</p>{/if}
 			</div>
-		{/if}
 
-		<!-- format warnings -->
-		<div class="format-flags">
-			<div class="flag" class:flagged={resume.metadata.hasMultipleColumns}>
-				{#if resume.metadata.hasMultipleColumns}
-					<svg
-						width="14"
-						height="14"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="#eab308"
-						stroke-width="2"
-					>
-						<circle cx="12" cy="12" r="10" />
-						<line x1="12" y1="8" x2="12" y2="12" />
-						<line x1="12" y1="16" x2="12.01" y2="16" />
-					</svg>
-				{:else}
-					<svg
-						width="14"
-						height="14"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="#22c55e"
-						stroke-width="2.5"
-					>
-						<polyline points="20,6 9,17 4,12" />
-					</svg>
-				{/if}
-				<span>Multi-Column Layout</span>
-			</div>
-			<div class="flag" class:flagged={resume.metadata.hasTables}>
-				{#if resume.metadata.hasTables}
-					<svg
-						width="14"
-						height="14"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="#eab308"
-						stroke-width="2"
-					>
-						<circle cx="12" cy="12" r="10" />
-						<line x1="12" y1="8" x2="12" y2="12" />
-						<line x1="12" y1="16" x2="12.01" y2="16" />
-					</svg>
-				{:else}
-					<svg
-						width="14"
-						height="14"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="#22c55e"
-						stroke-width="2.5"
-					>
-						<polyline points="20,6 9,17 4,12" />
-					</svg>
-				{/if}
-				<span>Tables Detected</span>
-			</div>
-			<div class="flag" class:flagged={resume.metadata.hasImages}>
-				{#if resume.metadata.hasImages}
-					<svg
-						width="14"
-						height="14"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="#eab308"
-						stroke-width="2"
-					>
-						<circle cx="12" cy="12" r="10" />
-						<line x1="12" y1="8" x2="12" y2="12" />
-						<line x1="12" y1="16" x2="12.01" y2="16" />
-					</svg>
-				{:else}
-					<svg
-						width="14"
-						height="14"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="#22c55e"
-						stroke-width="2.5"
-					>
-						<polyline points="20,6 9,17 4,12" />
-					</svg>
-				{/if}
-				<span>Images/Graphics</span>
+			<div class="detail flags">
+				<h4>{localeStore.t('overview.method')}</h4>
+				<p class:warning={resume.metadata.hasMultipleColumns}>
+					{resume.metadata.hasMultipleColumns ? '⚠' : '✓'} {localeStore.t('overview.layout')}:
+					{resume.metadata.hasMultipleColumns ? localeStore.t('overview.yes') : localeStore.t('overview.no')}
+				</p>
+				<p class:warning={resume.metadata.hasTables}>
+					{resume.metadata.hasTables ? '⚠' : '✓'} {localeStore.t('overview.tables')}:
+					{resume.metadata.hasTables ? localeStore.t('overview.yes') : localeStore.t('overview.no')}
+				</p>
+				<p class:warning={resume.metadata.hasImages}>
+					{resume.metadata.hasImages ? '⚠' : '✓'} {localeStore.t('overview.images')}:
+					{resume.metadata.hasImages ? localeStore.t('overview.yes') : localeStore.t('overview.no')}
+				</p>
 			</div>
 		</div>
-	</div>
+	</section>
 {/if}
 
 <style>
-	.resume-stats {
-		padding: 1.75rem;
-		background: var(--glass-bg);
+	.overview {
+		padding: 1.4rem;
 		border: 1px solid var(--glass-border);
 		border-radius: var(--radius-xl);
-		backdrop-filter: blur(var(--glass-blur));
+		background: var(--glass-bg);
 	}
 
-	.stats-header {
+	header {
 		display: flex;
 		align-items: center;
-		gap: 0.5rem;
-		margin-bottom: 1.5rem;
-		color: var(--accent-cyan);
-	}
-
-	.stats-header h3 {
-		font-size: 1.1rem;
-		font-weight: 700;
-		color: var(--text-primary);
-	}
-
-	.stats-grid {
-		display: grid;
-		grid-template-columns: repeat(3, 1fr);
+		justify-content: space-between;
 		gap: 1rem;
-		margin-bottom: 1.5rem;
+		margin-bottom: 1.2rem;
 	}
 
-	.stat-item {
-		display: flex;
-		flex-direction: column;
-		align-items: center;
-		padding: 0.75rem;
-		background: rgba(255, 255, 255, 0.02);
-		border: 1px solid var(--glass-border);
-		border-radius: var(--radius-md);
-	}
-
-	.stat-value {
-		font-size: 1.5rem;
-		font-weight: 800;
-		color: var(--text-primary);
-		font-variant-numeric: tabular-nums;
-		line-height: 1;
-	}
-
-	.stat-label {
-		font-size: 0.7rem;
+	.eyebrow,
+	h4,
+	.stats span,
+	.confidence span {
 		color: var(--text-tertiary);
+		font-size: 0.72rem;
 		text-transform: uppercase;
 		letter-spacing: 0.05em;
-		margin-top: 0.25rem;
 	}
 
-	.section-detail {
-		margin-bottom: 1.25rem;
-		padding-top: 1rem;
-		border-top: 1px solid var(--glass-border);
+	header h3 {
+		margin-top: 0.2rem;
+		color: var(--text-primary);
+		font-size: 1.05rem;
 	}
 
-	.section-detail h4 {
-		font-size: 0.85rem;
-		font-weight: 600;
-		color: var(--text-secondary);
-		margin-bottom: 0.6rem;
-	}
-
-	.section-chips,
-	.skill-chips {
-		display: flex;
-		flex-wrap: wrap;
-		gap: 0.35rem;
-	}
-
-	.section-chip {
-		display: inline-flex;
-		align-items: center;
-		gap: 0.3rem;
-		padding: 0.2rem 0.6rem;
-		background: rgba(34, 197, 94, 0.08);
-		color: #22c55e;
-		border: 1px solid rgba(34, 197, 94, 0.15);
-		border-radius: var(--radius-full);
-		font-size: 0.72rem;
-		font-weight: 500;
-		text-transform: capitalize;
-	}
-
-	.skill-chip {
-		padding: 0.2rem 0.6rem;
-		background: rgba(6, 182, 212, 0.08);
-		color: var(--accent-cyan);
-		border: 1px solid rgba(6, 182, 212, 0.15);
-		border-radius: var(--radius-full);
-		font-size: 0.72rem;
-		font-weight: 500;
-	}
-
-	.skill-chip.more {
-		background: rgba(255, 255, 255, 0.03);
-		color: var(--text-tertiary);
-		border-color: var(--glass-border);
-		cursor: pointer;
-		transition:
-			border-color 0.15s ease,
-			color 0.15s ease;
-		font-family: inherit;
-	}
-
-	.skill-chip.more:hover {
-		border-color: rgba(6, 182, 212, 0.3);
-		color: var(--accent-cyan);
-	}
-
-	.contact-items {
+	.confidence {
 		display: flex;
 		flex-direction: column;
-		gap: 0.4rem;
-	}
-
-	.contact-item {
-		display: flex;
 		align-items: center;
-		gap: 0.5rem;
-		font-size: 0.85rem;
-		color: var(--text-secondary);
+		min-width: 82px;
+		padding: 0.65rem;
+		border: 1px solid currentColor;
+		border-radius: var(--radius-lg);
 	}
 
-	.contact-item svg {
-		flex-shrink: 0;
-		color: var(--text-tertiary);
+	.confidence strong {
+		font-size: 1.25rem;
 	}
 
-	.contact-link {
-		text-decoration: none;
-		transition: color 0.15s ease;
-		cursor: pointer;
+	.confidence.high {
+		color: #22c55e;
 	}
 
-	.contact-link:hover {
-		color: var(--accent-cyan);
-	}
-
-	.contact-link:hover svg {
-		color: var(--accent-cyan);
-	}
-
-	.format-flags {
-		display: flex;
-		flex-wrap: wrap;
-		gap: 0.75rem;
-		padding-top: 1rem;
-		border-top: 1px solid var(--glass-border);
-	}
-
-	.flag {
-		display: flex;
-		align-items: center;
-		gap: 0.4rem;
-		font-size: 0.78rem;
-		color: var(--text-tertiary);
-	}
-
-	.flag.flagged {
+	.confidence.medium {
 		color: #eab308;
 	}
 
-	@media (max-width: 480px) {
-		.stats-grid {
-			grid-template-columns: repeat(2, 1fr);
+	.confidence.low {
+		color: #ef4444;
+	}
+
+	.stats {
+		display: grid;
+		grid-template-columns: repeat(6, minmax(0, 1fr));
+		gap: 0.65rem;
+	}
+
+	.stats div {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 0.3rem;
+		padding: 0.75rem 0.35rem;
+		border: 1px solid var(--glass-border);
+		border-radius: var(--radius-md);
+		background: rgba(255, 255, 255, 0.02);
+	}
+
+	.stats strong {
+		color: var(--text-primary);
+		font-size: 1.2rem;
+	}
+
+	.detail {
+		margin-top: 1.1rem;
+		padding-top: 1rem;
+		border-top: 1px solid var(--glass-border);
+	}
+
+	h4 {
+		margin-bottom: 0.6rem;
+	}
+
+	.chips {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.4rem;
+	}
+
+	.chips span,
+	.chips button {
+		padding: 0.28rem 0.55rem;
+		border: 1px solid rgba(6, 182, 212, 0.25);
+		border-radius: 999px;
+		background: rgba(6, 182, 212, 0.06);
+		color: var(--accent-cyan);
+		font-size: 0.72rem;
+	}
+
+	.chips button {
+		cursor: pointer;
+	}
+
+	.columns {
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+		gap: 1rem;
+	}
+
+	.contact p,
+	.flags p {
+		margin-top: 0.4rem;
+		overflow-wrap: anywhere;
+		color: var(--text-secondary);
+		font-size: 0.8rem;
+	}
+
+	.flags p {
+		color: #22c55e;
+	}
+
+	.flags p.warning {
+		color: #eab308;
+	}
+
+	@media (max-width: 760px) {
+		.stats {
+			grid-template-columns: repeat(3, minmax(0, 1fr));
+		}
+
+		.columns {
+			grid-template-columns: 1fr;
 		}
 	}
 </style>

--- a/src/lib/components/scoring/ScanHistory.svelte
+++ b/src/lib/components/scoring/ScanHistory.svelte
@@ -1,33 +1,32 @@
 <script lang="ts">
-	import { scoresStore, type ScanHistoryEntry } from '$stores/scores.svelte';
 	import { scrollBehavior } from '$lib/a11y';
+	import { localeStore } from '$stores/locale.svelte';
+	import { scoresStore, type ScanHistoryEntry } from '$stores/scores.svelte';
 
 	let expanded = $state(false);
-
 	const history = $derived(scoresStore.history);
 	const hasHistory = $derived(history.length > 0);
 
-	// per-row average-score delta vs the chronologically prior scan;
-	// history is newest-first so history[i+1] is the previous one
 	function deltaFor(index: number): number | null {
-		const prior = history[index + 1];
-		if (!prior) return null;
-		return history[index].averageScore - prior.averageScore;
+		const previous = history[index + 1];
+		return previous ? history[index].averageScore - previous.averageScore : null;
 	}
 
 	function formatDate(iso: string): string {
-		const d = new Date(iso);
-		const now = new Date();
-		const diff = now.getTime() - d.getTime();
-		const mins = Math.floor(diff / 60_000);
-		const hours = Math.floor(diff / 3_600_000);
-		const days = Math.floor(diff / 86_400_000);
-
-		if (mins < 1) return 'just now';
-		if (mins < 60) return `${mins}m ago`;
-		if (hours < 24) return `${hours}h ago`;
-		if (days < 7) return `${days}d ago`;
-		return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+		const date = new Date(iso);
+		const difference = Date.now() - date.getTime();
+		const minutes = Math.floor(difference / 60_000);
+		const hours = Math.floor(difference / 3_600_000);
+		const days = Math.floor(difference / 86_400_000);
+		const pt = localeStore.locale === 'pt-BR';
+		if (minutes < 1) return pt ? 'agora' : 'just now';
+		if (minutes < 60) return pt ? `há ${minutes} min` : `${minutes}m ago`;
+		if (hours < 24) return pt ? `há ${hours} h` : `${hours}h ago`;
+		if (days < 7) return pt ? `há ${days} d` : `${days}d ago`;
+		return date.toLocaleDateString(pt ? 'pt-BR' : 'en-US', {
+			day: '2-digit',
+			month: 'short'
+		});
 	}
 
 	function scoreColor(score: number): string {
@@ -36,350 +35,177 @@
 		return '#ef4444';
 	}
 
-	function handleLoadEntry(entry: ScanHistoryEntry) {
+	function load(entry: ScanHistoryEntry) {
 		scoresStore.loadFromHistory(entry);
-		// wait for the results section to render, then scroll to it.
-		// scrollBehavior() reads the user's prefers-reduced-motion setting,
-		// so users who asked for reduced motion get an instant jump rather
-		// than a smooth scroll their OS told us not to perform.
 		requestAnimationFrame(() => {
 			document
-				.querySelector('.results-section')
+				.querySelector('.results')
 				?.scrollIntoView({ behavior: scrollBehavior(), block: 'start' });
 		});
-	}
-
-	function handleClear() {
-		scoresStore.clearHistory();
 	}
 </script>
 
 {#if hasHistory}
-	<div class="history-section">
-		<button class="history-toggle" onclick={() => (expanded = !expanded)} aria-expanded={expanded}>
-			<div class="toggle-left">
-				<svg
-					width="14"
-					height="14"
-					viewBox="0 0 24 24"
-					fill="none"
-					stroke="currentColor"
-					stroke-width="2"
-				>
-					<circle cx="12" cy="12" r="10" />
-					<polyline points="12,6 12,12 16,14" />
-				</svg>
-				<span>Scan History</span>
-				<span class="history-count">{history.length}</span>
-			</div>
-			<svg
-				class="chevron"
-				class:open={expanded}
-				width="14"
-				height="14"
-				viewBox="0 0 24 24"
-				fill="none"
-				stroke="currentColor"
-				stroke-width="2"
-			>
-				<polyline points="6,9 12,15 18,9" />
-			</svg>
+	<section class="history">
+		<button class="toggle" type="button" onclick={() => (expanded = !expanded)} aria-expanded={expanded}>
+			<span>◷ {localeStore.locale === 'pt-BR' ? 'Histórico de análises' : 'Scan history'}</span>
+			<small>{history.length}</small>
+			<b aria-hidden="true">{expanded ? '⌃' : '⌄'}</b>
 		</button>
 
 		{#if expanded}
-			<div class="history-list">
-				{#each history as entry, i (entry.id)}
-					{@const delta = deltaFor(i)}
-					<button
-						class="history-entry"
-						onclick={() => handleLoadEntry(entry)}
-						title="Click to view these results"
-					>
-						<div class="entry-score-block">
-							<div class="entry-score" style="color: {scoreColor(entry.averageScore)}">
-								{entry.averageScore}
-							</div>
+			<div class="list">
+				{#each history as entry, index (entry.id)}
+					{@const delta = deltaFor(index)}
+					<button class="entry" type="button" onclick={() => load(entry)}>
+						<div class="score" style:color={scoreColor(entry.averageScore)}>
+							<strong>{entry.averageScore}</strong>
 							{#if delta !== null && delta !== 0}
-								<span
-									class="entry-delta"
-									class:positive={delta > 0}
-									class:negative={delta < 0}
-									title="{delta > 0 ? '+' : ''}{delta} vs previous scan"
-								>
+								<small class:positive={delta > 0} class:negative={delta < 0}>
 									{delta > 0 ? '+' : ''}{delta}
-								</span>
+								</small>
 							{/if}
 						</div>
-						<div class="entry-details">
-							<div class="entry-info">
-								{#if entry.fileName}
-									<span class="entry-filename">{entry.fileName}</span>
-								{/if}
-								<div class="entry-meta">
-									<span class="entry-mode">{entry.mode}</span>
-									<span class="entry-sep">&middot;</span>
-									<span class="entry-passing">{entry.passingCount}/6 passing</span>
-								</div>
-							</div>
-							<span class="entry-time">{formatDate(entry.timestamp)}</span>
+						<div class="details">
+							<strong>{entry.fileName || (localeStore.locale === 'pt-BR' ? 'Texto colado' : 'Pasted text')}</strong>
+							<span>
+								{entry.mode === 'targeted'
+									? localeStore.locale === 'pt-BR' ? 'vaga direcionada' : 'targeted'
+									: localeStore.locale === 'pt-BR' ? 'geral' : 'general'}
+								· {entry.passingCount}/{entry.results.length}
+							</span>
 						</div>
-						<svg
-							class="entry-arrow"
-							width="14"
-							height="14"
-							viewBox="0 0 24 24"
-							fill="none"
-							stroke="currentColor"
-							stroke-width="2"
-						>
-							<polyline points="9,18 15,12 9,6" />
-						</svg>
+						<time>{formatDate(entry.timestamp)}</time>
 					</button>
 				{/each}
-
-				<button class="clear-btn" onclick={handleClear}>
-					<svg
-						width="12"
-						height="12"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						stroke-width="2"
-					>
-						<polyline points="3,6 5,6 21,6" />
-						<path
-							d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"
-						/>
-					</svg>
-					Clear History
+				<button class="clear" type="button" onclick={() => scoresStore.clearHistory()}>
+					{localeStore.locale === 'pt-BR' ? 'Limpar histórico' : 'Clear history'}
 				</button>
 			</div>
 		{/if}
-	</div>
+	</section>
 {/if}
 
 <style>
-	.history-section {
-		margin-top: 1.5rem;
+	.history {
+		margin-top: 1rem;
 		border: 1px solid var(--glass-border);
-		border-radius: var(--radius-md);
+		border-radius: var(--radius-lg);
 		background: var(--glass-bg);
-		backdrop-filter: blur(var(--glass-blur));
 		overflow: hidden;
-		animation: fadeIn 0.3s ease;
 	}
 
-	@keyframes fadeIn {
-		from {
-			opacity: 0;
-			transform: translateY(8px);
-		}
-	}
-
-	.history-toggle {
+	.toggle,
+	.entry,
+	.clear {
 		width: 100%;
-		display: flex;
-		align-items: center;
-		justify-content: space-between;
-		padding: 0.75rem 1rem;
-		background: none;
-		border: none;
-		cursor: pointer;
+		border: 0;
+		background: transparent;
 		color: var(--text-secondary);
-		font-size: 0.8rem;
-		font-weight: 600;
-		transition: color 0.2s ease;
+		cursor: pointer;
+		font: inherit;
 	}
 
-	.history-toggle:hover {
-		color: var(--text-primary);
-	}
-
-	.toggle-left {
-		display: flex;
+	.toggle {
+		display: grid;
+		grid-template-columns: 1fr auto auto;
 		align-items: center;
-		gap: 0.5rem;
+		gap: 0.6rem;
+		padding: 0.8rem 1rem;
+		text-align: left;
 	}
 
-	.toggle-left svg {
-		color: var(--accent-cyan);
-		opacity: 0.7;
-	}
-
-	.history-count {
-		display: inline-flex;
-		align-items: center;
-		justify-content: center;
-		min-width: 18px;
-		height: 18px;
-		padding: 0 5px;
-		border-radius: var(--radius-full);
+	.toggle small {
+		display: grid;
+		place-items: center;
+		min-width: 22px;
+		height: 22px;
+		border-radius: 999px;
 		background: rgba(6, 182, 212, 0.1);
 		color: var(--accent-cyan);
-		font-size: 0.65rem;
-		font-weight: 700;
 	}
 
-	.chevron {
-		transition: transform 0.2s ease;
-	}
-
-	.chevron.open {
-		transform: rotate(180deg);
-	}
-
-	.history-list {
+	.list {
+		display: grid;
+		gap: 0.35rem;
+		padding: 0.55rem;
 		border-top: 1px solid var(--glass-border);
-		padding: 0.5rem;
-		display: flex;
-		flex-direction: column;
-		gap: 0.25rem;
-		animation: slideDown 0.2s ease;
 	}
 
-	@keyframes slideDown {
-		from {
-			opacity: 0;
-			transform: translateY(-4px);
-		}
-	}
-
-	.history-entry {
-		display: flex;
+	.entry {
+		display: grid;
+		grid-template-columns: 52px 1fr auto;
 		align-items: center;
 		gap: 0.75rem;
-		padding: 0.6rem 0.75rem;
-		border-radius: var(--radius-sm);
-		transition: background 0.15s ease;
-		width: 100%;
-		background: none;
-		border: none;
-		cursor: pointer;
+		padding: 0.7rem;
+		border-radius: var(--radius-md);
 		text-align: left;
-		font-family: inherit;
 	}
 
-	.history-entry:hover {
+	.entry:hover {
 		background: rgba(6, 182, 212, 0.04);
 	}
 
-	.entry-score-block {
+	.score {
 		display: flex;
 		flex-direction: column;
 		align-items: center;
-		gap: 0.15rem;
-		min-width: 2.5rem;
 	}
 
-	.entry-score {
+	.score strong {
 		font-size: 1.1rem;
-		font-weight: 800;
-		font-variant-numeric: tabular-nums;
-		text-align: center;
-		line-height: 1;
 	}
 
-	.entry-delta {
-		font-size: 0.62rem;
-		font-weight: 700;
-		font-variant-numeric: tabular-nums;
-		padding: 0.05rem 0.32rem;
-		border-radius: var(--radius-full);
-		line-height: 1.4;
+	.score small {
+		font-size: 0.65rem;
 	}
 
-	.entry-delta.positive {
+	.score small.positive {
 		color: #22c55e;
-		background: rgba(34, 197, 94, 0.12);
 	}
 
-	.entry-delta.negative {
+	.score small.negative {
 		color: #ef4444;
-		background: rgba(239, 68, 68, 0.12);
 	}
 
-	.entry-details {
-		flex: 1;
+	.details {
 		display: flex;
-		align-items: center;
-		justify-content: space-between;
-		gap: 0.5rem;
 		min-width: 0;
-	}
-
-	.entry-info {
-		display: flex;
 		flex-direction: column;
-		gap: 0.15rem;
-		min-width: 0;
+		gap: 0.2rem;
 	}
 
-	.entry-filename {
-		font-size: 0.78rem;
-		font-weight: 500;
-		color: var(--text-secondary);
-		white-space: nowrap;
+	.details strong {
 		overflow: hidden;
 		text-overflow: ellipsis;
-		max-width: 180px;
-	}
-
-	.entry-meta {
-		display: flex;
-		align-items: center;
-		gap: 0.4rem;
-		font-size: 0.72rem;
-		color: var(--text-tertiary);
-	}
-
-	.entry-mode {
-		text-transform: capitalize;
+		white-space: nowrap;
 		color: var(--text-secondary);
-		font-weight: 500;
+		font-size: 0.78rem;
 	}
 
-	.entry-sep {
-		opacity: 0.4;
-	}
-
-	.entry-time {
-		font-size: 0.7rem;
+	.details span,
+	time {
 		color: var(--text-tertiary);
+		font-size: 0.7rem;
+	}
+
+	time {
 		white-space: nowrap;
 	}
 
-	.entry-arrow {
-		color: var(--text-tertiary);
-		opacity: 0;
-		transition: opacity 0.15s ease;
-		flex-shrink: 0;
-	}
-
-	.history-entry:hover .entry-arrow {
-		opacity: 0.6;
-	}
-
-	.clear-btn {
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		gap: 0.4rem;
-		padding: 0.5rem;
-		margin-top: 0.25rem;
-		background: none;
-		border: 1px solid transparent;
-		border-radius: var(--radius-sm);
-		color: var(--text-tertiary);
-		font-size: 0.7rem;
-		font-weight: 500;
-		cursor: pointer;
-		transition:
-			color 0.2s ease,
-			border-color 0.2s ease;
-	}
-
-	.clear-btn:hover {
+	.clear {
+		padding: 0.6rem;
 		color: #ef4444;
-		border-color: rgba(239, 68, 68, 0.2);
+		font-size: 0.72rem;
+	}
+
+	@media (max-width: 520px) {
+		.entry {
+			grid-template-columns: 46px 1fr;
+		}
+
+		time {
+			display: none;
+		}
 	}
 </style>

--- a/src/lib/components/scoring/ScanningAnimation.svelte
+++ b/src/lib/components/scoring/ScanningAnimation.svelte
@@ -1,412 +1,97 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
+	import { localeStore } from '$stores/locale.svelte';
 
-	const platforms = [
-		{ name: 'Workday', vendor: 'Workday Inc.', color: '#06b6d4' },
-		{ name: 'Taleo', vendor: 'Oracle', color: '#f59e0b' },
-		{ name: 'iCIMS', vendor: 'iCIMS', color: '#3b82f6' },
-		{ name: 'Greenhouse', vendor: 'Greenhouse', color: '#22c55e' },
-		{ name: 'Lever', vendor: 'Employ', color: '#8b5cf6' },
-		{ name: 'SuccessFactors', vendor: 'SAP', color: '#f59e0b' }
-	];
-
-	// fun rotating status verbs (like Claude Code's style)
-	const statusVerbs = [
-		'parsing sections',
-		'extracting keywords',
-		'simulating Workday parser',
-		'testing Taleo compatibility',
-		'analyzing keyword density',
-		'evaluating formatting',
-		'checking section structure',
-		'running iCIMS Role Fit',
-		'measuring experience depth',
-		'scanning for ATS pitfalls',
-		'matching semantic clusters',
-		'computing relevance scores',
-		'profiling Greenhouse match',
-		'assessing Lever compatibility',
-		'calibrating SAP taxonomy',
-		'cross-referencing platforms',
-		'generating suggestions',
-		'finalizing scores'
-	];
-
-	let activeIndex = $state(0);
-	let verbIndex = $state(0);
-	let mounted = $state(false);
-	let elapsed = $state(0);
+	const platforms = ['Gupy-like', 'Workday', 'Taleo', 'SuccessFactors', 'iCIMS', 'Greenhouse', 'Lever'];
+	let active = $state(0);
 
 	onMount(() => {
-		mounted = true;
-
-		// cycle platforms
-		const platformInterval = setInterval(() => {
-			activeIndex = (activeIndex + 1) % platforms.length;
-		}, 2000);
-
-		// cycle status verbs faster
-		const verbInterval = setInterval(() => {
-			verbIndex = (verbIndex + 1) % statusVerbs.length;
-		}, 1400);
-
-		// elapsed timer
-		const timerInterval = setInterval(() => {
-			elapsed++;
-		}, 1000);
-
-		return () => {
-			clearInterval(platformInterval);
-			clearInterval(verbInterval);
-			clearInterval(timerInterval);
-		};
+		const timer = setInterval(() => {
+			active = (active + 1) % platforms.length;
+		}, 220);
+		return () => clearInterval(timer);
 	});
 </script>
 
-<div class="scanning" class:mounted>
-	<!-- glassmorphic scanning card -->
-	<div class="scan-card">
-		<!-- animated border -->
-		<div class="scan-border"></div>
-
-		<div class="scan-inner">
-			<!-- orbiting ring -->
-			<div class="orbit-container">
-				<div class="orbit-ring">
-					<div class="orbit-dot"></div>
-				</div>
-				<div class="center-icon">
-					<svg
-						width="28"
-						height="28"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						stroke-width="1.5"
-					>
-						<path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
-						<polyline points="14,2 14,8 20,8" />
-						<line x1="16" y1="13" x2="8" y2="13" />
-						<line x1="16" y1="17" x2="8" y2="17" />
-						<polyline points="10,9 9,9 8,9" />
-					</svg>
-				</div>
-			</div>
-
-			<h3 class="scan-title">Analyzing across 6 ATS platforms</h3>
-
-			<!-- rotating status verb -->
-			<div class="status-verb-container">
-				{#key verbIndex}
-					<span class="status-verb">{statusVerbs[verbIndex]}</span>
-				{/key}
-			</div>
-
-			<!-- platform progress row -->
-			<div class="platform-row">
-				{#each platforms as platform, i}
-					<div
-						class="platform-pip"
-						class:active={i === activeIndex}
-						class:done={i < activeIndex}
-						style="--pip-color: {platform.color}"
-					>
-						<div class="pip-fill" class:filling={i === activeIndex}></div>
-						{#if i < activeIndex}
-							<svg
-								width="10"
-								height="10"
-								viewBox="0 0 24 24"
-								fill="none"
-								stroke="currentColor"
-								stroke-width="3"
-							>
-								<polyline points="20,6 9,17 4,12" />
-							</svg>
-						{:else if i === activeIndex}
-							<div class="pip-spinner"></div>
-						{/if}
-						<span class="pip-label">{platform.name}</span>
-					</div>
-				{/each}
-			</div>
-
-			<!-- elapsed time -->
-			<div class="scan-meta">
-				<span class="meta-dot"></span>
-				<span>{elapsed}s elapsed</span>
-			</div>
-		</div>
+<div class="scanning" role="status">
+	<div class="spinner" aria-hidden="true"></div>
+	<h3>{localeStore.locale === 'pt-BR' ? 'Calculando pontuações determinísticas' : 'Computing deterministic scores'}</h3>
+	<p>{localeStore.locale === 'pt-BR'
+		? 'Aplicando regras, requisitos da vaga e perfis ATS locais.'
+		: 'Applying local rules, job requirements and ATS profiles.'}</p>
+	<div class="platforms">
+		{#each platforms as platform, index}
+			<span class:active={index === active} class:done={index < active}>{platform}</span>
+		{/each}
 	</div>
 </div>
 
 <style>
 	.scanning {
-		padding: 3rem 0;
-		opacity: 0;
-		transform: translateY(20px);
-		transition:
-			opacity 0.5s cubic-bezier(0.16, 1, 0.3, 1),
-			transform 0.5s cubic-bezier(0.16, 1, 0.3, 1);
-	}
-
-	.scanning.mounted {
-		opacity: 1;
-		transform: translateY(0);
-	}
-
-	/* glassmorphic card with animated border */
-	.scan-card {
-		position: relative;
-		max-width: 560px;
-		margin: 0 auto;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		max-width: 680px;
+		margin: 2rem auto;
+		padding: 2rem;
+		border: 1px solid var(--glass-border);
 		border-radius: var(--radius-xl);
-		overflow: hidden;
-	}
-
-	.scan-border {
-		position: absolute;
-		inset: 0;
-		border-radius: inherit;
-		padding: 1px;
-		background: conic-gradient(
-			from var(--border-angle, 0deg),
-			transparent 40%,
-			rgba(6, 182, 212, 0.6),
-			rgba(59, 130, 246, 0.4),
-			rgba(139, 92, 246, 0.3),
-			transparent 80%
-		);
-		mask:
-			linear-gradient(#000 0 0) content-box,
-			linear-gradient(#000 0 0);
-		mask-composite: exclude;
-		animation: rotate-border 3s linear infinite;
-	}
-
-	@property --border-angle {
-		syntax: '<angle>';
-		initial-value: 0deg;
-		inherits: false;
-	}
-
-	@keyframes rotate-border {
-		to {
-			--border-angle: 360deg;
-		}
-	}
-
-	.scan-inner {
-		position: relative;
-		padding: 2.5rem 2rem;
 		background: var(--glass-bg);
-		backdrop-filter: blur(var(--glass-blur));
-		border-radius: inherit;
 		text-align: center;
 	}
 
-	/* orbiting ring around center icon */
-	.orbit-container {
-		position: relative;
-		width: 72px;
-		height: 72px;
-		margin: 0 auto 1.5rem;
-	}
-
-	.orbit-ring {
-		position: absolute;
-		inset: 0;
-		border: 1px solid rgba(6, 182, 212, 0.2);
+	.spinner {
+		width: 46px;
+		height: 46px;
+		border: 3px solid rgba(6, 182, 212, 0.15);
+		border-top-color: var(--accent-cyan);
 		border-radius: 50%;
-		animation: spin 4s linear infinite;
+		animation: spin 0.75s linear infinite;
 	}
 
-	.orbit-dot {
-		position: absolute;
-		top: -3px;
-		left: 50%;
-		transform: translateX(-50%);
-		width: 6px;
-		height: 6px;
-		border-radius: 50%;
-		background: var(--accent-cyan);
-		box-shadow: 0 0 10px rgba(6, 182, 212, 0.6);
+	h3 {
+		margin-top: 1rem;
+		color: var(--text-primary);
+		font-size: 1.1rem;
 	}
 
-	.center-icon {
-		position: absolute;
-		inset: 0;
+	p {
+		margin-top: 0.45rem;
+		color: var(--text-tertiary);
+		font-size: 0.82rem;
+	}
+
+	.platforms {
 		display: flex;
-		align-items: center;
+		flex-wrap: wrap;
 		justify-content: center;
+		gap: 0.45rem;
+		margin-top: 1.2rem;
+	}
+
+	.platforms span {
+		padding: 0.3rem 0.55rem;
+		border: 1px solid var(--glass-border);
+		border-radius: 999px;
+		color: var(--text-tertiary);
+		font-size: 0.7rem;
+		transition: 0.2s ease;
+	}
+
+	.platforms span.active {
+		border-color: var(--accent-cyan);
 		color: var(--accent-cyan);
-		opacity: 0.8;
+		transform: translateY(-1px);
+	}
+
+	.platforms span.done {
+		border-color: rgba(34, 197, 94, 0.35);
+		color: #22c55e;
 	}
 
 	@keyframes spin {
 		to {
 			transform: rotate(360deg);
-		}
-	}
-
-	.scan-title {
-		font-size: 1.1rem;
-		font-weight: 700;
-		color: var(--text-primary);
-		margin-bottom: 0.75rem;
-	}
-
-	/* rotating status verb with entrance animation */
-	.status-verb-container {
-		height: 1.6rem;
-		overflow: hidden;
-		margin-bottom: 2rem;
-	}
-
-	.status-verb {
-		display: block;
-		font-size: 0.88rem;
-		color: var(--accent-cyan);
-		font-weight: 500;
-		animation: verb-enter 0.35s cubic-bezier(0.16, 1, 0.3, 1);
-	}
-
-	@keyframes verb-enter {
-		from {
-			opacity: 0;
-			transform: translateY(12px);
-			filter: blur(4px);
-		}
-		to {
-			opacity: 1;
-			transform: translateY(0);
-			filter: blur(0);
-		}
-	}
-
-	/* platform progress pips */
-	.platform-row {
-		display: flex;
-		justify-content: center;
-		gap: 0.5rem;
-		margin-bottom: 1.5rem;
-	}
-
-	.platform-pip {
-		position: relative;
-		display: flex;
-		flex-direction: column;
-		align-items: center;
-		gap: 0.4rem;
-		padding: 0.5rem 0.6rem;
-		border-radius: var(--radius-md);
-		background: rgba(255, 255, 255, 0.02);
-		border: 1px solid var(--glass-border);
-		min-width: 68px;
-		overflow: hidden;
-		transition:
-			border-color 0.3s ease,
-			background 0.3s ease;
-	}
-
-	.platform-pip.active {
-		border-color: var(--pip-color);
-		background: color-mix(in srgb, var(--pip-color) 6%, transparent);
-	}
-
-	.platform-pip.done {
-		border-color: rgba(34, 197, 94, 0.3);
-	}
-
-	.platform-pip.done svg {
-		color: #22c55e;
-	}
-
-	.pip-fill {
-		position: absolute;
-		bottom: 0;
-		left: 0;
-		height: 2px;
-		width: 0;
-		background: var(--pip-color);
-	}
-
-	.pip-fill.filling {
-		animation: fill-bar 2s linear forwards;
-	}
-
-	@keyframes fill-bar {
-		to {
-			width: 100%;
-		}
-	}
-
-	.pip-spinner {
-		width: 10px;
-		height: 10px;
-		border: 1.5px solid var(--glass-border);
-		border-top-color: var(--pip-color);
-		border-radius: 50%;
-		animation: spin 0.6s linear infinite;
-	}
-
-	.pip-label {
-		font-size: 0.58rem;
-		font-weight: 600;
-		color: var(--text-tertiary);
-		text-transform: uppercase;
-		letter-spacing: 0.04em;
-		white-space: nowrap;
-	}
-
-	.platform-pip.active .pip-label {
-		color: var(--text-secondary);
-	}
-
-	.platform-pip.done .pip-label {
-		color: var(--text-secondary);
-	}
-
-	/* meta info */
-	.scan-meta {
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		gap: 0.5rem;
-		font-size: 0.72rem;
-		color: var(--text-tertiary);
-		opacity: 0.6;
-	}
-
-	.meta-dot {
-		width: 5px;
-		height: 5px;
-		border-radius: 50%;
-		background: var(--accent-cyan);
-		animation: meta-pulse 1.5s ease-in-out infinite;
-	}
-
-	@keyframes meta-pulse {
-		0%,
-		100% {
-			opacity: 1;
-		}
-		50% {
-			opacity: 0.3;
-		}
-	}
-
-	@media (max-width: 640px) {
-		.platform-row {
-			flex-wrap: wrap;
-		}
-
-		.platform-pip {
-			min-width: 56px;
-		}
-
-		.scan-inner {
-			padding: 2rem 1.25rem;
 		}
 	}
 </style>

--- a/src/lib/components/scoring/ScoreCard.svelte
+++ b/src/lib/components/scoring/ScoreCard.svelte
@@ -1,67 +1,56 @@
 <script lang="ts">
+	import { getScoreColor } from '$engine/scorer/classification';
 	import type { ScoreResult } from '$engine/scorer/types';
-	import { getScoreColor, getScoreLabel } from '$engine/scorer/classification';
+	import { localeStore } from '$stores/locale.svelte';
 
 	let { result, previousScore }: { result: ScoreResult; previousScore?: number } = $props();
-
-	// only show the delta pill when there's a meaningful, signed change vs the
-	// previous scan; identical scores stay quiet to avoid visual noise
-	const delta = $derived(previousScore !== undefined ? result.overallScore - previousScore : null);
-	const showDelta = $derived(delta !== null && delta !== 0);
-
-	// mouse position in px for the spotlight hover effect
-	let mouseX = $state(0);
-	let mouseY = $state(0);
-
-	function handleMouseMove(e: MouseEvent) {
-		const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
-		mouseX = e.clientX - rect.left;
-		mouseY = e.clientY - rect.top;
-	}
-
+	const delta = $derived(previousScore === undefined ? null : result.overallScore - previousScore);
 	const scoreColor = $derived(getScoreColor(result.overallScore));
-	// svg circle math: circumference and dash offset for the ring progress
 	const circumference = 2 * Math.PI * 42;
 	const offset = $derived(circumference - (result.overallScore / 100) * circumference);
 
-	// breakdown categories with proper display labels
-	const breakdownItems = $derived([
-		{ key: 'formatting', label: 'Formatting', score: result.breakdown.formatting.score },
-		{ key: 'keywords', label: 'Keywords', score: result.breakdown.keywordMatch.score },
-		{ key: 'sections', label: 'Sections', score: result.breakdown.sections.score },
-		{ key: 'experience', label: 'Experience', score: result.breakdown.experience.score },
-		{ key: 'education', label: 'Education', score: result.breakdown.education.score }
+	const breakdown = $derived([
+		{
+			label: localeStore.locale === 'pt-BR' ? 'Formatação' : 'Formatting',
+			score: result.breakdown.formatting.score
+		},
+		{
+			label: localeStore.locale === 'pt-BR' ? 'Palavras-chave' : 'Keywords',
+			score: result.breakdown.keywordMatch.score,
+			hide: result.breakdown.keywordMatch.matched.length === 0 && result.breakdown.keywordMatch.missing.length === 0
+		},
+		{
+			label: localeStore.locale === 'pt-BR' ? 'Seções' : 'Sections',
+			score: result.breakdown.sections.score
+		},
+		{
+			label: localeStore.locale === 'pt-BR' ? 'Experiência' : 'Experience',
+			score: result.breakdown.experience.score
+		},
+		{
+			label: localeStore.locale === 'pt-BR' ? 'Formação' : 'Education',
+			score: result.breakdown.education.score
+		}
 	]);
+
+	function verdict(score: number): string {
+		const pt = localeStore.locale === 'pt-BR';
+		if (score >= 80) return pt ? 'Excelente' : 'Excellent';
+		if (score >= 65) return pt ? 'Bom' : 'Good';
+		if (score >= 50) return pt ? 'Precisa melhorar' : 'Needs work';
+		return pt ? 'Fraco' : 'Poor';
+	}
 </script>
 
-<!-- svelte-ignore a11y_no_static_element_interactions -->
-<div
-	class="score-card"
-	class:passing={result.passesFilter}
-	class:failing={!result.passesFilter}
-	onmousemove={handleMouseMove}
-	style="--spotlight-x: {mouseX}px; --spotlight-y: {mouseY}px; --score-color: {scoreColor};"
->
-	<div class="card-spotlight"></div>
-
-	<!-- header: system name + score ring -->
-	<div class="card-header">
-		<div class="system-info">
-			<h3 class="system-name">{result.system}</h3>
-			<p class="system-vendor">{result.vendor}</p>
+<article class="card" class:passing={result.passesFilter} style:--score-color={scoreColor}>
+	<header>
+		<div>
+			<h3>{result.system}</h3>
+			<p>{result.vendor}</p>
 		</div>
-		<div class="score-ring">
-			<svg viewBox="0 0 100 100" width="76" height="76">
-				<!-- background track -->
-				<circle
-					cx="50"
-					cy="50"
-					r="42"
-					fill="none"
-					stroke="rgba(255,255,255,0.05)"
-					stroke-width="6"
-				/>
-				<!-- colored progress arc -->
+		<div class="ring">
+			<svg viewBox="0 0 100 100" width="72" height="72" aria-hidden="true">
+				<circle cx="50" cy="50" r="42" fill="none" stroke="rgba(255,255,255,.06)" stroke-width="6" />
 				<circle
 					cx="50"
 					cy="50"
@@ -73,337 +62,183 @@
 					stroke-dashoffset={offset}
 					stroke-linecap="round"
 					transform="rotate(-90 50 50)"
-					class="score-progress"
 				/>
 			</svg>
-			<span class="score-value" style="color: {scoreColor}">
-				{result.overallScore}
-			</span>
-			{#if showDelta && delta !== null}
-				<span
-					class="score-delta"
-					class:positive={delta > 0}
-					class:negative={delta < 0}
-					title="{delta > 0 ? '+' : ''}{delta} vs previous scan"
-				>
-					{delta > 0 ? '+' : ''}{delta}
-				</span>
+			<strong style:color={scoreColor}>{result.overallScore}</strong>
+			{#if delta !== null && delta !== 0}
+				<small class:positive={delta > 0} class:negative={delta < 0}>{delta > 0 ? '+' : ''}{delta}</small>
 			{/if}
 		</div>
+	</header>
+
+	<div class="status">
+		<span class:pass={result.passesFilter} class:fail={!result.passesFilter}>
+			{result.passesFilter
+				? localeStore.locale === 'pt-BR' ? '✓ Provável aprovação' : '✓ Likely to pass'
+				: localeStore.locale === 'pt-BR' ? '× Pode ser filtrado' : '× May be filtered'}
+		</span>
+		<b style:color={scoreColor}>{verdict(result.overallScore)}</b>
 	</div>
 
-	<!-- pass/fail status badge -->
-	<div class="card-status">
-		{#if result.passesFilter}
-			<span class="status-badge pass">
-				<svg
-					width="12"
-					height="12"
-					viewBox="0 0 24 24"
-					fill="none"
-					stroke="currentColor"
-					stroke-width="3"
-				>
-					<polyline points="20,6 9,17 4,12" />
-				</svg>
-				Likely to Pass
-			</span>
-		{:else}
-			<span class="status-badge fail">
-				<svg
-					width="12"
-					height="12"
-					viewBox="0 0 24 24"
-					fill="none"
-					stroke="currentColor"
-					stroke-width="3"
-				>
-					<line x1="18" y1="6" x2="6" y2="18" />
-					<line x1="6" y1="6" x2="18" y2="18" />
-				</svg>
-				May Be Filtered
-			</span>
-		{/if}
-		<span class="score-label" style="color: {scoreColor}">{getScoreLabel(result.overallScore)}</span
-		>
-	</div>
-
-	<!-- category breakdown bars -->
-	<div class="card-breakdown">
-		{#each breakdownItems as item}
-			<div class="breakdown-item">
-				<span class="breakdown-label">{item.label}</span>
-				<div class="breakdown-bar">
-					<div
-						class="breakdown-fill"
-						style="width: {item.score}%; background: {getScoreColor(item.score)}"
-					></div>
-				</div>
-				<span class="breakdown-value" style="color: {getScoreColor(item.score)}">{item.score}</span>
+	<div class="breakdown">
+		{#each breakdown.filter((item) => !item.hide) as item}
+			<div>
+				<span>{item.label}</span>
+				<i><b style:width={`${item.score}%`} style:background={getScoreColor(item.score)}></b></i>
+				<strong style:color={getScoreColor(item.score)}>{item.score}</strong>
 			</div>
 		{/each}
 	</div>
 
-	<!-- keyword stats if available -->
 	{#if result.breakdown.keywordMatch.matched.length > 0 || result.breakdown.keywordMatch.missing.length > 0}
-		<div class="keyword-summary">
-			<div class="keyword-stat matched">
-				<span class="keyword-count">{result.breakdown.keywordMatch.matched.length}</span>
-				<span class="keyword-label">Matched</span>
-			</div>
-			<div class="keyword-stat missing">
-				<span class="keyword-count">{result.breakdown.keywordMatch.missing.length}</span>
-				<span class="keyword-label">Missing</span>
-			</div>
-		</div>
+		<footer>
+			<span class="matched">{result.breakdown.keywordMatch.matched.length} {localeStore.locale === 'pt-BR' ? 'encontradas' : 'matched'}</span>
+			<span class="missing">{result.breakdown.keywordMatch.missing.length} {localeStore.locale === 'pt-BR' ? 'ausentes' : 'missing'}</span>
+		</footer>
 	{/if}
-</div>
+</article>
 
 <style>
-	.score-card {
-		position: relative;
-		padding: 1.75rem;
-		background: var(--glass-bg);
+	.card {
+		padding: 1.35rem;
 		border: 1px solid var(--glass-border);
 		border-radius: var(--radius-xl);
-		backdrop-filter: blur(var(--glass-blur));
-		overflow: hidden;
-		transition:
-			border-color 0.3s ease,
-			transform 0.25s ease,
-			box-shadow 0.3s ease;
+		background: var(--glass-bg);
+		transition: transform 0.2s ease, border-color 0.2s ease;
 	}
 
-	.score-card:hover {
-		transform: translateY(-3px);
-		box-shadow: 0 16px 32px rgba(0, 0, 0, 0.25);
+	.card:hover {
+		transform: translateY(-2px);
+		border-color: color-mix(in srgb, var(--score-color) 35%, transparent);
 	}
 
-	.score-card.passing:hover {
-		border-color: rgba(34, 197, 94, 0.3);
-	}
-
-	.score-card.failing:hover {
-		border-color: rgba(239, 68, 68, 0.3);
-	}
-
-	.card-spotlight {
-		position: absolute;
-		inset: 0;
-		background: radial-gradient(
-			280px circle at var(--spotlight-x) var(--spotlight-y),
-			rgba(6, 182, 212, 0.06),
-			transparent 60%
-		);
-		pointer-events: none;
-		opacity: 0;
-		transition: opacity 0.3s ease;
-	}
-
-	.score-card:hover .card-spotlight {
-		opacity: 1;
-	}
-
-	.card-header {
-		display: flex;
-		justify-content: space-between;
-		align-items: flex-start;
-		margin-bottom: 1.25rem;
-		position: relative;
-		z-index: 1;
-	}
-
-	.system-info {
-		display: flex;
-		flex-direction: column;
-		gap: 0.25rem;
-	}
-
-	.system-name {
-		font-size: 1.2rem;
-		font-weight: 700;
-		color: var(--text-primary);
-		letter-spacing: -0.01em;
-	}
-
-	.system-vendor {
-		font-size: 0.78rem;
-		color: var(--text-tertiary);
-		text-transform: uppercase;
-		letter-spacing: 0.04em;
-	}
-
-	.score-ring {
-		position: relative;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-	}
-
-	.score-value {
-		position: absolute;
-		font-size: 1.35rem;
-		font-weight: 800;
-		font-variant-numeric: tabular-nums;
-	}
-
-	.score-progress {
-		transition: stroke-dashoffset 1.2s cubic-bezier(0.16, 1, 0.3, 1);
-	}
-
-	.score-delta {
-		position: absolute;
-		bottom: -10px;
-		right: -8px;
-		padding: 0.08rem 0.42rem;
-		font-size: 0.62rem;
-		font-weight: 700;
-		font-variant-numeric: tabular-nums;
-		border-radius: var(--radius-full);
-		line-height: 1.4;
-		white-space: nowrap;
-		box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
-	}
-
-	.score-delta.positive {
-		color: #22c55e;
-		background: rgba(34, 197, 94, 0.18);
-		border: 1px solid rgba(34, 197, 94, 0.32);
-	}
-
-	.score-delta.negative {
-		color: #ef4444;
-		background: rgba(239, 68, 68, 0.18);
-		border: 1px solid rgba(239, 68, 68, 0.32);
-	}
-
-	.card-status {
+	header,
+	.status,
+	footer {
 		display: flex;
 		align-items: center;
 		justify-content: space-between;
-		margin-bottom: 1.25rem;
-		position: relative;
-		z-index: 1;
-	}
-
-	.status-badge {
-		display: inline-flex;
-		align-items: center;
-		gap: 0.35rem;
-		padding: 0.3rem 0.75rem;
-		border-radius: 999px;
-		font-size: 0.72rem;
-		font-weight: 600;
-		text-transform: uppercase;
-		letter-spacing: 0.04em;
-	}
-
-	.status-badge.pass {
-		background: rgba(34, 197, 94, 0.1);
-		color: #22c55e;
-		border: 1px solid rgba(34, 197, 94, 0.2);
-	}
-
-	.status-badge.fail {
-		background: rgba(239, 68, 68, 0.1);
-		color: #ef4444;
-		border: 1px solid rgba(239, 68, 68, 0.2);
-	}
-
-	.score-label {
-		font-size: 0.72rem;
-		font-weight: 600;
-		text-transform: uppercase;
-		letter-spacing: 0.04em;
-	}
-
-	.card-breakdown {
-		display: flex;
-		flex-direction: column;
-		gap: 0.6rem;
-		position: relative;
-		z-index: 1;
-	}
-
-	.breakdown-item {
-		display: flex;
-		align-items: center;
-		gap: 0.75rem;
-	}
-
-	.breakdown-label {
-		font-size: 0.78rem;
-		color: var(--text-tertiary);
-		width: 85px;
-		flex-shrink: 0;
-		font-weight: 500;
-	}
-
-	.breakdown-bar {
-		flex: 1;
-		height: 5px;
-		background: rgba(255, 255, 255, 0.05);
-		border-radius: 3px;
-		overflow: hidden;
-	}
-
-	.breakdown-fill {
-		height: 100%;
-		border-radius: 3px;
-		transition: width 1.2s cubic-bezier(0.16, 1, 0.3, 1);
-	}
-
-	.breakdown-value {
-		font-size: 0.78rem;
-		font-weight: 600;
-		width: 28px;
-		text-align: right;
-		flex-shrink: 0;
-		font-variant-numeric: tabular-nums;
-	}
-
-	.keyword-summary {
-		display: flex;
 		gap: 1rem;
-		margin-top: 1.25rem;
-		padding-top: 1rem;
-		border-top: 1px solid var(--glass-border);
-		position: relative;
-		z-index: 1;
 	}
 
-	.keyword-stat {
-		display: flex;
-		align-items: center;
-		gap: 0.4rem;
+	h3 {
+		color: var(--text-primary);
+		font-size: 1.05rem;
 	}
 
-	.keyword-count {
-		font-size: 1rem;
-		font-weight: 700;
-		font-variant-numeric: tabular-nums;
-	}
-
-	.keyword-label {
-		font-size: 0.72rem;
+	header p {
+		margin-top: 0.2rem;
+		color: var(--text-tertiary);
+		font-size: 0.7rem;
 		text-transform: uppercase;
-		letter-spacing: 0.04em;
-		font-weight: 500;
 	}
 
-	.keyword-stat.matched .keyword-count {
+	.ring {
+		position: relative;
+		display: grid;
+		place-items: center;
+		flex: 0 0 auto;
+	}
+
+	.ring svg,
+	.ring > strong,
+	.ring > small {
+		grid-area: 1 / 1;
+	}
+
+	.ring > strong {
+		font-size: 1.25rem;
+	}
+
+	.ring > small {
+		align-self: end;
+		justify-self: end;
+		padding: 0.12rem 0.3rem;
+		border-radius: 999px;
+		background: rgba(255, 255, 255, 0.08);
+		font-size: 0.62rem;
+	}
+
+	.ring > small.positive {
 		color: #22c55e;
 	}
 
-	.keyword-stat.matched .keyword-label {
-		color: var(--accent-green);
-	}
-
-	.keyword-stat.missing .keyword-count {
+	.ring > small.negative {
 		color: #ef4444;
 	}
 
-	.keyword-stat.missing .keyword-label {
+	.status {
+		margin: 0.75rem 0 1rem;
+	}
+
+	.status span,
+	.status b {
+		font-size: 0.7rem;
+		text-transform: uppercase;
+	}
+
+	.status span {
+		padding: 0.3rem 0.55rem;
+		border-radius: 999px;
+	}
+
+	.status span.pass {
+		background: rgba(34, 197, 94, 0.08);
+		color: #22c55e;
+	}
+
+	.status span.fail {
+		background: rgba(239, 68, 68, 0.08);
+		color: #ef4444;
+	}
+
+	.breakdown {
+		display: grid;
+		gap: 0.55rem;
+	}
+
+	.breakdown > div {
+		display: grid;
+		grid-template-columns: 92px 1fr 30px;
+		align-items: center;
+		gap: 0.55rem;
+	}
+
+	.breakdown span,
+	.breakdown strong {
+		font-size: 0.7rem;
+	}
+
+	.breakdown span {
+		color: var(--text-tertiary);
+	}
+
+	.breakdown i {
+		display: block;
+		height: 5px;
+		border-radius: 999px;
+		background: rgba(255, 255, 255, 0.055);
+		overflow: hidden;
+	}
+
+	.breakdown i b {
+		display: block;
+		height: 100%;
+		border-radius: inherit;
+	}
+
+	footer {
+		margin-top: 1rem;
+		padding-top: 0.75rem;
+		border-top: 1px solid var(--glass-border);
+		font-size: 0.7rem;
+	}
+
+	footer .matched {
+		color: #22c55e;
+	}
+
+	footer .missing {
 		color: #ef4444;
 	}
 </style>

--- a/src/lib/components/scoring/ScoreDashboard.svelte
+++ b/src/lib/components/scoring/ScoreDashboard.svelte
@@ -1,1854 +1,374 @@
 <script lang="ts">
-	import { scoresStore } from '$stores/scores.svelte';
-	import ScoreCard from './ScoreCard.svelte';
-	import ScoreBreakdown from './ScoreBreakdown.svelte';
-	import KeywordAnalysis from './KeywordAnalysis.svelte';
-	import WeakestAreas from './WeakestAreas.svelte';
-	import ResumeStats from './ResumeStats.svelte';
-	import ShareBadge from './ShareBadge.svelte';
 	import { generatePDF } from '$engine/scorer/report';
-	import { getScoreColor, getScoreLabel } from '$engine/scorer/classification';
-	import { computeScanComparison } from '$engine/scorer/comparison';
-	import { pickQuickWins } from '$engine/scorer/quick-wins';
-	import { getExampleFor } from '$engine/suggestions/templates';
-	import { logger } from '$lib/log';
 	import type { Suggestion, StructuredSuggestion } from '$engine/scorer/types';
+	import { getScoreColor } from '$engine/scorer/classification';
+	import { localeStore } from '$stores/locale.svelte';
+	import { scoresStore } from '$stores/scores.svelte';
+	import ResumeStats from './ResumeStats.svelte';
+	import ScoreCard from './ScoreCard.svelte';
 
-	// derived stats for the summary card header
-	const avgScore = $derived(scoresStore.averageScore);
-	const passCount = $derived(scoresStore.passingCount);
-	const totalCount = $derived(scoresStore.results.length);
-
-	// top 3 highest-impact suggestions across all platforms, deduplicated
-	// by summary text. surfaces in the Quick Wins band so users see what
-	// to fix first without scrolling through every per-platform tab.
-	// reuses the existing impactColorMap declared further down.
-	const quickWins = $derived(pickQuickWins(scoresStore.results, 3));
-
-	// toggle between grid cards and detailed breakdown view
-	let activeView = $state<'cards' | 'detailed'>('cards');
-	let showShareBadge = $state(false);
-
-	// pdf export state
 	let isExporting = $state(false);
+	let expanded = $state<number | null>(null);
+	const average = $derived(scoresStore.averageScore);
+	const passing = $derived(scoresStore.passingCount);
+	const total = $derived(scoresStore.results.length);
 
-	// collapsible suggestion cards
-	let expandedSuggestion = $state<number | null>(null);
-
-	function toggleSuggestion(index: number) {
-		expandedSuggestion = expandedSuggestion === index ? null : index;
+	function isStructured(value: Suggestion): value is StructuredSuggestion {
+		return typeof value === 'object' && value !== null && 'summary' in value;
 	}
 
-	function isStructured(s: Suggestion): s is StructuredSuggestion {
-		return typeof s === 'object' && 'summary' in s;
-	}
-
-	const impactColorMap: Record<string, string> = {
-		critical: '#ef4444',
-		high: '#f97316',
-		medium: '#eab308',
-		low: '#22c55e'
-	};
-
-	// deduplicate suggestions across all platforms
-	const allSuggestions = $derived.by(() => {
+	const suggestions = $derived.by(() => {
 		const seen = new Set<string>();
-		const suggestions: Suggestion[] = [];
-		for (const r of scoresStore.results) {
-			for (const s of r.suggestions) {
-				const key = isStructured(s) ? s.summary : s;
-				if (!seen.has(key)) {
-					seen.add(key);
-					suggestions.push(s);
-				}
+		const values: Suggestion[] = [];
+		for (const result of scoresStore.results) {
+			for (const suggestion of result.suggestions) {
+				const key = isStructured(suggestion) ? suggestion.summary : suggestion;
+				if (seen.has(key)) continue;
+				seen.add(key);
+				values.push(suggestion);
 			}
 		}
-		return suggestions.slice(0, 5);
+		return values.slice(0, 8);
 	});
 
-	// generates a PDF report using jsPDF
 	async function exportResults() {
 		if (isExporting) return;
 		isExporting = true;
 		try {
 			await generatePDF();
-		} catch (err) {
-			logger.error('export.pdf_failed', {
-				error: err instanceof Error ? err.message : String(err)
-			});
 		} finally {
 			isExporting = false;
 		}
 	}
 
-	// alias for backward compat in template
-	const getAvgColor = getScoreColor;
-
-	// per-block copy state for the example blocks - keyed by `${suggestionIndex}-${'before'|'after'}`
-	// so multiple copies can show their "copied" state without trampling each other
-	let copiedKey = $state<string | null>(null);
-	let copiedTimer: ReturnType<typeof setTimeout> | null = null;
-
-	// widened to Event so both pointer and keyboard handlers can pass through
-	// without unsafe casts (KeyboardEvent and MouseEvent both have stopPropagation)
-	async function copyExample(text: string, key: string, e: Event) {
-		// the example block is inside the suggestion-card click target, so without
-		// stopping propagation the click bubbles up and toggles the suggestion's
-		// expanded state, which collapses the block the user just copied from
-		e.stopPropagation();
-		try {
-			await navigator.clipboard.writeText(text);
-		} catch {
-			const ta = document.createElement('textarea');
-			ta.value = text;
-			ta.style.position = 'fixed';
-			ta.style.opacity = '0';
-			document.body.appendChild(ta);
-			ta.select();
-			try {
-				document.execCommand('copy');
-			} finally {
-				document.body.removeChild(ta);
-			}
-		}
-		copiedKey = key;
-		if (copiedTimer) clearTimeout(copiedTimer);
-		copiedTimer = setTimeout(() => {
-			copiedKey = null;
-			copiedTimer = null;
-		}, 1600);
-	}
-
-	// live countdown for the rate-limit retry hint inside the fallback toast
-	// only ticks while the toast is visible and a retry timestamp is set
-	let now = $state(Date.now());
-	$effect(() => {
-		if (!scoresStore.llmFallback || scoresStore.llmRetryAtMs === null) return;
-		const id = setInterval(() => {
-			now = Date.now();
-		}, 1000);
-		return () => clearInterval(id);
-	});
-	const retrySecondsRemaining = $derived(
-		scoresStore.llmRetryAtMs !== null
-			? Math.max(0, Math.ceil((scoresStore.llmRetryAtMs - now) / 1000))
-			: 0
-	);
-
-	// scan-vs-previous-scan comparison
-	// startScoring snapshots the previous top-of-history into previousScanForComparison,
-	// which avoids the brief race where scanHistory[1] is stale before the post-save reload
-	// finishes; we fall back to scanHistory[1] for any path that didn't go through startScoring
-	// suppressed when viewing a snapshot loaded from history
-	const previousScan = $derived(
-		scoresStore.isFromHistory
-			? null
-			: (scoresStore.previousScanForComparison ?? scoresStore.scanHistory[1] ?? null)
-	);
-	const comparison = $derived(
-		previousScan && scoresStore.hasResults
-			? computeScanComparison(scoresStore.results, previousScan.results)
-			: null
-	);
-	// fast lookup so each ScoreCard can render its own delta in the grid
-	const previousByPlatform = $derived(
-		new Map(comparison?.platforms.map((p) => [p.system, p.previous]) ?? [])
-	);
-
-	// twitter share intent for the "I improved" moment - the URL points at /share
-	// (not the homepage) so twitter's crawler fetches a page whose og:image is a
-	// dynamic PNG rendering this user's actual delta and score
-	function shareImprovementToTwitter() {
-		if (!comparison || comparison.deltaAverage <= 0 || typeof window === 'undefined') return;
-		const text = `Just improved my ATS resume score from ${comparison.previousAverage} to ${comparison.currentAverage} (+${comparison.deltaAverage}) using @ATSScreener (free, simulates how Workday, Lever, iCIMS and others actually parse resumes)`;
-		const params = new URLSearchParams({
-			score: String(scoresStore.averageScore),
-			pass: String(scoresStore.passingCount),
-			total: String(scoresStore.results.length),
-			delta: String(comparison.deltaAverage)
-		});
-		const sharePageUrl = `${window.location.origin}/share?${params.toString()}`;
-		const intent = `https://twitter.com/intent/tweet?text=${encodeURIComponent(text)}&url=${encodeURIComponent(sharePageUrl)}`;
-		window.open(intent, '_blank', 'noopener,noreferrer,width=600,height=520');
+	function label(score: number): string {
+		const pt = localeStore.locale === 'pt-BR';
+		if (score >= 80) return pt ? 'Excelente' : 'Excellent';
+		if (score >= 65) return pt ? 'Bom' : 'Good';
+		if (score >= 50) return pt ? 'Precisa melhorar' : 'Needs work';
+		return pt ? 'Fraco' : 'Poor';
 	}
 </script>
 
 {#if scoresStore.hasResults}
 	<div class="dashboard">
-		<!-- summary header card -->
-		<div class="dashboard-header">
-			<div class="summary-card">
-				<div class="summary-left">
-					<div class="summary-score">
-						<span class="score-number" style="color: {getAvgColor(avgScore)}">
-							{avgScore}
-						</span>
-						<span class="score-verdict" style="color: {getAvgColor(avgScore)}">
-							{getScoreLabel(avgScore)}
-						</span>
-						<span class="score-label">Average Score</span>
-					</div>
-				</div>
-				<div class="summary-center">
-					<div class="mini-bars">
-						{#each scoresStore.results as result}
-							<div class="mini-bar-item">
-								<div class="mini-bar-track">
-									<div
-										class="mini-bar-fill"
-										style="width: {result.overallScore}%; background: {getAvgColor(
-											result.overallScore
-										)}"
-									></div>
-								</div>
-								<span class="mini-bar-label">{result.system}</span>
-							</div>
-						{/each}
-					</div>
-				</div>
-				<div class="summary-right">
-					<div class="summary-stat">
-						<span class="stat-value">{passCount}/{totalCount}</span>
-						<span class="stat-label">Systems Passed</span>
-					</div>
-					<div class="mode-badge">
-						{#if scoresStore.mode === 'targeted'}
-							<svg
-								width="12"
-								height="12"
-								viewBox="0 0 24 24"
-								fill="none"
-								stroke="currentColor"
-								stroke-width="2"
-							>
-								<circle cx="12" cy="12" r="10" />
-								<circle cx="12" cy="12" r="6" />
-								<circle cx="12" cy="12" r="2" />
-							</svg>
-							Targeted Scoring
-						{:else}
-							<svg
-								width="12"
-								height="12"
-								viewBox="0 0 24 24"
-								fill="none"
-								stroke="currentColor"
-								stroke-width="2"
-							>
-								<path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
-							</svg>
-							General Readiness
-						{/if}
-					</div>
-				</div>
+		<section class="summary">
+			<div class="score" style:color={getScoreColor(average)}>
+				<strong>{average}</strong>
+				<span>{label(average)}</span>
 			</div>
-
-			{#if comparison}
-				{@const positive = comparison.deltaAverage > 0}
-				{@const negative = comparison.deltaAverage < 0}
-				<div
-					class="comparison-band"
-					class:up={positive}
-					class:down={negative}
-					class:flat={!positive && !negative}
-				>
-					<div class="comparison-headline">
-						{#if positive}
-							<svg
-								width="16"
-								height="16"
-								viewBox="0 0 24 24"
-								fill="none"
-								stroke="currentColor"
-								stroke-width="2"
-							>
-								<polyline points="17 6 23 6 23 12" />
-								<path d="M1 18l8-8 4 4 9-9" />
-							</svg>
-						{:else if negative}
-							<svg
-								width="16"
-								height="16"
-								viewBox="0 0 24 24"
-								fill="none"
-								stroke="currentColor"
-								stroke-width="2"
-							>
-								<polyline points="17 18 23 18 23 12" />
-								<path d="M1 6l8 8 4-4 9 9" />
-							</svg>
-						{:else}
-							<svg
-								width="16"
-								height="16"
-								viewBox="0 0 24 24"
-								fill="none"
-								stroke="currentColor"
-								stroke-width="2"
-							>
-								<line x1="5" y1="12" x2="19" y2="12" />
-							</svg>
-						{/if}
-						<span class="comparison-text">
-							{#if positive}
-								Your score went from <strong>{comparison.previousAverage}</strong> to
-								<strong>{comparison.currentAverage}</strong>
-								<span class="delta-pill positive">+{comparison.deltaAverage}</span>
-							{:else if negative}
-								Your score moved from <strong>{comparison.previousAverage}</strong> to
-								<strong>{comparison.currentAverage}</strong>
-								<span class="delta-pill negative">{comparison.deltaAverage}</span>
-							{:else}
-								No change since your last scan ({comparison.currentAverage})
-							{/if}
-						</span>
+			<div class="bars">
+				{#each scoresStore.results as result}
+					<div>
+						<span>{result.system}</span>
+						<i><b style:width={`${result.overallScore}%`} style:background={getScoreColor(result.overallScore)}></b></i>
 					</div>
-					<div class="comparison-meta">
-						{#if comparison.deltaPassing !== 0}
-							<span
-								class="meta-chip"
-								class:positive={comparison.deltaPassing > 0}
-								class:negative={comparison.deltaPassing < 0}
-							>
-								{comparison.previousPassing} → {comparison.currentPassing} passing
-							</span>
-						{/if}
-						{#if comparison.improved > 0}
-							<span class="meta-chip positive">{comparison.improved} improved</span>
-						{/if}
-						{#if comparison.regressed > 0}
-							<span class="meta-chip negative">{comparison.regressed} regressed</span>
-						{/if}
-						{#if comparison.unchanged > 0 && comparison.improved === 0 && comparison.regressed === 0}
-							<span class="meta-chip">{comparison.unchanged} unchanged</span>
-						{/if}
-						{#if positive}
-							<button
-								class="share-improvement-btn"
-								onclick={shareImprovementToTwitter}
-								title="Share this improvement on X"
-								aria-label="Share improvement on X"
-							>
-								<svg width="13" height="13" viewBox="0 0 24 24" fill="currentColor">
-									<path
-										d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"
-									/>
-								</svg>
-								Share +{comparison.deltaAverage}
-							</button>
-						{/if}
-					</div>
-				</div>
-			{/if}
-
-			{#if scoresStore.llmFallback}
-				<div class="fallback-toast">
-					<div class="fallback-toast-left">
-						<svg
-							class="fallback-warn-icon"
-							width="16"
-							height="16"
-							viewBox="0 0 24 24"
-							fill="none"
-							stroke="#eab308"
-							stroke-width="2"
-							stroke-linecap="round"
-							stroke-linejoin="round"
-						>
-							<path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z" />
-							<line x1="12" y1="9" x2="12" y2="13" />
-							<line x1="12" y1="17" x2="12.01" y2="17" />
-						</svg>
-						<p class="fallback-toast-msg">
-							<strong>AI scoring temporarily unavailable</strong> &mdash; looks like too many of you
-							want to check your resumes at the same time! i'm covering the API costs myself and
-							things are a little overwhelmed right now. your scores below are still accurate
-							(rule-based analysis), but the AI suggestions/accuracy won't be as specific. try again
-							later, or if you want to help keep this free for everyone
-							<span class="fallback-emoji">😅</span>
-							{#if retrySecondsRemaining > 0}
-								<span class="fallback-retry-hint">
-									AI scoring re-available in <strong>{retrySecondsRemaining}s</strong>
-								</span>
-							{/if}
-						</p>
-					</div>
-					<div class="fallback-toast-actions">
-						<a
-							href="https://buymeacoffee.com/sunnypatell"
-							target="_blank"
-							rel="noopener"
-							class="fallback-pill coffee-pill"
-						>
-							<svg
-								width="15"
-								height="15"
-								viewBox="0 0 24 24"
-								fill="none"
-								stroke="currentColor"
-								stroke-width="2"
-								stroke-linecap="round"
-								stroke-linejoin="round"
-							>
-								<path d="M10 2v2" />
-								<path d="M14 2v2" />
-								<path
-									d="M16 8a1 1 0 0 1 1 1v8a4 4 0 0 1-4 4H7a4 4 0 0 1-4-4V9a1 1 0 0 1 1-1h14a4 4 0 1 1 0 8h-1"
-								/>
-								<path d="M6 2v2" />
-							</svg>
-							Coffee
-						</a>
-						<a
-							href="https://github.com/sponsors/sunnypatell"
-							target="_blank"
-							rel="noopener"
-							class="fallback-pill sponsor-pill"
-						>
-							<svg
-								width="14"
-								height="14"
-								viewBox="0 0 24 24"
-								fill="none"
-								stroke="currentColor"
-								stroke-width="2"
-								stroke-linecap="round"
-								stroke-linejoin="round"
-							>
-								<path
-									d="M19 14c1.49-1.46 3-3.21 3-5.5A5.5 5.5 0 0 0 16.5 3c-1.76 0-3 .5-4.5 2-1.5-1.5-2.74-2-4.5-2A5.5 5.5 0 0 0 2 8.5c0 2.3 1.5 4.05 3 5.5l7 7Z"
-								/>
-							</svg>
-							Sponsor
-						</a>
-					</div>
-				</div>
-			{/if}
-		</div>
-
-		<!--
-			quick wins band: top 3 highest-impact suggestions across all
-			platforms (deduplicated). surfaces what to fix first without
-			users having to scroll through every per-platform tab. only
-			renders when there is at least one structured suggestion.
-		-->
-		{#if quickWins.length > 0}
-			<div class="quick-wins-band">
-				<div class="quick-wins-header">
-					<svg
-						class="quick-wins-icon"
-						width="16"
-						height="16"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						stroke-width="2"
-						stroke-linecap="round"
-						stroke-linejoin="round"
-						aria-hidden="true"
-					>
-						<path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z" />
-					</svg>
-					<span>Highest-impact fixes</span>
-					<span class="quick-wins-subtle">Fix these first</span>
-				</div>
-				<ol class="quick-wins-list">
-					{#each quickWins as win, i (win.summary)}
-						<li class="quick-wins-item">
-							<span class="quick-wins-rank">{i + 1}</span>
-							<span class="quick-wins-summary">{win.summary}</span>
-							<span
-								class="quick-wins-impact"
-								style="color: {impactColorMap[win.impact] ?? '#a1a1aa'};"
-							>
-								{win.impact}
-							</span>
-						</li>
-					{/each}
-				</ol>
+				{/each}
 			</div>
-		{/if}
+			<div class="passing">
+				<strong>{passing}/{total}</strong>
+				<span>{localeStore.locale === 'pt-BR' ? 'Sistemas aprovados' : 'Systems passed'}</span>
+				<small>{scoresStore.mode === 'targeted'
+					? localeStore.locale === 'pt-BR' ? 'Análise por vaga' : 'Targeted scoring'
+					: localeStore.locale === 'pt-BR' ? 'Prontidão geral' : 'General readiness'}</small>
+			</div>
+		</section>
 
-		<!-- view toggle + export -->
 		<div class="toolbar">
-			<div class="view-toggle">
-				<button
-					class="toggle-btn"
-					class:active={activeView === 'cards'}
-					onclick={() => (activeView = 'cards')}
-				>
-					<svg
-						width="16"
-						height="16"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						stroke-width="2"
-					>
-						<rect x="3" y="3" width="7" height="7" />
-						<rect x="14" y="3" width="7" height="7" />
-						<rect x="3" y="14" width="7" height="7" />
-						<rect x="14" y="14" width="7" height="7" />
-					</svg>
-					Card View
-				</button>
-				<button
-					class="toggle-btn"
-					class:active={activeView === 'detailed'}
-					onclick={() => (activeView = 'detailed')}
-				>
-					<svg
-						width="16"
-						height="16"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						stroke-width="2"
-					>
-						<line x1="8" y1="6" x2="21" y2="6" />
-						<line x1="8" y1="12" x2="21" y2="12" />
-						<line x1="8" y1="18" x2="21" y2="18" />
-						<line x1="3" y1="6" x2="3.01" y2="6" />
-						<line x1="3" y1="12" x2="3.01" y2="12" />
-						<line x1="3" y1="18" x2="3.01" y2="18" />
-					</svg>
-					Detailed View
-				</button>
-			</div>
-
-			<div class="toolbar-actions">
-				<button
-					class="toolbar-btn"
-					onclick={() => (showShareBadge = true)}
-					title="Share score badge"
-				>
-					<svg
-						width="16"
-						height="16"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						stroke-width="2"
-					>
-						<circle cx="18" cy="5" r="3" />
-						<circle cx="6" cy="12" r="3" />
-						<circle cx="18" cy="19" r="3" />
-						<line x1="8.59" y1="13.51" x2="15.42" y2="17.49" />
-						<line x1="15.41" y1="6.51" x2="8.59" y2="10.49" />
-					</svg>
-					Share
-				</button>
-				<button
-					class="toolbar-btn"
-					onclick={exportResults}
-					disabled={isExporting}
-					title="Export results as PDF"
-				>
-					{#if isExporting}
-						<svg
-							class="export-spinner"
-							width="16"
-							height="16"
-							viewBox="0 0 24 24"
-							fill="none"
-							stroke="currentColor"
-							stroke-width="2"
-						>
-							<path d="M21 12a9 9 0 1 1-6.219-8.56" />
-						</svg>
-						Generating...
-					{:else}
-						<svg
-							width="16"
-							height="16"
-							viewBox="0 0 24 24"
-							fill="none"
-							stroke="currentColor"
-							stroke-width="2"
-						>
-							<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
-							<polyline points="7,10 12,15 17,10" />
-							<line x1="12" y1="15" x2="12" y2="3" />
-						</svg>
-						Export PDF
-					{/if}
-				</button>
-			</div>
+			<p>
+				{localeStore.locale === 'pt-BR'
+					? 'Pontuação determinística, explicável e sem IA generativa.'
+					: 'Deterministic, explainable scoring without generative AI.'}
+			</p>
+			<button type="button" onclick={exportResults} disabled={isExporting}>
+				{isExporting
+					? localeStore.locale === 'pt-BR' ? 'Gerando...' : 'Generating...'
+					: localeStore.locale === 'pt-BR' ? 'Exportar PDF' : 'Export PDF'}
+			</button>
 		</div>
 
-		<!-- card view: 6 ATS score cards in a grid -->
-		{#if activeView === 'cards'}
-			<div class="scores-grid">
-				{#each scoresStore.results as result (result.system)}
-					<ScoreCard {result} previousScore={previousByPlatform.get(result.system)} />
-				{/each}
-			</div>
-		{:else}
-			<!-- detailed view: expandable breakdown per system -->
-			<div class="breakdowns-list">
-				{#each scoresStore.results as result (result.system)}
-					<ScoreBreakdown {result} />
-				{/each}
-			</div>
-		{/if}
+		<div class="cards">
+			{#each scoresStore.results as result}
+				<ScoreCard {result} />
+			{/each}
+		</div>
 
-		<!-- priority focus areas + resume overview -->
 		<div class="analysis-grid">
-			<WeakestAreas results={scoresStore.results} />
+			<section class="suggestions-panel">
+				<header>
+					<h2>{localeStore.locale === 'pt-BR' ? 'Prioridades de melhoria' : 'Improvement priorities'}</h2>
+					<p>{localeStore.locale === 'pt-BR'
+						? 'Recomendações geradas por regras e evidências do currículo.'
+						: 'Recommendations generated from rules and resume evidence.'}</p>
+				</header>
+
+				{#if suggestions.length === 0}
+					<p class="empty">{localeStore.locale === 'pt-BR' ? 'Nenhuma recomendação crítica.' : 'No critical recommendations.'}</p>
+				{:else}
+					<ol>
+						{#each suggestions as suggestion, index}
+							{@const structured = isStructured(suggestion)}
+							<li>
+								<button type="button" onclick={() => (expanded = expanded === index ? null : index)}>
+									<span class="number">{index + 1}</span>
+									<span>{structured ? suggestion.summary : suggestion}</span>
+									<span aria-hidden="true">{expanded === index ? '−' : '+'}</span>
+								</button>
+								{#if expanded === index && structured && suggestion.details.length > 0}
+									<ul>{#each suggestion.details as detail}<li>{detail}</li>{/each}</ul>
+								{/if}
+							</li>
+						{/each}
+					</ol>
+				{/if}
+			</section>
+
 			<ResumeStats />
 		</div>
 
-		<!-- keyword analysis (full-width) -->
-		<KeywordAnalysis results={scoresStore.results} />
-
-		<!-- deduplicated suggestions as collapsible cards -->
-		{#if allSuggestions.length > 0}
-			<div class="suggestions-section">
-				<div class="suggestions-header">
-					<svg
-						width="18"
-						height="18"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						stroke-width="2"
-					>
-						<path
-							d="m12 3-1.912 5.813a2 2 0 0 1-1.275 1.275L3 12l5.813 1.912a2 2 0 0 1 1.275 1.275L12 21l1.912-5.813a2 2 0 0 1 1.275-1.275L21 12l-5.813-1.912a2 2 0 0 1-1.275-1.275L12 3Z"
-						/>
-					</svg>
-					<h3 class="suggestions-title">Optimization Suggestions</h3>
-				</div>
-				<p class="suggestions-subtitle">
-					Actionable recommendations based on analysis across all 6 ATS platforms. Click to expand.
-				</p>
-				<div class="suggestions-cards">
-					{#each allSuggestions as suggestion, i}
-						{@const structured = isStructured(suggestion)}
-						{@const impactColor = structured
-							? (impactColorMap[suggestion.impact] ?? '#eab308')
-							: impactColorMap[i === 0 ? 'critical' : i === 1 ? 'high' : i < 4 ? 'medium' : 'low']}
-						{@const impactLabel = structured
-							? suggestion.impact
-							: i === 0
-								? 'critical'
-								: i === 1
-									? 'high'
-									: i < 4
-										? 'medium'
-										: 'low'}
-						<!-- div+role=button instead of <button> so the nested copy <button>s
-						     inside the body don't violate "no interactive descendants in a
-						     button" (invalid HTML, broken keyboard/screen-reader semantics) -->
-						<div
-							class="suggestion-card"
-							class:expanded={expandedSuggestion === i}
-							role="button"
-							tabindex="0"
-							aria-expanded={expandedSuggestion === i}
-							onclick={() => toggleSuggestion(i)}
-							onkeydown={(e) => {
-								if (e.key === 'Enter' || e.key === ' ') {
-									e.preventDefault();
-									toggleSuggestion(i);
-								}
-							}}
-						>
-							<div class="suggestion-card-header">
-								<div class="suggestion-card-left">
-									<span class="suggestion-priority" style="background: {impactColor};">
-										{i + 1}
-									</span>
-									<span class="suggestion-summary">
-										{structured
-											? suggestion.summary
-											: typeof suggestion === 'string'
-												? suggestion
-												: ''}
-									</span>
-								</div>
-								<div class="suggestion-card-right">
-									{#if structured && suggestion.platforms.length > 0}
-										<div class="suggestion-platforms">
-											{#each suggestion.platforms.slice(0, 3) as platform}
-												<span class="platform-chip">{platform}</span>
-											{/each}
-										</div>
-									{/if}
-									<span class="suggestion-impact" style="color: {impactColor};">
-										{impactLabel}
-									</span>
-									<svg
-										class="suggestion-chevron"
-										class:rotated={expandedSuggestion === i}
-										width="14"
-										height="14"
-										viewBox="0 0 24 24"
-										fill="none"
-										stroke="currentColor"
-										stroke-width="2"
-									>
-										<polyline points="6,9 12,15 18,9" />
-									</svg>
-								</div>
-							</div>
-							{#if expandedSuggestion === i}
-								{@const suggestionText = structured
-									? suggestion.summary
-									: typeof suggestion === 'string'
-										? suggestion
-										: ''}
-								{@const example = getExampleFor(suggestionText)}
-								<div class="suggestion-card-body">
-									{#if structured && suggestion.details.length > 0}
-										<ul class="suggestion-details">
-											{#each suggestion.details as detail}
-												<li>{detail}</li>
-											{/each}
-										</ul>
-									{:else if !structured}
-										<!-- defensive: if suggestion is somehow a non-string non-structured
-										value (e.g. malformed LLM output), interpolating directly would
-										render "[object Object]" - same class as the bug fixed in
-										ScoreBreakdown. typeof guard keeps the render type-safe -->
-										<p>{typeof suggestion === 'string' ? suggestion : ''}</p>
-									{/if}
-									{#if example}
-										<div class="suggestion-example">
-											<p class="example-tip">{example.tip}</p>
-											<div class="example-pair">
-												<div class="example-block before">
-													<div class="example-block-header">
-														<span class="example-label">Before</span>
-														<button
-															type="button"
-															class="copy-btn"
-															class:copied={copiedKey === `${i}-before`}
-															onclick={(e) => copyExample(example.before, `${i}-before`, e)}
-															aria-label="Copy before text"
-														>
-															{#if copiedKey === `${i}-before`}
-																<svg
-																	width="11"
-																	height="11"
-																	viewBox="0 0 24 24"
-																	fill="none"
-																	stroke="currentColor"
-																	stroke-width="3"
-																>
-																	<polyline points="20,6 9,17 4,12" />
-																</svg>
-																Copied
-															{:else}
-																<svg
-																	width="11"
-																	height="11"
-																	viewBox="0 0 24 24"
-																	fill="none"
-																	stroke="currentColor"
-																	stroke-width="2"
-																>
-																	<rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
-																	<path
-																		d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"
-																	/>
-																</svg>
-																Copy
-															{/if}
-														</button>
-													</div>
-													<pre>{example.before}</pre>
-												</div>
-												<div class="example-block after">
-													<div class="example-block-header">
-														<span class="example-label">After</span>
-														<button
-															type="button"
-															class="copy-btn"
-															class:copied={copiedKey === `${i}-after`}
-															onclick={(e) => copyExample(example.after, `${i}-after`, e)}
-															aria-label="Copy after text"
-														>
-															{#if copiedKey === `${i}-after`}
-																<svg
-																	width="11"
-																	height="11"
-																	viewBox="0 0 24 24"
-																	fill="none"
-																	stroke="currentColor"
-																	stroke-width="3"
-																>
-																	<polyline points="20,6 9,17 4,12" />
-																</svg>
-																Copied
-															{:else}
-																<svg
-																	width="11"
-																	height="11"
-																	viewBox="0 0 24 24"
-																	fill="none"
-																	stroke="currentColor"
-																	stroke-width="2"
-																>
-																	<rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
-																	<path
-																		d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"
-																	/>
-																</svg>
-																Copy
-															{/if}
-														</button>
-													</div>
-													<pre>{example.after}</pre>
-												</div>
-											</div>
-										</div>
-									{/if}
-								</div>
-							{/if}
-						</div>
-					{/each}
-				</div>
-			</div>
-		{/if}
+		<section class="disclaimer">
+			<strong>Gupy-like</strong>
+			<p>{localeStore.locale === 'pt-BR'
+				? 'Simulação transparente baseada apenas em orientações públicas da Gupy. Não reproduz nem afirma conhecer o algoritmo proprietário.'
+				: 'Transparent simulation based only on Gupy public guidance. It does not reproduce or claim knowledge of the proprietary algorithm.'}</p>
+		</section>
 	</div>
 {/if}
 
-<ShareBadge bind:open={showShareBadge} />
-
 <style>
 	.dashboard {
-		margin-top: 2rem;
 		display: flex;
 		flex-direction: column;
-		gap: 2rem;
+		gap: 1.1rem;
 	}
 
-	.dashboard-header {
-		margin-bottom: 0;
-	}
-
-	.summary-card {
-		display: flex;
+	.summary {
+		display: grid;
+		grid-template-columns: 150px 1fr 180px;
 		align-items: center;
-		justify-content: space-between;
-		padding: 2rem 2.5rem;
-		background: var(--glass-bg);
+		gap: 1.2rem;
+		padding: 1.4rem;
 		border: 1px solid var(--glass-border);
 		border-radius: var(--radius-xl);
-		backdrop-filter: blur(var(--glass-blur));
-		gap: 2rem;
+		background: var(--glass-bg);
 	}
 
-	.summary-score {
+	.score,
+	.passing {
 		display: flex;
 		flex-direction: column;
-		align-items: flex-start;
 	}
 
-	.score-number {
-		font-size: 3.5rem;
-		font-weight: 800;
+	.score strong {
+		font-size: 3rem;
 		line-height: 1;
-		font-variant-numeric: tabular-nums;
 	}
 
-	.score-verdict {
-		font-size: 0.9rem;
-		font-weight: 700;
-		margin-top: 0.35rem;
-	}
-
-	.score-label {
-		font-size: 0.78rem;
-		color: var(--text-tertiary);
+	.score span,
+	.passing span {
+		margin-top: 0.3rem;
+		color: var(--text-secondary);
+		font-size: 0.8rem;
 		text-transform: uppercase;
-		letter-spacing: 0.06em;
-		font-weight: 500;
-		margin-top: 0.15rem;
 	}
 
-	/* mini bar chart in summary header */
-	.summary-center {
-		flex: 1;
-		max-width: 360px;
+	.bars {
+		display: grid;
+		gap: 0.45rem;
 	}
 
-	.mini-bars {
-		display: flex;
-		flex-direction: column;
-		gap: 0.35rem;
-	}
-
-	.mini-bar-item {
-		display: flex;
+	.bars div {
+		display: grid;
+		grid-template-columns: 110px 1fr;
 		align-items: center;
-		gap: 0.5rem;
+		gap: 0.65rem;
 	}
 
-	.mini-bar-track {
-		flex: 1;
-		height: 4px;
-		background: rgba(255, 255, 255, 0.05);
-		border-radius: 2px;
+	.bars span {
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		color: var(--text-tertiary);
+		font-size: 0.7rem;
+	}
+
+	.bars i {
+		display: block;
+		height: 5px;
+		border-radius: 999px;
+		background: rgba(255, 255, 255, 0.06);
 		overflow: hidden;
 	}
 
-	.mini-bar-fill {
-		height: 100%;
-		border-radius: 2px;
-		transition: width 1.2s cubic-bezier(0.16, 1, 0.3, 1);
-	}
-
-	.mini-bar-label {
-		font-size: 0.65rem;
-		color: var(--text-tertiary);
-		width: 80px;
-		text-align: right;
-		font-weight: 500;
-	}
-
-	.summary-right {
-		display: flex;
-		flex-direction: column;
-		align-items: flex-end;
-		gap: 0.75rem;
-	}
-
-	.summary-stat {
-		display: flex;
-		align-items: baseline;
-		gap: 0.5rem;
-	}
-
-	.stat-value {
-		font-size: 1.5rem;
-		font-weight: 700;
-		color: var(--text-primary);
-		font-variant-numeric: tabular-nums;
-	}
-
-	.stat-label {
-		font-size: 0.82rem;
-		color: var(--text-tertiary);
-	}
-
-	.mode-badge {
-		display: inline-flex;
-		align-items: center;
-		gap: 0.4rem;
-		padding: 0.3rem 0.85rem;
-		background: rgba(6, 182, 212, 0.08);
-		border: 1px solid rgba(6, 182, 212, 0.2);
-		border-radius: 999px;
-		font-size: 0.75rem;
-		font-weight: 600;
-		color: var(--accent-cyan);
-	}
-
-	/* compact toast-style fallback banner */
-	.fallback-toast {
-		display: flex;
-		align-items: center;
-		justify-content: space-between;
-		gap: 1rem;
-		margin-top: 0.75rem;
-		padding: 0.75rem 1.25rem;
-		background: rgba(234, 179, 8, 0.06);
-		border: 1px solid rgba(234, 179, 8, 0.2);
-		border-radius: var(--radius-lg);
-		backdrop-filter: blur(var(--glass-blur));
-		animation: toastSlideIn 0.35s cubic-bezier(0.16, 1, 0.3, 1);
-	}
-
-	@keyframes toastSlideIn {
-		from {
-			opacity: 0;
-			transform: translateY(-8px);
-		}
-		to {
-			opacity: 1;
-			transform: translateY(0);
-		}
-	}
-
-	.fallback-toast-left {
-		display: flex;
-		align-items: flex-start;
-		gap: 0.6rem;
-		flex: 1;
-		min-width: 0;
-	}
-
-	.fallback-warn-icon {
-		flex-shrink: 0;
-		margin-top: 2px;
-	}
-
-	.fallback-toast-msg {
-		font-size: 0.82rem;
-		color: var(--text-secondary);
-		line-height: 1.55;
-		margin: 0;
-	}
-
-	.fallback-toast-msg strong {
-		color: #eab308;
-		font-weight: 600;
-	}
-
-	.fallback-emoji {
-		font-size: 1rem;
-		vertical-align: middle;
-		line-height: 1;
-	}
-
-	.fallback-retry-hint {
+	.bars b {
 		display: block;
-		margin-top: 0.4rem;
-		font-size: 0.78rem;
-		color: var(--text-tertiary);
-		font-variant-numeric: tabular-nums;
+		height: 100%;
+		border-radius: inherit;
 	}
 
-	.fallback-retry-hint strong {
-		color: var(--accent-cyan);
-		font-weight: 600;
-	}
-
-	/* scan-vs-previous comparison band */
-	.comparison-band {
-		display: flex;
-		flex-wrap: wrap;
+	.passing {
 		align-items: center;
-		justify-content: space-between;
-		gap: 0.75rem 1rem;
-		margin-top: 1rem;
-		padding: 0.75rem 1.1rem;
-		border-radius: var(--radius-lg);
-		background: var(--glass-bg);
-		border: 1px solid var(--glass-border);
-		backdrop-filter: blur(12px);
+		text-align: center;
 	}
 
-	.comparison-band.up {
-		border-color: rgba(34, 197, 94, 0.25);
-		background: rgba(34, 197, 94, 0.04);
-	}
-
-	.comparison-band.down {
-		border-color: rgba(239, 68, 68, 0.22);
-		background: rgba(239, 68, 68, 0.04);
-	}
-
-	.comparison-band.flat {
-		border-color: rgba(255, 255, 255, 0.08);
-	}
-
-	.comparison-headline {
-		display: flex;
-		align-items: center;
-		gap: 0.6rem;
-		font-size: 0.88rem;
-		color: var(--text-secondary);
-	}
-
-	.comparison-band.up .comparison-headline svg {
-		color: #22c55e;
-	}
-
-	.comparison-band.down .comparison-headline svg {
-		color: #ef4444;
-	}
-
-	.comparison-band.flat .comparison-headline svg {
-		color: var(--text-tertiary);
-	}
-
-	.comparison-text strong {
+	.passing strong {
 		color: var(--text-primary);
-		font-variant-numeric: tabular-nums;
+		font-size: 1.7rem;
 	}
 
-	.delta-pill {
-		display: inline-flex;
-		align-items: center;
-		padding: 0.1rem 0.5rem;
-		margin-left: 0.4rem;
-		font-size: 0.78rem;
-		font-weight: 600;
-		border-radius: var(--radius-full);
-		font-variant-numeric: tabular-nums;
-	}
-
-	.delta-pill.positive {
-		color: #22c55e;
-		background: rgba(34, 197, 94, 0.12);
-	}
-
-	.delta-pill.negative {
-		color: #ef4444;
-		background: rgba(239, 68, 68, 0.12);
-	}
-
-	.comparison-meta {
-		display: flex;
-		flex-wrap: wrap;
-		gap: 0.4rem;
-	}
-
-	.meta-chip {
-		padding: 0.18rem 0.55rem;
-		font-size: 0.74rem;
-		color: var(--text-tertiary);
-		border-radius: var(--radius-full);
-		background: rgba(255, 255, 255, 0.04);
-		border: 1px solid rgba(255, 255, 255, 0.06);
-		font-variant-numeric: tabular-nums;
-	}
-
-	.meta-chip.positive {
-		color: #22c55e;
-		border-color: rgba(34, 197, 94, 0.2);
-		background: rgba(34, 197, 94, 0.06);
-	}
-
-	.meta-chip.negative {
-		color: #ef4444;
-		border-color: rgba(239, 68, 68, 0.2);
-		background: rgba(239, 68, 68, 0.06);
-	}
-
-	.share-improvement-btn {
-		display: inline-flex;
-		align-items: center;
-		gap: 0.32rem;
-		padding: 0.18rem 0.6rem;
-		font-size: 0.74rem;
-		font-weight: 600;
-		font-family: inherit;
-		color: var(--text-primary);
-		background: rgba(255, 255, 255, 0.08);
-		border: 1px solid rgba(255, 255, 255, 0.12);
-		border-radius: var(--radius-full);
-		cursor: pointer;
-		transition:
-			background 0.18s ease,
-			border-color 0.18s ease,
-			transform 0.18s ease;
-	}
-
-	.share-improvement-btn:hover {
-		background: rgba(34, 197, 94, 0.12);
-		border-color: rgba(34, 197, 94, 0.35);
-		transform: translateY(-1px);
-	}
-
-	.share-improvement-btn svg {
-		opacity: 0.85;
-	}
-
-	.fallback-toast-actions {
-		display: flex;
-		gap: 0.5rem;
-		flex-shrink: 0;
-	}
-
-	.fallback-pill {
-		display: inline-flex;
-		align-items: center;
-		gap: 0.35rem;
-		padding: 0.4rem 0.85rem;
-		font-size: 0.78rem;
-		font-weight: 600;
-		text-decoration: none;
-		border-radius: 999px;
-		white-space: nowrap;
-		transition:
-			transform 0.15s ease,
-			background 0.15s ease,
-			border-color 0.15s ease,
-			box-shadow 0.15s ease;
-	}
-
-	.fallback-pill:hover {
-		transform: translateY(-1px);
-	}
-
-	.coffee-pill {
-		background: rgba(255, 221, 0, 0.1);
-		border: 1px solid rgba(255, 221, 0, 0.3);
-		color: #ffdd00;
-	}
-
-	.coffee-pill:hover {
-		background: rgba(255, 221, 0, 0.18);
-		border-color: rgba(255, 221, 0, 0.5);
-		box-shadow: 0 0 14px rgba(255, 221, 0, 0.08);
-	}
-
-	.sponsor-pill {
-		background: rgba(219, 39, 119, 0.1);
-		border: 1px solid rgba(219, 39, 119, 0.3);
-		color: #ec4899;
-	}
-
-	.sponsor-pill:hover {
-		background: rgba(219, 39, 119, 0.18);
-		border-color: rgba(219, 39, 119, 0.5);
-		box-shadow: 0 0 14px rgba(219, 39, 119, 0.08);
-	}
-
-	/* quick wins band: surfaces top 3 highest-impact suggestions before
-	   the user dives into per-platform detail. visually weighted between
-	   the dashboard-header and the toolbar so it feels like a primary
-	   recommendation, not a secondary chip. */
-	.quick-wins-band {
-		margin-bottom: 1.5rem;
-		padding: 1.1rem 1.25rem;
-		background:
-			linear-gradient(135deg, rgba(6, 182, 212, 0.04), rgba(139, 92, 246, 0.03)), var(--glass-bg);
-		border: 1px solid rgba(6, 182, 212, 0.18);
-		border-radius: var(--radius-lg, 14px);
-	}
-
-	.quick-wins-header {
-		display: flex;
-		align-items: center;
-		gap: 0.5rem;
-		margin-bottom: 0.85rem;
-		font-size: 0.85rem;
-		font-weight: 600;
-		color: var(--text-primary);
-		letter-spacing: 0.02em;
-	}
-
-	.quick-wins-icon {
-		color: var(--accent-cyan);
-		flex-shrink: 0;
-	}
-
-	.quick-wins-subtle {
-		margin-left: auto;
-		font-size: 0.72rem;
-		font-weight: 500;
-		color: var(--text-tertiary);
-		letter-spacing: 0.06em;
-		text-transform: uppercase;
-	}
-
-	.quick-wins-list {
-		display: flex;
-		flex-direction: column;
-		gap: 0.4rem;
-		margin: 0;
-		padding: 0;
-		list-style: none;
-	}
-
-	.quick-wins-item {
-		display: flex;
-		align-items: center;
-		gap: 0.75rem;
-		padding: 0.55rem 0.75rem;
-		background: rgba(255, 255, 255, 0.02);
-		border: 1px solid rgba(255, 255, 255, 0.05);
-		border-radius: var(--radius-md, 8px);
-	}
-
-	.quick-wins-rank {
-		flex-shrink: 0;
-		width: 22px;
-		height: 22px;
-		display: inline-flex;
-		align-items: center;
-		justify-content: center;
-		font-size: 0.72rem;
-		font-weight: 700;
-		color: var(--accent-cyan);
-		background: rgba(6, 182, 212, 0.1);
+	.passing small {
+		margin-top: 0.65rem;
+		padding: 0.3rem 0.55rem;
 		border: 1px solid rgba(6, 182, 212, 0.25);
-		border-radius: 50%;
+		border-radius: 999px;
+		color: var(--accent-cyan);
 	}
 
-	.quick-wins-summary {
-		flex: 1;
-		font-size: 0.88rem;
-		color: var(--text-primary);
-		line-height: 1.5;
-	}
-
-	.quick-wins-impact {
-		flex-shrink: 0;
-		font-size: 0.7rem;
-		font-weight: 600;
-		text-transform: uppercase;
-		letter-spacing: 0.05em;
-	}
-
-	/* toolbar: toggle + export */
 	.toolbar {
 		display: flex;
 		align-items: center;
 		justify-content: space-between;
 		gap: 1rem;
-	}
-
-	.toolbar-actions {
-		display: flex;
-		gap: 0.5rem;
-	}
-
-	.toolbar-btn {
-		display: inline-flex;
-		align-items: center;
-		gap: 0.4rem;
-		padding: 0.5rem 1rem;
-		background: var(--glass-bg);
-		border: 1px solid var(--glass-border);
-		border-radius: var(--radius-md);
-		font-size: 0.82rem;
-		font-weight: 500;
-		color: var(--text-secondary);
-		cursor: pointer;
-		backdrop-filter: blur(var(--glass-blur));
-		transition:
-			border-color 0.2s ease,
-			color 0.2s ease,
-			background 0.2s ease;
-	}
-
-	.toolbar-btn:hover:not(:disabled) {
-		border-color: rgba(6, 182, 212, 0.3);
-		color: var(--accent-cyan);
-		background: rgba(6, 182, 212, 0.05);
-	}
-
-	.toolbar-btn:disabled {
-		opacity: 0.7;
-		cursor: not-allowed;
-	}
-
-	.export-spinner {
-		animation: spin 1s linear infinite;
-	}
-
-	@keyframes spin {
-		from {
-			transform: rotate(0deg);
-		}
-		to {
-			transform: rotate(360deg);
-		}
-	}
-
-	/* view toggle tabs */
-	.view-toggle {
-		display: flex;
-		gap: 0.5rem;
-		padding: 0.25rem;
-		background: var(--glass-bg);
-		border: 1px solid var(--glass-border);
-		border-radius: var(--radius-lg);
-		width: fit-content;
-		backdrop-filter: blur(var(--glass-blur));
-	}
-
-	.toggle-btn {
-		display: inline-flex;
-		align-items: center;
-		gap: 0.4rem;
-		padding: 0.5rem 1rem;
-		background: transparent;
-		border: none;
-		border-radius: var(--radius-md);
-		font-size: 0.82rem;
-		font-weight: 500;
-		color: var(--text-tertiary);
-		cursor: pointer;
-		transition:
-			background 0.2s ease,
-			color 0.2s ease;
-	}
-
-	.toggle-btn:hover {
-		color: var(--text-secondary);
-	}
-
-	.toggle-btn.active {
-		background: rgba(6, 182, 212, 0.1);
-		color: var(--accent-cyan);
-		border: 1px solid rgba(6, 182, 212, 0.2);
-	}
-
-	.scores-grid {
-		display: grid;
-		/* 280px min lets 5 columns fit at ~1400px container width, reducing dead
-		   side-space vs the old 340px min that produced only 4 columns */
-		grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-		gap: 1.5rem;
-	}
-
-	.breakdowns-list {
-		display: flex;
-		flex-direction: column;
-		gap: 0.75rem;
-	}
-
-	/* two-column analysis grid for chart + stats */
-	.analysis-grid {
-		display: grid;
-		grid-template-columns: 1.4fr 1fr;
-		gap: 1.5rem;
-	}
-
-	.suggestions-section {
-		padding: 1.75rem;
-		background: var(--glass-bg);
-		border: 1px solid var(--glass-border);
-		border-radius: var(--radius-xl);
-		backdrop-filter: blur(var(--glass-blur));
-	}
-
-	.suggestions-header {
-		display: flex;
-		align-items: center;
-		gap: 0.5rem;
-		margin-bottom: 0.5rem;
-		color: var(--accent-cyan);
-	}
-
-	.suggestions-title {
-		font-size: 1.1rem;
-		font-weight: 700;
-		color: var(--text-primary);
-	}
-
-	.suggestions-subtitle {
-		font-size: 0.85rem;
-		color: var(--text-tertiary);
-		margin-bottom: 1.25rem;
-	}
-
-	.suggestions-cards {
-		display: flex;
-		flex-direction: column;
-		gap: 0.5rem;
-	}
-
-	.suggestion-card {
-		width: 100%;
-		text-align: left;
-		padding: 0;
-		background: rgba(255, 255, 255, 0.02);
-		border: 1px solid var(--glass-border);
-		border-radius: var(--radius-lg);
-		cursor: pointer;
-		transition:
-			border-color 0.2s ease,
-			background 0.2s ease;
-		overflow: hidden;
-		font-family: inherit;
-	}
-
-	.suggestion-card:hover {
-		border-color: rgba(6, 182, 212, 0.25);
-		background: rgba(6, 182, 212, 0.03);
-	}
-
-	.suggestion-card.expanded {
-		border-color: rgba(6, 182, 212, 0.3);
-	}
-
-	.suggestion-card-header {
-		display: flex;
-		align-items: center;
-		justify-content: space-between;
 		padding: 0.85rem 1rem;
-		gap: 0.75rem;
-	}
-
-	.suggestion-card-left {
-		display: flex;
-		align-items: center;
-		gap: 0.65rem;
-		min-width: 0;
-		flex: 1;
-	}
-
-	.suggestion-priority {
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		width: 22px;
-		height: 22px;
-		border-radius: 50%;
-		color: #fff;
-		font-size: 0.68rem;
-		font-weight: 700;
-		flex-shrink: 0;
-	}
-
-	.suggestion-summary {
-		font-size: 0.88rem;
+		border: 1px solid rgba(34, 197, 94, 0.2);
+		border-radius: var(--radius-lg);
+		background: rgba(34, 197, 94, 0.035);
 		color: var(--text-secondary);
-		line-height: 1.4;
+		font-size: 0.82rem;
 	}
 
-	.suggestion-card.expanded .suggestion-summary {
-		font-weight: 600;
-		color: var(--text-primary);
-	}
-
-	.suggestion-platforms {
-		display: flex;
-		gap: 0.3rem;
-	}
-
-	.platform-chip {
-		padding: 0.15rem 0.5rem;
-		font-size: 0.6rem;
-		font-weight: 600;
-		text-transform: uppercase;
-		letter-spacing: 0.04em;
-		background: rgba(6, 182, 212, 0.08);
-		border: 1px solid rgba(6, 182, 212, 0.2);
-		border-radius: 999px;
+	.toolbar button {
+		padding: 0.55rem 0.75rem;
+		border: 1px solid var(--glass-border);
+		border-radius: var(--radius-md);
+		background: transparent;
 		color: var(--accent-cyan);
+		cursor: pointer;
 		white-space: nowrap;
 	}
 
-	.suggestion-card-right {
-		display: flex;
-		align-items: center;
-		gap: 0.5rem;
-		flex-shrink: 0;
+	.cards {
+		display: grid;
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+		gap: 1rem;
 	}
 
-	.suggestion-impact {
-		font-size: 0.7rem;
-		font-weight: 600;
-		text-transform: uppercase;
-		letter-spacing: 0.04em;
-	}
-
-	.suggestion-chevron {
-		color: var(--text-tertiary);
-		transition: transform 0.2s ease;
-	}
-
-	.suggestion-chevron.rotated {
-		transform: rotate(180deg);
-	}
-
-	.suggestion-card-body {
-		padding: 0 1rem 1rem 3rem;
-		animation: cardExpand 0.25s ease;
-	}
-
-	.suggestion-card-body p {
-		font-size: 0.88rem;
-		color: var(--text-secondary);
-		line-height: 1.7;
-		margin: 0;
-	}
-
-	.suggestion-details {
-		list-style: none;
-		padding: 0;
-		margin: 0;
-		display: flex;
-		flex-direction: column;
-		gap: 0.5rem;
-	}
-
-	.suggestion-details li {
-		font-size: 0.85rem;
-		color: var(--text-secondary);
-		line-height: 1.6;
-		padding-left: 1.1rem;
-		position: relative;
-	}
-
-	.suggestion-details li::before {
-		content: '';
-		position: absolute;
-		left: 0;
-		top: 0.55rem;
-		width: 5px;
-		height: 5px;
-		border-radius: 50%;
-		background: var(--accent-cyan);
-		opacity: 0.6;
-	}
-
-	/* before/after example block inside expanded suggestion */
-	.suggestion-example {
-		margin-top: 1rem;
-		padding: 0.85rem 1rem 0.95rem;
-		background: rgba(255, 255, 255, 0.02);
-		border: 1px solid var(--glass-border);
-		border-radius: var(--radius-md);
-	}
-
-	.example-tip {
-		font-size: 0.78rem;
-		color: var(--text-secondary);
-		margin: 0 0 0.75rem;
-		line-height: 1.55;
-	}
-
-	.example-pair {
+	.analysis-grid {
 		display: grid;
 		grid-template-columns: 1fr 1fr;
-		gap: 0.6rem;
+		gap: 1rem;
+		align-items: start;
 	}
 
-	.example-block {
-		padding: 0.55rem 0.75rem;
-		border-radius: var(--radius-sm);
-		border: 1px solid;
-		min-width: 0;
+	.suggestions-panel,
+	.disclaimer {
+		padding: 1.4rem;
+		border: 1px solid var(--glass-border);
+		border-radius: var(--radius-xl);
+		background: var(--glass-bg);
 	}
 
-	.example-block.before {
-		background: rgba(239, 68, 68, 0.05);
-		border-color: rgba(239, 68, 68, 0.18);
+	.suggestions-panel h2 {
+		color: var(--text-primary);
+		font-size: 1.1rem;
 	}
 
-	.example-block.after {
-		background: rgba(34, 197, 94, 0.05);
-		border-color: rgba(34, 197, 94, 0.2);
-	}
-
-	.example-block-header {
-		display: flex;
-		align-items: center;
-		justify-content: space-between;
-		gap: 0.5rem;
-		margin-bottom: 0.35rem;
-	}
-
-	.example-label {
-		display: block;
-		font-size: 0.62rem;
-		font-weight: 700;
-		text-transform: uppercase;
-		letter-spacing: 0.1em;
-		opacity: 0.8;
-	}
-
-	.copy-btn {
-		display: inline-flex;
-		align-items: center;
-		gap: 0.25rem;
-		padding: 0.1rem 0.45rem;
-		font-size: 0.66rem;
-		font-weight: 600;
+	.suggestions-panel header p,
+	.empty,
+	.disclaimer p {
+		margin-top: 0.35rem;
 		color: var(--text-tertiary);
-		background: rgba(255, 255, 255, 0.04);
-		border: 1px solid rgba(255, 255, 255, 0.08);
-		border-radius: var(--radius-full);
+		font-size: 0.8rem;
+		line-height: 1.5;
+	}
+
+	ol {
+		display: grid;
+		gap: 0.55rem;
+		margin-top: 1rem;
+		list-style: none;
+	}
+
+	ol > li {
+		border: 1px solid var(--glass-border);
+		border-radius: var(--radius-md);
+		background: rgba(255, 255, 255, 0.02);
+		overflow: hidden;
+	}
+
+	ol button {
+		display: grid;
+		grid-template-columns: 26px 1fr auto;
+		align-items: center;
+		gap: 0.65rem;
+		width: 100%;
+		padding: 0.75rem;
+		border: 0;
+		background: transparent;
+		color: var(--text-secondary);
 		cursor: pointer;
-		transition:
-			background 0.15s ease,
-			border-color 0.15s ease,
-			color 0.15s ease;
-		user-select: none;
+		text-align: left;
 	}
 
-	.copy-btn:hover {
-		background: rgba(255, 255, 255, 0.08);
-		border-color: rgba(255, 255, 255, 0.16);
-		color: var(--text-secondary);
+	.number {
+		display: grid;
+		place-items: center;
+		width: 24px;
+		height: 24px;
+		border-radius: 50%;
+		background: rgba(6, 182, 212, 0.1);
+		color: var(--accent-cyan);
+		font-weight: 700;
 	}
 
-	.copy-btn:focus-visible {
-		outline: 2px solid var(--accent-cyan);
-		outline-offset: 2px;
+	ol ul {
+		padding: 0 1rem 0.8rem 3.2rem;
+		color: var(--text-tertiary);
+		font-size: 0.78rem;
 	}
 
-	.copy-btn.copied {
-		color: #22c55e;
-		background: rgba(34, 197, 94, 0.1);
-		border-color: rgba(34, 197, 94, 0.28);
+	.disclaimer {
+		border-color: rgba(6, 182, 212, 0.2);
 	}
 
-	.example-block.before .example-label {
-		color: #ef4444;
+	.disclaimer strong {
+		color: var(--accent-cyan);
 	}
 
-	.example-block.after .example-label {
-		color: #22c55e;
-	}
-
-	.example-block pre {
-		margin: 0;
-		font-family: var(--font-mono);
-		font-size: 0.74rem;
-		line-height: 1.55;
-		color: var(--text-secondary);
-		white-space: pre-wrap;
-		word-break: break-word;
-	}
-
-	@media (max-width: 640px) {
-		.example-pair {
-			grid-template-columns: 1fr;
+	@media (max-width: 850px) {
+		.summary {
+			grid-template-columns: 100px 1fr;
 		}
-	}
 
-	@keyframes cardExpand {
-		from {
-			opacity: 0;
-			transform: translateY(-6px);
+		.passing {
+			grid-column: 1 / -1;
 		}
-		to {
-			opacity: 1;
-			transform: translateY(0);
-		}
-	}
 
-	@media (max-width: 900px) {
 		.analysis-grid {
 			grid-template-columns: 1fr;
 		}
 	}
 
-	@media (max-width: 640px) {
-		.summary-card {
-			flex-direction: column;
-			text-align: center;
-			gap: 1.5rem;
-			padding: 1.75rem;
-		}
-
-		/* keep the suggestions card padded the same as priority focus areas
-		   so all dashboard cards have the same outer width and feel uniform. */
-		.suggestions-section {
-			padding: 1.75rem;
-		}
-
-		.summary-center {
-			max-width: 100%;
-			width: 100%;
-		}
-
-		/* mini bars on mobile: bigger labels, taller tracks, fill the column.
-		   without these the bars look invisible because the row gaps and
-		   the 80px right-aligned label leave the track squeezed thin. */
-		.mini-bars {
-			gap: 0.55rem;
-		}
-		.mini-bar-item {
-			gap: 0.75rem;
-		}
-		.mini-bar-track {
-			height: 6px;
-		}
-		.mini-bar-label {
-			width: 110px;
-			font-size: 0.72rem;
-			text-align: left;
-		}
-
-		.summary-right {
-			align-items: center;
-		}
-
-		.summary-score {
-			align-items: center;
-		}
-
-		.scores-grid {
+	@media (max-width: 650px) {
+		.cards {
 			grid-template-columns: 1fr;
 		}
 
-		/* toolbar: stack view-toggle and actions vertically on narrow screens
-		   so the buttons do not squash below 44px wide. */
+		.summary {
+			grid-template-columns: 1fr;
+		}
+
+		.score {
+			align-items: center;
+		}
+
+		.bars div {
+			grid-template-columns: 100px 1fr;
+		}
+
 		.toolbar {
-			flex-wrap: wrap;
-			gap: 0.75rem;
-		}
-
-		.view-toggle {
-			width: 100%;
-		}
-
-		.toggle-btn {
-			flex: 1;
-			justify-content: center;
-			/* WCAG 2.5.5: ensure buttons are at least 44px tall */
-			min-height: 44px;
-		}
-
-		.toolbar-actions {
-			width: 100%;
-			justify-content: stretch;
-		}
-
-		.toolbar-btn {
-			flex: 1;
-			justify-content: center;
-			/* WCAG 2.5.5 touch target */
-			min-height: 44px;
-		}
-
-		.fallback-toast {
-			flex-direction: column;
 			align-items: stretch;
-		}
-
-		.fallback-toast-actions {
-			justify-content: center;
-		}
-
-		/* quick-wins items: allow text to wrap so long suggestions stay readable */
-		.quick-wins-item {
-			flex-wrap: wrap;
-			gap: 0.5rem 0.75rem;
-		}
-
-		.quick-wins-impact {
-			margin-left: auto;
-		}
-
-		/* suggestion cards: on narrow viewports the right-side cluster (platform
-		   chips + impact label + chevron) can exceed the row width and overlap the
-		   summary text. wrap the header so the right cluster drops below on
-		   overflow, and let the left side truncate text before that happens. */
-		.suggestion-card-header {
-			flex-wrap: wrap;
-			gap: 0.5rem;
-		}
-
-		.suggestion-card-left {
-			min-width: 0;
-		}
-
-		.suggestion-summary {
-			overflow: hidden;
-			text-overflow: ellipsis;
-			display: -webkit-box;
-			-webkit-line-clamp: 2;
-			line-clamp: 2;
-			-webkit-box-orient: vertical;
-		}
-
-		/* when the card is expanded on mobile, drop the clamp so the full
-		   suggestion text is visible inside the open accordion. */
-		.suggestion-card.expanded .suggestion-summary {
-			display: block;
-			-webkit-line-clamp: unset;
-			line-clamp: unset;
-			-webkit-box-orient: unset;
-			overflow: visible;
-			text-overflow: clip;
-		}
-
-		/* hide platform chips on very small viewports to reclaim space */
-		.suggestion-platforms {
-			display: none;
+			flex-direction: column;
 		}
 	}
 </style>

--- a/src/lib/components/upload/JobDescriptionInput.svelte
+++ b/src/lib/components/upload/JobDescriptionInput.svelte
@@ -1,307 +1,102 @@
 <script lang="ts">
-	import { scoresStore } from '$stores/scores.svelte';
-	import { resumeStore } from '$stores/resume.svelte';
-	import { jdLibrary } from '$stores/jd-library.svelte';
-	import { authStore } from '$stores/auth.svelte';
 	import { SAMPLE_JD } from '$lib/sample-resume';
-	import { logger } from '$lib/log';
+	import { localeStore } from '$stores/locale.svelte';
+	import { resumeStore } from '$stores/resume.svelte';
+	import { scoresStore } from '$stores/scores.svelte';
 
 	let expanded = $state(false);
-	let libraryOpen = $state(false);
-
-	// debounced JD value drives the live skill-extraction preview - parsing on
-	// every keystroke would re-tokenize a long JD on every char and feel laggy
-	const DEBOUNCE_MS = 400;
-	const MIN_JD_LENGTH_FOR_PREVIEW = 50;
-	let debouncedJD = $state('');
-	$effect(() => {
-		const v = scoresStore.jobDescription;
-		const id = setTimeout(() => {
-			debouncedJD = v;
-		}, DEBOUNCE_MS);
-		return () => clearTimeout(id);
-	});
-
-	type ParsedJD = {
+	let parsed = $state<{
 		extractedSkills: string[];
 		requiredSkills: string[];
 		experienceLevel: string;
 		roleType: string;
 		industryContext: string;
-	};
-	let parsed = $state<ParsedJD | null>(null);
+	} | null>(null);
+	let debounce: ReturnType<typeof setTimeout> | undefined;
 
-	// dynamically import the parser only when there's enough JD to preview - avoids
-	// pulling compromise/skills-taxonomy into the layout chunk for users who never
-	// open the JD section
 	$effect(() => {
-		const v = debouncedJD;
-		if (v.length < MIN_JD_LENGTH_FOR_PREVIEW) {
+		const value = scoresStore.jobDescription;
+		clearTimeout(debounce);
+		if (value.trim().length < 50) {
 			parsed = null;
 			return;
 		}
-		let cancelled = false;
-		(async () => {
+		debounce = setTimeout(async () => {
 			try {
 				const { parseJobDescription } = await import('$engine/job-parser');
-				if (cancelled) return;
-				const result = parseJobDescription(v);
-				if (cancelled) return;
+				const result = parseJobDescription(value);
 				parsed = {
-					extractedSkills: result.extractedSkills.slice(0, 12),
+					extractedSkills: result.extractedSkills.slice(0, 16),
 					requiredSkills: result.requiredSkills,
 					experienceLevel: result.experienceLevel,
 					roleType: result.roleType,
 					industryContext: result.industryContext
 				};
-			} catch (err) {
-				// preview is best-effort - if the parser throws (corrupt input,
-				// transient import failure), keep the previous parsed state and
-				// log so it's grep-able in console without breaking the scan flow
-				logger.warn('jd_preview.parse_failed', {
-					error: err instanceof Error ? err.message : String(err)
-				});
+			} catch {
+				parsed = null;
 			}
-		})();
-		return () => {
-			cancelled = true;
-		};
+		}, 350);
+		return () => clearTimeout(debounce);
 	});
 
-	const resumeSkillsSet = $derived(
-		new Set((resumeStore.resume?.skills ?? []).map((s) => s.toLowerCase()))
+	const resumeSkills = $derived(
+		new Set((resumeStore.resume?.skills ?? []).map((skill) => skill.toLocaleLowerCase()))
 	);
 
-	const matchSummary = $derived.by(() => {
-		if (!parsed || resumeSkillsSet.size === 0) return null;
-		const matched = parsed.extractedSkills.filter((s) => resumeSkillsSet.has(s.toLowerCase()));
-		return {
-			matched: matched.length,
-			total: parsed.extractedSkills.length,
-			matchedSet: new Set(matched.map((s) => s.toLowerCase()))
-		};
-	});
-
-	function isMatched(skill: string): boolean {
-		return matchSummary?.matchedSet.has(skill.toLowerCase()) ?? false;
+	function matched(skill: string): boolean {
+		return resumeSkills.has(skill.toLocaleLowerCase());
 	}
 
-	// relative-time formatter - same logic as ScanHistory.svelte
-	function formatDate(iso: string): string {
-		const d = new Date(iso);
-		const now = new Date();
-		const diff = now.getTime() - d.getTime();
-		const mins = Math.floor(diff / 60_000);
-		const hours = Math.floor(diff / 3_600_000);
-		const days = Math.floor(diff / 86_400_000);
-		if (mins < 1) return 'just now';
-		if (mins < 60) return `${mins}m ago`;
-		if (hours < 24) return `${hours}h ago`;
-		if (days < 7) return `${days}d ago`;
-		return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
-	}
-
-	const MIN_JD_TO_SAVE = 50;
-
-	function saveCurrentJD() {
-		const content = scoresStore.jobDescription;
-		if (content.trim().length < MIN_JD_TO_SAVE) return;
-		const label = window.prompt('label this job description (e.g. "Senior Engineer at Acme")');
-		if (label === null) return; // user cancelled
-		jdLibrary.save(label, content);
-	}
-
-	function loadFromLibrary(content: string) {
-		scoresStore.setJobDescription(content);
-		libraryOpen = false;
-	}
-
-	const savedJDs = $derived(jdLibrary.list);
+	const matchCount = $derived(parsed?.extractedSkills.filter(matched).length ?? 0);
 </script>
 
-<div class="jd-input">
-	<button class="jd-toggle" onclick={() => (expanded = !expanded)} aria-expanded={expanded}>
-		<span class="toggle-icon" class:expanded>
-			<svg
-				width="16"
-				height="16"
-				viewBox="0 0 24 24"
-				fill="none"
-				stroke="currentColor"
-				stroke-width="2"
-			>
-				<polyline points="6,9 12,15 18,9" />
-			</svg>
-		</span>
-		{#if expanded}
-			Hide Job Description (Optional)
-		{:else}
-			Add Job Description for Targeted Scoring
-		{/if}
+<div class="job-description">
+	<button class="toggle" type="button" onclick={() => (expanded = !expanded)} aria-expanded={expanded}>
+		<span aria-hidden="true">{expanded ? '⌃' : '⌄'}</span>
+		{expanded ? localeStore.t('jd.hide') : localeStore.t('jd.show')}
 	</button>
 
 	{#if expanded}
-		<div class="jd-textarea-wrapper">
+		<div class="panel">
 			<textarea
-				class="jd-textarea"
-				placeholder="Paste the job description here for targeted keyword matching and industry-specific scoring..."
-				rows="8"
+				rows="9"
+				placeholder={localeStore.t('jd.placeholder')}
 				value={scoresStore.jobDescription}
-				oninput={(e) => scoresStore.setJobDescription((e.target as HTMLTextAreaElement).value)}
+				oninput={(event) =>
+					scoresStore.setJobDescription((event.target as HTMLTextAreaElement).value)}
 			></textarea>
-			<div class="jd-action-row">
+
+			<div class="actions">
 				{#if !scoresStore.hasJobDescription}
-					<button
-						type="button"
-						class="jd-sample-btn"
-						onclick={() => scoresStore.setJobDescription(SAMPLE_JD)}
-					>
-						Try with a sample job description
+					<button type="button" onclick={() => scoresStore.setJobDescription(SAMPLE_JD)}>
+						{localeStore.locale === 'pt-BR' ? 'Usar vaga de exemplo' : 'Use sample job'}
 					</button>
 				{/if}
-				<!-- the Saved JDs feature is localStorage-only, so it works on
-				     self-host (firebase disabled) AND for authenticated users on
-				     hosted. anonymous visitors on hosted firebase still don't see
-				     it: signing in is required for any scan-adjacent persistence. -->
-				{#if authStore.disabled || authStore.isAuthenticated}
-					<button
-						type="button"
-						class="jd-save-btn"
-						disabled={scoresStore.jobDescription.trim().length < MIN_JD_TO_SAVE}
-						onclick={saveCurrentJD}
-					>
-						<svg
-							width="12"
-							height="12"
-							viewBox="0 0 24 24"
-							fill="none"
-							stroke="currentColor"
-							stroke-width="2"
-						>
-							<path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z" />
-							<polyline points="17,21 17,13 7,13 7,21" />
-							<polyline points="7,3 7,8 15,8" />
-						</svg>
-						Save JD
+				{#if scoresStore.hasJobDescription}
+					<button type="button" onclick={() => scoresStore.setJobDescription('')}>
+						{localeStore.locale === 'pt-BR' ? 'Limpar' : 'Clear'}
 					</button>
-					{#if savedJDs.length > 0}
-						<div class="jd-library-wrap">
-							<button
-								type="button"
-								class="jd-library-btn"
-								aria-expanded={libraryOpen}
-								onclick={() => (libraryOpen = !libraryOpen)}
-							>
-								<svg
-									width="12"
-									height="12"
-									viewBox="0 0 24 24"
-									fill="none"
-									stroke="currentColor"
-									stroke-width="2"
-								>
-									<path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20" />
-									<path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z" />
-								</svg>
-								Saved JDs ({savedJDs.length})
-							</button>
-							{#if libraryOpen}
-								<div class="jd-library-dropdown" role="listbox" aria-label="Saved job descriptions">
-									{#each savedJDs as entry (entry.id)}
-										<div class="jd-library-item" role="option" aria-selected="false">
-											<button
-												type="button"
-												class="jd-library-load"
-												onclick={() => loadFromLibrary(entry.content)}
-											>
-												<span class="jd-library-label">{entry.label}</span>
-												<span class="jd-library-time">{formatDate(entry.savedAt)}</span>
-											</button>
-											<button
-												type="button"
-												class="jd-library-delete"
-												aria-label="Delete {entry.label}"
-												onclick={() => jdLibrary.remove(entry.id)}
-											>
-												<svg
-													width="12"
-													height="12"
-													viewBox="0 0 24 24"
-													fill="none"
-													stroke="currentColor"
-													stroke-width="2.5"
-												>
-													<line x1="18" y1="6" x2="6" y2="18" />
-													<line x1="6" y1="6" x2="18" y2="18" />
-												</svg>
-											</button>
-										</div>
-									{/each}
-								</div>
-							{/if}
-						</div>
-					{/if}
 				{/if}
 			</div>
+
 			{#if scoresStore.hasJobDescription}
-				<div class="jd-status">
-					<svg
-						width="14"
-						height="14"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						stroke-width="2"
-					>
-						<path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" />
-						<polyline points="22,4 12,14.01 9,11.01" />
-					</svg>
-					<span>Targeted mode active. Your resume will be scored against this specific job.</span>
-				</div>
+				<p class="active">✓ {localeStore.t('jd.active')}</p>
 			{/if}
 
 			{#if parsed && parsed.extractedSkills.length > 0}
-				<div class="jd-preview">
-					<div class="jd-preview-header">
-						<span class="preview-label">Detected from JD</span>
-						{#if matchSummary}
-							<span
-								class="match-summary"
-								class:strong={matchSummary.matched / Math.max(matchSummary.total, 1) >= 0.6}
-							>
-								<strong>{matchSummary.matched}</strong> of
-								<strong>{matchSummary.total}</strong> in your resume
-							</span>
-						{/if}
+				<div class="preview">
+					<div class="preview-header">
+						<strong>{localeStore.t('jd.detected')}</strong>
+						<span>{matchCount}/{parsed.extractedSkills.length} {localeStore.t('jd.inResume')}</span>
 					</div>
-
-					<div class="jd-meta-chips">
-						{#if parsed.roleType !== 'other'}
-							<span class="meta-chip">{parsed.roleType}</span>
-						{/if}
-						{#if parsed.industryContext !== 'general'}
-							<span class="meta-chip">{parsed.industryContext}</span>
-						{/if}
-						<span class="meta-chip">{parsed.experienceLevel}</span>
+					<div class="meta">
+						{#if parsed.roleType !== 'other'}<span>{parsed.roleType}</span>{/if}
+						{#if parsed.industryContext !== 'general'}<span>{parsed.industryContext}</span>{/if}
+						<span>{parsed.experienceLevel}</span>
 					</div>
-
-					<div class="skill-chips">
+					<div class="skills">
 						{#each parsed.extractedSkills as skill}
-							<span class="skill-chip" class:matched={isMatched(skill)}>
-								{#if isMatched(skill)}
-									<svg
-										width="10"
-										height="10"
-										viewBox="0 0 24 24"
-										fill="none"
-										stroke="currentColor"
-										stroke-width="3"
-									>
-										<polyline points="20,6 9,17 4,12" />
-									</svg>
-								{/if}
-								{skill}
-							</span>
+							<span class:matched={matched(skill)}>{matched(skill) ? '✓ ' : ''}{skill}</span>
 						{/each}
 					</div>
 				</div>
@@ -311,366 +106,109 @@
 </div>
 
 <style>
-	.jd-input {
-		margin-top: 1.5rem;
-	}
-
-	.jd-toggle {
-		display: flex;
-		align-items: center;
-		gap: 0.5rem;
-		padding: 0.8rem 1.25rem;
-		background: var(--glass-bg);
-		border: 1px solid var(--glass-border);
-		border-radius: var(--radius-lg);
-		color: var(--text-secondary);
-		cursor: pointer;
-		font-size: 0.9rem;
-		font-weight: 500;
-		width: 100%;
-		backdrop-filter: blur(var(--glass-blur));
-		transition:
-			border-color 0.2s ease,
-			color 0.2s ease;
-	}
-
-	.jd-toggle:hover {
-		border-color: var(--accent-cyan);
-		color: var(--text-primary);
-	}
-
-	.toggle-icon {
-		transition: transform 0.2s ease;
-		display: inline-flex;
-		color: var(--accent-cyan);
-	}
-
-	.toggle-icon.expanded {
-		transform: rotate(180deg);
-	}
-
-	.jd-textarea-wrapper {
+	.job-description {
 		margin-top: 1rem;
 	}
 
-	.jd-textarea {
+	.toggle {
+		display: flex;
+		align-items: center;
+		gap: 0.6rem;
 		width: 100%;
-		padding: 1.25rem;
-		background: var(--glass-bg);
+		padding: 0.9rem 1rem;
 		border: 1px solid var(--glass-border);
 		border-radius: var(--radius-lg);
-		color: var(--text-primary);
-		font-family: var(--font-sans);
-		font-size: 0.9rem;
-		line-height: 1.6;
-		resize: vertical;
-		backdrop-filter: blur(var(--glass-blur));
-		transition: border-color 0.2s ease;
-	}
-
-	.jd-textarea:focus {
-		outline: none;
-		border-color: var(--accent-cyan);
-		box-shadow: 0 0 20px rgba(6, 182, 212, 0.08);
-	}
-
-	.jd-textarea::placeholder {
-		color: var(--text-tertiary);
-	}
-
-	.jd-action-row {
-		display: flex;
-		flex-wrap: wrap;
-		align-items: center;
-		gap: 0.5rem;
-		margin-top: 0.6rem;
-	}
-
-	.jd-sample-btn {
-		display: inline-flex;
-		align-items: center;
-		padding: 0.4rem 0.85rem;
-		background: rgba(6, 182, 212, 0.06);
-		color: var(--accent-cyan);
-		border: 1px solid rgba(6, 182, 212, 0.2);
-		border-radius: var(--radius-md);
-		font-size: 0.8rem;
-		font-weight: 500;
-		cursor: pointer;
-		transition:
-			background 0.15s ease,
-			border-color 0.15s ease;
-	}
-
-	.jd-sample-btn:hover {
-		background: rgba(6, 182, 212, 0.12);
-		border-color: rgba(6, 182, 212, 0.35);
-	}
-
-	.jd-status {
-		display: flex;
-		align-items: center;
-		gap: 0.5rem;
-		margin-top: 0.75rem;
-		font-size: 0.85rem;
-		color: var(--accent-cyan);
-		padding: 0.5rem 0.75rem;
-		background: rgba(6, 182, 212, 0.05);
-		border: 1px solid rgba(6, 182, 212, 0.15);
-		border-radius: var(--radius-md);
-	}
-
-	/* live preview block: detected role / industry / skills from the typed JD */
-	.jd-preview {
-		margin-top: 0.85rem;
-		padding: 0.85rem 1rem 1rem;
-		background: rgba(255, 255, 255, 0.02);
-		border: 1px solid var(--glass-border);
-		border-radius: var(--radius-md);
-		animation: previewIn 0.25s ease;
-	}
-
-	@keyframes previewIn {
-		from {
-			opacity: 0;
-			transform: translateY(-4px);
-		}
-	}
-
-	.jd-preview-header {
-		display: flex;
-		align-items: center;
-		justify-content: space-between;
-		gap: 0.75rem;
-		margin-bottom: 0.65rem;
-	}
-
-	.preview-label {
-		font-size: 0.7rem;
-		font-weight: 600;
-		text-transform: uppercase;
-		letter-spacing: 0.08em;
-		color: var(--text-tertiary);
-	}
-
-	.match-summary {
-		font-size: 0.75rem;
-		color: var(--text-tertiary);
-		font-variant-numeric: tabular-nums;
-	}
-
-	.match-summary strong {
-		color: var(--text-secondary);
-		font-weight: 600;
-	}
-
-	.match-summary.strong strong {
-		color: #22c55e;
-	}
-
-	.jd-meta-chips {
-		display: flex;
-		flex-wrap: wrap;
-		gap: 0.35rem;
-		margin-bottom: 0.6rem;
-	}
-
-	.meta-chip {
-		padding: 0.15rem 0.5rem;
-		font-size: 0.68rem;
-		font-weight: 500;
-		text-transform: capitalize;
-		color: var(--text-tertiary);
-		background: rgba(255, 255, 255, 0.04);
-		border: 1px solid rgba(255, 255, 255, 0.06);
-		border-radius: var(--radius-full);
-	}
-
-	.skill-chips {
-		display: flex;
-		flex-wrap: wrap;
-		gap: 0.35rem;
-	}
-
-	.skill-chip {
-		display: inline-flex;
-		align-items: center;
-		gap: 0.25rem;
-		padding: 0.18rem 0.55rem;
-		font-size: 0.74rem;
-		font-weight: 500;
-		color: var(--text-secondary);
-		background: rgba(6, 182, 212, 0.06);
-		border: 1px solid rgba(6, 182, 212, 0.15);
-		border-radius: var(--radius-full);
-	}
-
-	.skill-chip.matched {
-		color: #22c55e;
-		background: rgba(34, 197, 94, 0.1);
-		border-color: rgba(34, 197, 94, 0.28);
-	}
-
-	@media (max-width: 640px) {
-		/* bump action-row buttons to 44px tall on mobile to meet WCAG 2.5.5 */
-		.jd-sample-btn,
-		.jd-save-btn,
-		.jd-library-btn {
-			min-height: 44px;
-		}
-
-		/* JD textarea: 8 rows eats the whole screen on a 375px phone.
-		   5 rows keeps the placeholder visible and shows text without hiding the
-		   action row below the fold. */
-		.jd-textarea {
-			min-height: 110px;
-		}
-	}
-
-	/* save JD button */
-	.jd-save-btn {
-		display: inline-flex;
-		align-items: center;
-		gap: 0.35rem;
-		padding: 0.4rem 0.85rem;
-		background: rgba(6, 182, 212, 0.06);
-		color: var(--accent-cyan);
-		border: 1px solid rgba(6, 182, 212, 0.2);
-		border-radius: var(--radius-md);
-		font-size: 0.8rem;
-		font-weight: 500;
-		cursor: pointer;
-		transition:
-			background 0.15s ease,
-			border-color 0.15s ease,
-			opacity 0.15s ease;
-	}
-
-	.jd-save-btn:hover:not(:disabled) {
-		background: rgba(6, 182, 212, 0.12);
-		border-color: rgba(6, 182, 212, 0.35);
-	}
-
-	.jd-save-btn:disabled {
-		opacity: 0.35;
-		cursor: not-allowed;
-	}
-
-	/* library pill and dropdown */
-	.jd-library-wrap {
-		position: relative;
-	}
-
-	.jd-library-btn {
-		display: inline-flex;
-		align-items: center;
-		gap: 0.35rem;
-		padding: 0.4rem 0.85rem;
-		background: rgba(255, 255, 255, 0.04);
-		color: var(--text-secondary);
-		border: 1px solid var(--glass-border);
-		border-radius: var(--radius-md);
-		font-size: 0.8rem;
-		font-weight: 500;
-		cursor: pointer;
-		transition:
-			background 0.15s ease,
-			border-color 0.15s ease,
-			color 0.15s ease;
-	}
-
-	.jd-library-btn:hover,
-	.jd-library-btn[aria-expanded='true'] {
-		background: rgba(255, 255, 255, 0.07);
-		border-color: rgba(255, 255, 255, 0.15);
-		color: var(--text-primary);
-	}
-
-	.jd-library-dropdown {
-		position: absolute;
-		top: calc(100% + 6px);
-		left: 0;
-		z-index: 50;
-		min-width: 280px;
-		/* on narrow viewports the dropdown must not overflow the screen edge.
-		   clamp to the viewport width minus 2rem breathing room. right: 0
-		   anchors the right edge when the left-side anchor would push it off-screen. */
-		max-width: min(360px, calc(100vw - 2rem));
-		right: 0;
 		background: var(--glass-bg);
-		border: 1px solid var(--glass-border);
-		border-radius: var(--radius-lg);
-		backdrop-filter: blur(var(--glass-blur));
-		box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
-		overflow: hidden;
-		animation: previewIn 0.15s ease;
-	}
-
-	.jd-library-item {
-		display: flex;
-		align-items: center;
-		border-bottom: 1px solid rgba(255, 255, 255, 0.04);
-	}
-
-	.jd-library-item:last-child {
-		border-bottom: none;
-	}
-
-	.jd-library-load {
-		flex: 1;
-		display: flex;
-		flex-direction: column;
-		align-items: flex-start;
-		gap: 0.15rem;
-		padding: 0.65rem 0.85rem;
-		background: none;
-		border: none;
+		color: var(--text-secondary);
 		cursor: pointer;
+		font-weight: 600;
 		text-align: left;
-		transition: background 0.12s ease;
 	}
 
-	.jd-library-load:hover {
-		background: rgba(6, 182, 212, 0.06);
+	.toggle:hover {
+		border-color: rgba(6, 182, 212, 0.45);
 	}
 
-	.jd-library-label {
-		font-size: 0.82rem;
-		font-weight: 500;
-		color: var(--text-primary);
-		white-space: nowrap;
-		overflow: hidden;
-		text-overflow: ellipsis;
-		max-width: 240px;
+	.panel {
+		margin-top: 0.65rem;
+		padding: 1rem;
+		border: 1px solid var(--glass-border);
+		border-radius: var(--radius-lg);
+		background: var(--glass-bg);
 	}
 
-	.jd-library-time {
-		font-size: 0.72rem;
-		color: var(--text-tertiary);
-		font-variant-numeric: tabular-nums;
-	}
-
-	.jd-library-delete {
-		flex-shrink: 0;
-		display: inline-flex;
-		align-items: center;
-		justify-content: center;
-		/* 44x44 meets WCAG 2.5.5 touch target size recommendation */
-		width: 44px;
-		height: 44px;
-		margin-right: 0.15rem;
-		background: none;
-		border: none;
+	textarea {
+		width: 100%;
+		resize: vertical;
+		padding: 0.9rem;
+		border: 1px solid var(--glass-border);
 		border-radius: var(--radius-md);
-		color: var(--text-tertiary);
-		cursor: pointer;
-		transition:
-			background 0.12s ease,
-			color 0.12s ease;
+		background: rgba(0, 0, 0, 0.18);
+		color: var(--text-primary);
+		font: inherit;
+		line-height: 1.5;
 	}
 
-	.jd-library-delete:hover {
-		background: rgba(239, 68, 68, 0.12);
-		color: #ef4444;
+	textarea:focus {
+		outline: 1px solid var(--accent-cyan);
+		border-color: var(--accent-cyan);
+	}
+
+	.actions {
+		display: flex;
+		gap: 0.6rem;
+		margin-top: 0.7rem;
+	}
+
+	.actions button {
+		padding: 0.5rem 0.75rem;
+		border: 1px solid var(--glass-border);
+		border-radius: var(--radius-md);
+		background: transparent;
+		color: var(--accent-cyan);
+		cursor: pointer;
+	}
+
+	.active {
+		margin-top: 0.8rem;
+		color: #22c55e;
+		font-size: 0.82rem;
+	}
+
+	.preview {
+		margin-top: 1rem;
+		padding-top: 1rem;
+		border-top: 1px solid var(--glass-border);
+	}
+
+	.preview-header {
+		display: flex;
+		justify-content: space-between;
+		gap: 1rem;
+		color: var(--text-secondary);
+		font-size: 0.8rem;
+	}
+
+	.meta,
+	.skills {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.45rem;
+		margin-top: 0.65rem;
+	}
+
+	.meta span,
+	.skills span {
+		padding: 0.25rem 0.55rem;
+		border: 1px solid var(--glass-border);
+		border-radius: 999px;
+		color: var(--text-tertiary);
+		font-size: 0.72rem;
+	}
+
+	.skills span.matched {
+		border-color: rgba(34, 197, 94, 0.4);
+		background: rgba(34, 197, 94, 0.08);
+		color: #22c55e;
 	}
 </style>

--- a/src/lib/components/upload/ResumeUploader.svelte
+++ b/src/lib/components/upload/ResumeUploader.svelte
@@ -1,19 +1,16 @@
 <script lang="ts">
+	import { localeStore } from '$stores/locale.svelte';
 	import { resumeStore } from '$stores/resume.svelte';
 
-	// visual feedback for the drag-and-drop zone
 	let isDragging = $state(false);
-	// ref to the hidden file input for programmatic click
 	let fileInput: HTMLInputElement;
-
-	// MIME types we accept (PDF and DOCX only)
-	const ACCEPTED_TYPES = [
+	const acceptedTypes = [
 		'application/pdf',
 		'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
 	];
 
-	function handleDragOver(e: DragEvent) {
-		e.preventDefault();
+	function handleDragOver(event: DragEvent) {
+		event.preventDefault();
 		isDragging = true;
 	}
 
@@ -21,27 +18,27 @@
 		isDragging = false;
 	}
 
-	function handleDrop(e: DragEvent) {
-		e.preventDefault();
+	function handleDrop(event: DragEvent) {
+		event.preventDefault();
 		isDragging = false;
-		const file = e.dataTransfer?.files[0];
+		const file = event.dataTransfer?.files[0];
 		if (file) validateAndSetFile(file);
 	}
 
-	function handleFileSelect(e: Event) {
-		const input = e.target as HTMLInputElement;
+	function handleFileSelect(event: Event) {
+		const input = event.target as HTMLInputElement;
 		const file = input.files?.[0];
 		if (file) validateAndSetFile(file);
 	}
 
-	// validates type + size before passing to the store
 	function validateAndSetFile(file: File) {
-		if (!ACCEPTED_TYPES.includes(file.type)) {
-			resumeStore.setError('Please upload a PDF or DOCX file.');
+		const extensionAccepted = /\.(pdf|docx)$/i.test(file.name);
+		if (!acceptedTypes.includes(file.type) && !extensionAccepted) {
+			resumeStore.setError(localeStore.t('uploader.invalid'));
 			return;
 		}
 		if (file.size > 10 * 1024 * 1024) {
-			resumeStore.setError('File too large (max 10MB).');
+			resumeStore.setError(localeStore.t('uploader.large'));
 			return;
 		}
 		resumeStore.setFile(file);
@@ -51,14 +48,10 @@
 		fileInput.click();
 	}
 
-	// space and enter both activate per WAI-ARIA button semantics. preventDefault
-	// stops space from scrolling the page when the uploader has focus.
-	// guard against bubbled keys from focusable children (the privacy link
-	// inside upload-prompt) so following the link does not trigger file pick.
-	function handleUploaderKey(e: KeyboardEvent) {
-		if (e.target !== e.currentTarget) return;
-		if (e.key === 'Enter' || e.key === ' ') {
-			e.preventDefault();
+	function handleKey(event: KeyboardEvent) {
+		if (event.target !== event.currentTarget) return;
+		if (event.key === 'Enter' || event.key === ' ') {
+			event.preventDefault();
 			openFilePicker();
 		}
 	}
@@ -73,15 +66,10 @@
 	ondrop={handleDrop}
 	role="button"
 	tabindex="0"
-	aria-label="Upload resume. Click, press Enter or Space, or drag a PDF or DOCX file."
+	aria-label={localeStore.t('uploader.aria')}
 	onclick={openFilePicker}
-	onkeydown={handleUploaderKey}
+	onkeydown={handleKey}
 >
-	<!--
-		accept includes both extensions and MIME types. iOS Safari requires
-		MIME types to show the "Choose File" / "Browse" option reliably;
-		extensions alone are sometimes ignored by the iOS document picker.
-	-->
 	<input
 		bind:this={fileInput}
 		type="file"
@@ -90,90 +78,28 @@
 		class="visually-hidden"
 	/>
 
-	{#if resumeStore.file}
+	{#if resumeStore.isParsing}
+		<div class="state-block">
+			<div class="spinner"></div>
+			<p class="primary">{localeStore.t('uploader.parsing')}</p>
+			<p class="secondary">{localeStore.t('uploader.parsingHint')}</p>
+		</div>
+	{:else if resumeStore.file}
 		<div class="file-info">
-			<div class="file-icon">
-				{#if resumeStore.file.name.endsWith('.pdf')}
-					<svg
-						width="28"
-						height="28"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						stroke-width="1.5"
-					>
-						<path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
-						<polyline points="14,2 14,8 20,8" />
-						<path d="M10 12l2 2 4-4" />
-					</svg>
-				{:else}
-					<svg
-						width="28"
-						height="28"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						stroke-width="1.5"
-					>
-						<path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
-						<polyline points="14,2 14,8 20,8" />
-						<line x1="16" y1="13" x2="8" y2="13" />
-						<line x1="16" y1="17" x2="8" y2="17" />
-					</svg>
-				{/if}
-			</div>
+			<div class="file-icon" aria-hidden="true">▣</div>
 			<div class="file-details">
 				<p class="file-name">{resumeStore.file.name}</p>
 				<p class="file-size">{(resumeStore.file.size / 1024).toFixed(0)} KB</p>
 			</div>
-			<div class="file-check">
-				<svg
-					width="20"
-					height="20"
-					viewBox="0 0 24 24"
-					fill="none"
-					stroke="currentColor"
-					stroke-width="2.5"
-				>
-					<polyline points="20,6 9,17 4,12" />
-				</svg>
-			</div>
-		</div>
-	{:else if resumeStore.isParsing}
-		<div class="parsing">
-			<div class="spinner"></div>
-			<p class="parsing-text">Parsing Your Resume...</p>
-			<p class="parsing-hint">Extracting text, sections, and metadata</p>
+			<div class="check" aria-hidden="true">✓</div>
 		</div>
 	{:else}
-		<div class="upload-prompt">
-			<div class="upload-icon-wrapper">
-				<svg
-					class="upload-icon"
-					width="32"
-					height="32"
-					viewBox="0 0 24 24"
-					fill="none"
-					stroke="currentColor"
-					stroke-width="1.5"
-				>
-					<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
-					<polyline points="17,8 12,3 7,8" />
-					<line x1="12" y1="3" x2="12" y2="15" />
-				</svg>
-			</div>
-			<p class="upload-text">Drag & Drop Your Resume Here</p>
-			<p class="upload-hint">or click to browse. PDF or DOCX, max 10MB.</p>
-			<div class="supported-formats">
-				<span class="format-badge">.PDF</span>
-				<span class="format-badge">.DOCX</span>
-			</div>
-			<p class="privacy-hint">
-				Parsed entirely in your browser. The file itself never reaches our servers.
-				<a href="/docs/legal/privacy/" class="privacy-link" onclick={(e) => e.stopPropagation()}>
-					Read more
-				</a>
-			</p>
+		<div class="state-block">
+			<div class="upload-icon" aria-hidden="true">⇧</div>
+			<p class="primary">{localeStore.t('uploader.title')}</p>
+			<p class="secondary">{localeStore.t('uploader.hint')}</p>
+			<div class="formats"><span>.PDF</span><span>.DOCX</span></div>
+			<p class="privacy">{localeStore.t('uploader.privacy')}</p>
 		</div>
 	{/if}
 
@@ -185,30 +111,25 @@
 <style>
 	.uploader {
 		position: relative;
-		padding: 3rem 2rem;
+		padding: 2.5rem 1.5rem;
 		background: var(--glass-bg);
 		border: 2px dashed var(--glass-border);
 		border-radius: var(--radius-xl);
-		backdrop-filter: blur(var(--glass-blur));
 		cursor: pointer;
-		transition:
-			border-color 0.3s ease,
-			background 0.3s ease,
-			box-shadow 0.3s ease;
 		text-align: center;
+		transition: 0.2s ease;
 	}
 
 	.uploader:hover,
 	.uploader.dragging {
 		border-color: var(--accent-cyan);
-		background: rgba(6, 182, 212, 0.03);
-		box-shadow: 0 0 30px rgba(6, 182, 212, 0.08);
+		background: rgba(6, 182, 212, 0.04);
 	}
 
 	.uploader.has-file {
 		border-style: solid;
-		border-color: rgba(34, 197, 94, 0.3);
-		background: rgba(34, 197, 94, 0.03);
+		border-color: rgba(34, 197, 94, 0.45);
+		background: rgba(34, 197, 94, 0.035);
 	}
 
 	.visually-hidden {
@@ -219,79 +140,66 @@
 		margin: -1px;
 		overflow: hidden;
 		clip: rect(0, 0, 0, 0);
+		white-space: nowrap;
 		border: 0;
 	}
 
-	.upload-icon-wrapper {
-		width: 64px;
-		height: 64px;
+	.state-block {
 		display: flex;
+		flex-direction: column;
 		align-items: center;
-		justify-content: center;
-		margin: 0 auto 1.25rem;
+	}
+
+	.upload-icon,
+	.file-icon {
+		display: grid;
+		place-items: center;
+		width: 56px;
+		height: 56px;
+		margin-bottom: 1rem;
+		border: 1px solid rgba(6, 182, 212, 0.25);
 		border-radius: var(--radius-lg);
 		background: rgba(6, 182, 212, 0.08);
-		border: 1px solid rgba(6, 182, 212, 0.15);
 		color: var(--accent-cyan);
+		font-size: 1.75rem;
 	}
 
-	.upload-text {
-		font-size: 1.1rem;
-		font-weight: 600;
+	.primary {
+		font-size: 1.05rem;
+		font-weight: 700;
 		color: var(--text-primary);
-		margin-bottom: 0.4rem;
 	}
 
-	.upload-hint {
+	.secondary,
+	.privacy,
+	.file-size {
+		color: var(--text-tertiary);
+	}
+
+	.secondary {
+		margin-top: 0.35rem;
 		font-size: 0.88rem;
-		color: var(--text-tertiary);
-		margin-bottom: 1rem;
 	}
 
-	.supported-formats {
+	.privacy {
+		max-width: 580px;
+		margin-top: 1rem;
+		font-size: 0.75rem;
+		line-height: 1.45;
+	}
+
+	.formats {
 		display: flex;
-		justify-content: center;
 		gap: 0.5rem;
+		margin-top: 1rem;
 	}
 
-	.format-badge {
-		padding: 0.2rem 0.6rem;
-		font-size: 0.7rem;
-		font-weight: 600;
-		color: var(--text-tertiary);
-		background: rgba(255, 255, 255, 0.03);
+	.formats span {
+		padding: 0.22rem 0.55rem;
 		border: 1px solid var(--glass-border);
 		border-radius: var(--radius-md);
-		letter-spacing: 0.05em;
-	}
-
-	.privacy-hint {
-		margin-top: 1rem;
-		font-size: 0.78rem;
+		font-size: 0.7rem;
 		color: var(--text-tertiary);
-		opacity: 0.75;
-		line-height: 1.5;
-	}
-
-	.privacy-link {
-		color: var(--accent-cyan);
-		text-decoration: none;
-		border-bottom: 1px solid transparent;
-		transition: border-color 0.15s ease;
-		margin-left: 0.25rem;
-	}
-
-	.privacy-link:hover,
-	.privacy-link:focus-visible {
-		border-bottom-color: var(--accent-cyan);
-	}
-
-	/* let the global :focus-visible ring (in $lib/styles/global.css) apply on
-	   keyboard focus. removing it would mean the only focus indicator on this
-	   inline link is the underline, which is too subtle for keyboard users. */
-	.privacy-link:focus-visible {
-		border-radius: 2px;
-		outline-offset: 2px;
 	}
 
 	.file-info {
@@ -301,65 +209,53 @@
 		gap: 1rem;
 	}
 
-	.file-icon {
-		color: var(--accent-cyan);
+	.file-info .file-icon {
+		margin: 0;
 	}
 
 	.file-details {
+		min-width: 0;
 		text-align: left;
 	}
 
 	.file-name {
-		font-weight: 600;
+		max-width: min(55vw, 430px);
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		font-weight: 700;
 		color: var(--text-primary);
-		font-size: 1rem;
 	}
 
 	.file-size {
-		font-size: 0.82rem;
-		color: var(--text-tertiary);
-		margin-top: 0.15rem;
+		margin-top: 0.2rem;
+		font-size: 0.8rem;
 	}
 
-	.file-check {
+	.check {
 		color: #22c55e;
-	}
-
-	.parsing {
-		display: flex;
-		flex-direction: column;
-		align-items: center;
-		gap: 0.75rem;
-	}
-
-	.parsing-text {
-		font-weight: 600;
-		color: var(--text-primary);
-	}
-
-	.parsing-hint {
-		font-size: 0.85rem;
-		color: var(--text-tertiary);
+		font-size: 1.25rem;
 	}
 
 	.spinner {
-		width: 32px;
-		height: 32px;
-		border: 3px solid var(--glass-border);
+		width: 34px;
+		height: 34px;
+		margin-bottom: 1rem;
+		border: 3px solid rgba(6, 182, 212, 0.18);
 		border-top-color: var(--accent-cyan);
 		border-radius: 50%;
 		animation: spin 0.8s linear infinite;
+	}
+
+	.error {
+		margin-top: 1rem;
+		color: #ef4444;
+		font-size: 0.86rem;
 	}
 
 	@keyframes spin {
 		to {
 			transform: rotate(360deg);
 		}
-	}
-
-	.error {
-		margin-top: 1rem;
-		color: #ef4444;
-		font-size: 0.9rem;
 	}
 </style>

--- a/src/lib/engine/job-parser/extractor.ts
+++ b/src/lib/engine/job-parser/extractor.ts
@@ -1,42 +1,121 @@
 import type { ParsedJobDescription } from './types';
-import { tokenize, extractNgrams } from '$engine/nlp/tokenizer';
+import { extractNgrams, tokenize } from '$engine/nlp/tokenizer';
 import { detectIndustry, getIndustrySkills } from '$engine/nlp/skills-taxonomy';
 
-// rule-based JD extractor. LLM enhancement happens server-side. works for any industry
+const COMMON_SKILLS = [
+	'python',
+	'java',
+	'javascript',
+	'typescript',
+	'react',
+	'react native',
+	'angular',
+	'vue',
+	'next.js',
+	'node.js',
+	'golang',
+	'go',
+	'rust',
+	'swift',
+	'kotlin',
+	'ruby',
+	'php',
+	'c++',
+	'c#',
+	'.net',
+	'sql',
+	'nosql',
+	'mongodb',
+	'postgresql',
+	'mysql',
+	'redis',
+	'docker',
+	'kubernetes',
+	'aws',
+	'azure',
+	'gcp',
+	'terraform',
+	'jenkins',
+	'git',
+	'github',
+	'linux',
+	'fastapi',
+	'express',
+	'rest api',
+	'restful api',
+	'apis rest',
+	'microservices',
+	'microsservicos',
+	'microsserviços',
+	'selenium',
+	'playwright',
+	'beautifulsoup',
+	'web scraping',
+	'machine learning',
+	'deep learning',
+	'data science',
+	'nlp',
+	'natural language processing',
+	'computer vision',
+	'tensorflow',
+	'pytorch',
+	'pandas',
+	'spark',
+	'hadoop',
+	'tableau',
+	'power bi',
+	'etl',
+	'salesforce',
+	'hubspot',
+	'sap',
+	'oracle',
+	'quickbooks',
+	'excel',
+	'powerpoint',
+	'jira',
+	'confluence',
+	'asana',
+	'slack',
+	'cpa',
+	'pmp',
+	'cissp',
+	'ceh',
+	'six sigma',
+	'scrum',
+	'agile',
+	'metodologias ageis',
+	'metodologias ágeis',
+	'lideranca',
+	'liderança',
+	'comunicacao',
+	'comunicação',
+	'atendimento ao cliente',
+	'gestao de projetos',
+	'gestão de projetos'
+];
+
 export function parseJobDescription(text: string): ParsedJobDescription {
-	const lower = text.toLowerCase();
-
-	// extract all meaningful tokens
+	const normalized = fold(text);
+	const language = detectLanguage(normalized);
 	const tokens = tokenize(text);
-	const terms = [...new Set(tokens.map((t) => t.normalized))];
-
-	// extract bigrams and trigrams for multi-word skills
+	const terms = [...new Set(tokens.map((token) => token.normalized))];
 	const bigrams = extractNgrams(text, 2);
 	const trigrams = extractNgrams(text, 3);
-
-	// detect industry context
 	const industries = detectIndustry(text);
-	const industryContext = industries.length > 0 ? industries[0].industry : 'general';
-
-	// get known skills for detected industry
-	const industrySkills =
-		industries.length > 0
-			? getIndustrySkills(industries[0].industry).map((s) => s.toLowerCase())
-			: [];
-
-	// extract skills by matching against taxonomy + common patterns
-	const extractedSkills = extractSkills(terms, bigrams, trigrams, industrySkills);
-
-	// separate required vs preferred
+	const industryContext = industries[0]?.industry ?? 'general';
+	const industrySkills = industries.length
+		? getIndustrySkills(industries[0].industry).map((skill) => fold(skill))
+		: [];
+	const extractedSkills = extractSkills(text, terms, bigrams, trigrams, industrySkills);
 	const { required, preferred } = categorizeSkills(text, extractedSkills);
-
-	// detect experience level
-	const experienceLevel = detectExperienceLevel(lower);
-	const educationRequirement = detectEducationRequirement(lower);
-	const roleType = detectRoleType(lower);
-
-	// extract key phrases (important multi-word terms from the JD)
-	const keyPhrases = [...bigrams, ...trigrams].filter((phrase) => isKeyPhrase(phrase)).slice(0, 20);
+	const minimumExperienceYears = detectMinimumExperienceYears(normalized);
+	const experienceLevel = detectExperienceLevel(normalized, minimumExperienceYears);
+	const educationRequirement = detectEducationRequirement(normalized);
+	const roleType = detectRoleType(normalized);
+	const keyPhrases = [...bigrams, ...trigrams]
+		.filter(isKeyPhrase)
+		.filter((phrase, index, all) => all.indexOf(phrase) === index)
+		.slice(0, 24);
 
 	return {
 		rawText: text,
@@ -44,150 +123,279 @@ export function parseJobDescription(text: string): ParsedJobDescription {
 		requiredSkills: required,
 		preferredSkills: preferred,
 		experienceLevel,
+		minimumExperienceYears,
 		educationRequirement,
 		industryContext,
 		roleType,
-		keyPhrases
+		keyPhrases,
+		language
 	};
 }
 
+function fold(value: string): string {
+	return value.normalize('NFKD').replace(/\p{M}/gu, '').toLowerCase();
+}
+
+function detectLanguage(text: string): 'pt-BR' | 'en' {
+	const pt = (
+		text.match(
+			/\b(?:requisitos|obrigatorio|desejavel|experiencia|formacao|habilidades|competencias|vaga|cargo|anos)\b/g
+		) || []
+	).length;
+	const en = (
+		text.match(
+			/\b(?:requirements|required|preferred|experience|education|skills|position|role|years)\b/g
+		) || []
+	).length;
+	return pt > en ? 'pt-BR' : 'en';
+}
+
 function extractSkills(
+	text: string,
 	terms: string[],
 	bigrams: string[],
 	trigrams: string[],
 	industrySkills: string[]
 ): string[] {
-	const skills = new Set<string>();
-	const industrySet = new Set(industrySkills);
-
-	// match single terms against industry taxonomy
+	const result = new Set<string>();
+	const corpus = fold(text);
+	const candidates = new Set([...industrySkills, ...COMMON_SKILLS.map(fold)]);
 	for (const term of terms) {
-		if (industrySet.has(term) && term.length >= 2) {
-			skills.add(term);
-		}
+		if (candidates.has(term) && term.length >= 2) result.add(canonicalSkill(term));
 	}
-
-	// match multi-word terms
 	for (const phrase of [...bigrams, ...trigrams]) {
-		if (industrySet.has(phrase)) {
-			skills.add(phrase);
+		const folded = fold(phrase);
+		if (candidates.has(folded)) result.add(canonicalSkill(folded));
+	}
+	for (const skill of candidates) {
+		const escaped = skill.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+		if (
+			new RegExp(
+				`(^|[^\\p{L}\\p{N}])${escaped}(?=$|[^\\p{L}\\p{N}])`,
+				'iu'
+			).test(corpus)
+		) {
+			result.add(canonicalSkill(skill));
 		}
 	}
+	return [...result];
+}
 
-	// also catch common skill patterns not in taxonomy
-	const skillPatterns = [
-		// tech
-		/\b(?:python|java|javascript|typescript|react|angular|vue|node\.?js|go|rust|swift|kotlin|ruby|php|c\+\+|c#|\.net|sql|nosql|mongodb|postgresql|redis|docker|kubernetes|aws|azure|gcp|terraform|jenkins|git|linux)\b/gi,
-		// data/ml
-		/\b(?:machine learning|deep learning|data science|nlp|natural language|computer vision|tensorflow|pytorch|pandas|spark|hadoop|tableau|power bi|etl)\b/gi,
-		// business
-		/\b(?:salesforce|hubspot|sap|oracle|quickbooks|excel|powerpoint|jira|confluence|asana|slack)\b/gi,
-		// certifications
-		/\b(?:cpa|pmp|aws certified|google certified|azure certified|cissp|ceh|six sigma|scrum master|agile)\b/gi
-	];
-
-	for (const pattern of skillPatterns) {
-		const matches = terms.join(' ').match(pattern);
-		if (matches) {
-			for (const match of matches) {
-				skills.add(match.toLowerCase());
-			}
-		}
-	}
-
-	return [...skills];
+function canonicalSkill(skill: string): string {
+	const key = fold(skill).replace(/\s+/g, ' ').trim();
+	const aliases: Record<string, string> = {
+		golang: 'Go',
+		go: 'Go',
+		typescript: 'TypeScript',
+		javascript: 'JavaScript',
+		python: 'Python',
+		'react native': 'React Native',
+		react: 'React',
+		'next.js': 'Next.js',
+		nextjs: 'Next.js',
+		'node.js': 'Node.js',
+		nodejs: 'Node.js',
+		fastapi: 'FastAPI',
+		postgresql: 'PostgreSQL',
+		mysql: 'MySQL',
+		mongodb: 'MongoDB',
+		github: 'GitHub',
+		docker: 'Docker',
+		kubernetes: 'Kubernetes',
+		aws: 'AWS',
+		azure: 'Azure',
+		gcp: 'GCP',
+		sql: 'SQL',
+		'power bi': 'Power BI',
+		'rest api': 'REST APIs',
+		'restful api': 'REST APIs',
+		'apis rest': 'REST APIs',
+		microsservicos: 'Microservices',
+		microservices: 'Microservices',
+		'metodologias ageis': 'Agile',
+		agile: 'Agile',
+		scrum: 'Scrum',
+		lideranca: 'Leadership',
+		comunicacao: 'Communication',
+		'gestao de projetos': 'Project Management',
+		'atendimento ao cliente': 'Customer Service'
+	};
+	return aliases[key] ?? skill.trim();
 }
 
 function categorizeSkills(
 	text: string,
 	skills: string[]
 ): { required: string[]; preferred: string[] } {
-	const lines = text.split('\n');
-	const required: string[] = [];
-	const preferred: string[] = [];
-
-	// find sections
-	let inRequired = false;
-	let inPreferred = false;
-
-	for (const line of lines) {
-		const lower = line.toLowerCase().trim();
-
-		// detect section headers
-		if (/(?:required|must have|minimum|essential|requirements)\b/.test(lower)) {
-			inRequired = true;
-			inPreferred = false;
-		} else if (/(?:preferred|nice to have|bonus|desired|plus|ideal)\b/.test(lower)) {
-			inRequired = false;
-			inPreferred = true;
+	const required = new Set<string>();
+	const preferred = new Set<string>();
+	let mode: 'required' | 'preferred' | 'neutral' = 'neutral';
+	for (const rawLine of text.split(/\r?\n/)) {
+		const line = fold(rawLine).trim();
+		if (!line) continue;
+		if (
+			/\b(?:preferred|nice to have|bonus|desired|plus|ideal|desejavel|desejaveis|diferencial|diferenciais|sera um diferencial)\b/.test(
+				line
+			)
+		) {
+			mode = 'preferred';
+		} else if (
+			/\b(?:required|must have|minimum|essential|requirements|mandatory|requisitos|obrigatorio|obrigatorios|essencial|necessario|necessarios)\b/.test(
+				line
+			)
+		) {
+			mode = 'required';
 		}
-
-		// check which skills appear in this line
 		for (const skill of skills) {
-			if (lower.includes(skill)) {
-				if (inPreferred && !inRequired) {
-					if (!preferred.includes(skill)) preferred.push(skill);
-				} else {
-					// default to required if section is ambiguous or explicitly required
-					if (!required.includes(skill)) required.push(skill);
-				}
+			if (!containsSkill(line, fold(skill))) continue;
+			if (
+				mode === 'preferred' ||
+				/\b(?:preferred|desejavel|diferencial|bonus)\b/.test(line)
+			) {
+				preferred.add(skill);
+			} else {
+				required.add(skill);
 			}
 		}
 	}
-
-	// any skills not categorized go to required by default
 	for (const skill of skills) {
-		if (!required.includes(skill) && !preferred.includes(skill)) {
-			required.push(skill);
-		}
+		if (!required.has(skill) && !preferred.has(skill)) required.add(skill);
 	}
-
-	return { required, preferred };
+	for (const skill of preferred) required.delete(skill);
+	return { required: [...required], preferred: [...preferred] };
 }
 
-function detectExperienceLevel(text: string): string {
-	if (/\b(?:director|vp|vice president|head of|chief)\b/.test(text)) return 'executive';
-	if (/\b(?:lead|principal|staff|architect)\b/.test(text)) return 'lead';
-	if (/\b(?:senior|sr\.?)\b/.test(text) || /\b[5-9]\+?\s*(?:years?|yrs?)\b/.test(text))
-		return 'senior';
-	if (/\b[3-4]\+?\s*(?:years?|yrs?)\b/.test(text)) return 'mid';
-	if (/\b(?:junior|jr\.?|entry)\b/.test(text) || /\b[0-2]\+?\s*(?:years?|yrs?)\b/.test(text))
+function containsSkill(text: string, skill: string): boolean {
+	const aliases: Record<string, string[]> = {
+		go: ['go', 'golang'],
+		'rest apis': ['rest api', 'restful api', 'apis rest'],
+		microservices: ['microservices', 'microsservicos'],
+		leadership: ['leadership', 'lideranca'],
+		communication: ['communication', 'comunicacao'],
+		'project management': ['project management', 'gestao de projetos']
+	};
+	return (aliases[skill] ?? [skill]).some((alias) => {
+		const escaped = alias.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+		return new RegExp(
+			`(^|[^\\p{L}\\p{N}])${escaped}(?=$|[^\\p{L}\\p{N}])`,
+			'iu'
+		).test(text);
+	});
+}
+
+function detectMinimumExperienceYears(text: string): number | null {
+	const matches = [
+		...text.matchAll(
+			/\b(\d{1,2})(?:\s*(?:-|a|to)\s*\d{1,2})?\s*\+?\s*(?:anos?|years?|yrs?)\b/giu
+		)
+	]
+		.map((match) => Number(match[1]))
+		.filter((value) => Number.isFinite(value) && value <= 30);
+	return matches.length ? Math.max(...matches) : null;
+}
+
+function detectExperienceLevel(
+	text: string,
+	minimumYears: number | null
+): ParsedJobDescription['experienceLevel'] {
+	if (
+		/\b(?:director|vp|vice president|head of|chief|diretor|diretora|vice-presidente|presidente|c-level)\b/.test(
+			text
+		)
+	) {
+		return 'executive';
+	}
+	if (
+		/\b(?:lead|principal|staff|architect|lider|especialista principal|arquiteto|arquiteta)\b/.test(
+			text
+		)
+	) {
+		return 'lead';
+	}
+	if (/\b(?:senior|sr\.?)\b/.test(text) || (minimumYears ?? 0) >= 5) return 'senior';
+	if (
+		/\b(?:junior|jr\.?|entry|iniciante)\b/.test(text) ||
+		(minimumYears !== null && minimumYears <= 2)
+	) {
 		return 'entry';
-	if (/\b(?:intern|internship|co-op|new grad)\b/.test(text)) return 'entry';
+	}
+	if (/\b(?:intern|internship|co-op|new grad|estagio|estagiario|aprendiz)\b/.test(text)) {
+		return 'entry';
+	}
 	return 'mid';
 }
 
 function detectEducationRequirement(text: string): string {
-	if (/\b(?:ph\.?d|doctorate)\b/.test(text)) return 'PhD';
-	if (/\b(?:master'?s?|mba|m\.s\.?|m\.a\.?)\b/.test(text)) return "Master's degree";
-	if (/\b(?:bachelor'?s?|b\.s\.?|b\.a\.?|degree)\b/.test(text)) return "Bachelor's degree";
-	if (/\b(?:associate'?s?)\b/.test(text)) return "Associate's degree";
+	if (/\b(?:ph\.?d|doctorate|doutorado)\b/.test(text)) return 'doctorate';
+	if (/\b(?:master'?s?|mba|m\.?s\.?|m\.?a\.?|mestrado|pos-graduacao)\b/.test(text)) {
+		return 'master';
+	}
+	if (
+		/\b(?:bachelor'?s?|b\.?s\.?|b\.?a\.?|bacharelado|graduacao|ensino superior)\b/.test(
+			text
+		)
+	) {
+		return 'bachelor';
+	}
+	if (/\b(?:associate'?s?|tecnologo|tecnologia)\b/.test(text)) return 'associate';
+	if (/\b(?:technical degree|curso tecnico|ensino tecnico)\b/.test(text)) return 'technical';
 	return 'not specified';
 }
 
 function detectRoleType(text: string): string {
 	if (
-		/\b(?:engineer|developer|programmer|devops|sre|software|frontend|backend|fullstack)\b/.test(
+		/\b(?:engineer|developer|programmer|devops|sre|software|frontend|backend|fullstack|engenheiro|desenvolvedor|programador)\b/.test(
 			text
 		)
-	)
+	) {
 		return 'engineering';
-	if (/\b(?:sales|account executive|business development)\b/.test(text)) return 'sales';
-	if (/\b(?:market|brand|content|seo|social media)\b/.test(text)) return 'marketing';
-	if (/\b(?:financial|finance|accounting|audit|tax|treasury|cpa|cfa)\b/.test(text))
+	}
+	if (/\b(?:sales|account executive|business development|vendas|comercial|promotor)\b/.test(text)) {
+		return 'sales';
+	}
+	if (/\b(?:market|brand|content|seo|social media|marketing|conteudo|midias sociais)\b/.test(text)) {
+		return 'marketing';
+	}
+	if (
+		/\b(?:financial|finance|accounting|audit|tax|treasury|cpa|cfa|financeiro|financas|contabilidade|auditoria)\b/.test(
+			text
+		)
+	) {
 		return 'finance';
-	if (/\b(?:nurse|physician|clinical|patient|healthcare)\b/.test(text)) return 'healthcare';
-	if (/\b(?:legal|attorney|counsel|compliance)\b/.test(text)) return 'legal';
-	if (/\b(?:operat|supply chain|logistics|procurement)\b/.test(text)) return 'operations';
-	if (/\b(?:design|ux|ui|graphic|creative)\b/.test(text)) return 'design';
+	}
+	if (/\b(?:nurse|physician|clinical|patient|healthcare|enfermeiro|medico|clinico|saude)\b/.test(text)) {
+		return 'healthcare';
+	}
+	if (/\b(?:legal|attorney|counsel|compliance|juridico|advogado|advogada)\b/.test(text)) {
+		return 'legal';
+	}
+	if (/\b(?:operat\w*|supply chain|logistics|operacao|logistica|suprimentos)\b/.test(text)) {
+		return 'operations';
+	}
+	if (/\b(?:design|ux|ui|graphic|creative|criativo|criativa)\b/.test(text)) return 'design';
 	return 'other';
 }
 
 function isKeyPhrase(phrase: string): boolean {
 	const words = phrase.split(' ');
-	// filter out phrases that are too generic
-	const genericWords = new Set(['the', 'and', 'for', 'with', 'this', 'that', 'will', 'you', 'are']);
-	if (words.every((w) => genericWords.has(w))) return false;
-	if (words.some((w) => w.length <= 1)) return false;
-	return true;
+	const generic = new Set([
+		'the',
+		'and',
+		'for',
+		'with',
+		'this',
+		'that',
+		'will',
+		'you',
+		'are',
+		'para',
+		'com',
+		'uma',
+		'um',
+		'que',
+		'por',
+		'das',
+		'dos'
+	]);
+	return !words.every((word) => generic.has(word)) && !words.some((word) => word.length <= 1);
 }

--- a/src/lib/engine/job-parser/types.ts
+++ b/src/lib/engine/job-parser/types.ts
@@ -3,9 +3,11 @@ export interface ParsedJobDescription {
 	extractedSkills: string[];
 	requiredSkills: string[];
 	preferredSkills: string[];
-	experienceLevel: string;
+	experienceLevel: 'entry' | 'mid' | 'senior' | 'lead' | 'executive';
+	minimumExperienceYears: number | null;
 	educationRequirement: string;
 	industryContext: string;
 	roleType: string;
 	keyPhrases: string[];
+	language: 'pt-BR' | 'en';
 }

--- a/src/lib/engine/llm/index.ts
+++ b/src/lib/engine/llm/index.ts
@@ -1,4 +1,52 @@
-export { scoreLLM, analyzWithLLM } from './client';
+import { env as publicEnv } from '$env/dynamic/public';
+import { scoreResume } from '$engine/scorer/engine';
+import type { ScoringInput } from '$engine/scorer/types';
+import { resumeStore } from '$stores/resume.svelte';
+import {
+	analyzWithLLM,
+	scoreLLM as scoreWithRemoteLLM,
+	type ScoreLLMResult
+} from './client';
+
+export async function scoreLLM(
+	resumeText: string,
+	jobDescription?: string,
+	options?: { signal?: AbortSignal }
+): Promise<ScoreLLMResult> {
+	const deterministicOnly = publicEnv.PUBLIC_DETERMINISTIC_ONLY !== 'false';
+	if (!deterministicOnly) {
+		return scoreWithRemoteLLM(resumeText, jobDescription, options);
+	}
+
+	if (options?.signal?.aborted) return { status: 'cancelled' };
+	const resume = resumeStore.resume;
+	if (!resume) return { status: 'error' };
+
+	const input: ScoringInput = {
+		resumeText: resume.rawText,
+		resumeSkills: resume.skills,
+		resumeSections: resume.sections.map((section) => section.type),
+		experienceBullets: resume.experience.flatMap((entry) => entry.bullets),
+		educationText: resume.education.map((entry) => entry.rawText).join('\n'),
+		hasMultipleColumns: resume.metadata.hasMultipleColumns,
+		hasTables: resume.metadata.hasTables,
+		hasImages: resume.metadata.hasImages,
+		pageCount: resume.metadata.pageCount,
+		wordCount: resume.metadata.wordCount,
+		jobDescription,
+		locale: resume.metadata.language,
+		extractionQuality: resume.metadata.extractionQuality
+	};
+
+	return {
+		status: 'ok',
+		results: scoreResume(input),
+		provider: 'deterministic-local',
+		fallback: false
+	};
+}
+
+export { analyzWithLLM };
 export { generateFallbackAnalysis } from './fallback';
 export {
 	buildFullScoringPrompt,

--- a/src/lib/engine/nlp/tokenizer.ts
+++ b/src/lib/engine/nlp/tokenizer.ts
@@ -1,125 +1,6 @@
-// stop words to exclude from keyword analysis (common english words with no semantic weight)
 const STOP_WORDS = new Set([
-	'a',
-	'an',
-	'the',
-	'and',
-	'or',
-	'but',
-	'in',
-	'on',
-	'at',
-	'to',
-	'for',
-	'of',
-	'with',
-	'by',
-	'from',
-	'as',
-	'is',
-	'was',
-	'are',
-	'were',
-	'be',
-	'been',
-	'being',
-	'have',
-	'has',
-	'had',
-	'do',
-	'does',
-	'did',
-	'will',
-	'would',
-	'could',
-	'should',
-	'may',
-	'might',
-	'shall',
-	'can',
-	'need',
-	'not',
-	'no',
-	'nor',
-	'so',
-	'if',
-	'then',
-	'than',
-	'too',
-	'very',
-	'just',
-	'about',
-	'above',
-	'after',
-	'again',
-	'all',
-	'also',
-	'am',
-	'any',
-	'because',
-	'before',
-	'between',
-	'both',
-	'each',
-	'few',
-	'further',
-	'get',
-	'got',
-	'here',
-	'how',
-	'i',
-	'into',
-	'it',
-	'its',
-	'me',
-	'more',
-	'most',
-	'my',
-	'myself',
-	'now',
-	'only',
-	'other',
-	'our',
-	'out',
-	'over',
-	'own',
-	'same',
-	'she',
-	'he',
-	'her',
-	'him',
-	'his',
-	'some',
-	'such',
-	'that',
-	'their',
-	'them',
-	'there',
-	'these',
-	'they',
-	'this',
-	'those',
-	'through',
-	'under',
-	'until',
-	'up',
-	'us',
-	'we',
-	'what',
-	'when',
-	'where',
-	'which',
-	'while',
-	'who',
-	'whom',
-	'why',
-	'you',
-	'your',
-	'etc',
-	'ie',
-	'eg',
-	'per',
-	'via'
+	'a','an','the','and','or','but','in','on','at','to','for','of','with','by','from','as','is','was','are','were','be','been','being','have','has','had','do','does','did','will','would','could','should','may','might','shall','can','need','not','no','nor','so','if','then','than','too','very','just','about','above','after','again','all','also','am','any','because','before','between','both','each','few','further','get','got','here','how','i','into','it','its','me','more','most','my','myself','now','only','other','our','out','over','own','same','she','he','her','him','his','some','such','that','their','them','there','these','they','this','those','through','under','until','up','us','we','what','when','where','which','while','who','whom','why','you','your','etc','ie','eg','per','via',
+	'o','os','um','uma','uns','umas','e','ou','mas','em','no','na','nos','nas','ao','aos','para','por','de','do','da','dos','das','com','sem','sob','sobre','entre','ate','até','desde','como','que','se','ser','foi','sao','são','era','eram','ter','tem','teve','tinha','há','ha','mais','menos','muito','muita','muitos','muitas','pouco','pouca','ja','já','ainda','tambem','também','apenas','cada','todo','toda','todos','todas','seu','sua','seus','suas','meu','minha','meus','minhas','ele','ela','eles','elas','isso','isto','aquele','aquela','onde','quando','qual','quais','porque','pelo','pela','pelos','pelas','num','numa','via'
 ]);
 
 export interface Token {
@@ -128,62 +9,55 @@ export interface Token {
 	position: number;
 }
 
-// tokenizes text into terms: lowercase, strip punctuation, filter stop words
+function cleanToken(raw: string): string {
+	return raw
+		.normalize('NFKC')
+		.replace(/^[^\p{L}\p{N}#+.]+|[^\p{L}\p{N}#+.]+$/gu, '')
+		.trim();
+}
+
+function fold(value: string): string {
+	return value.normalize('NFKD').replace(/\p{M}/gu, '').toLocaleLowerCase('en-US');
+}
+
 export function tokenize(text: string): Token[] {
-	const words = text.split(/[\s,;|]+/);
+	const words = text.split(/[\s,;|•·▪]+/u);
 	const tokens: Token[] = [];
-
-	for (let i = 0; i < words.length; i++) {
-		const raw = words[i];
-		// strip leading/trailing punctuation but preserve internal hyphens and dots
-		const cleaned = raw.replace(/^[^a-zA-Z0-9#+]+|[^a-zA-Z0-9#+]+$/g, '');
-		if (cleaned.length === 0) continue;
-
-		const normalized = cleaned.toLowerCase();
-		if (STOP_WORDS.has(normalized)) continue;
-		if (normalized.length < 2) continue;
-
-		tokens.push({ raw: cleaned, normalized, position: i });
+	for (let position = 0; position < words.length; position++) {
+		const raw = cleanToken(words[position]);
+		if (!raw) continue;
+		const normalized = fold(raw);
+		if (normalized.length < 2 || STOP_WORDS.has(normalized)) continue;
+		tokens.push({ raw, normalized, position });
 	}
-
 	return tokens;
 }
 
-// extracts n-grams (multi-word phrases) for matching compound skills
 export function extractNgrams(text: string, n: number): string[] {
 	const words = text
-		.toLowerCase()
-		.split(/[\s,;|]+/)
-		.map((w) => w.replace(/^[^a-zA-Z0-9]+|[^a-zA-Z0-9]+$/g, ''))
-		.filter((w) => w.length > 0);
-
+		.split(/[\s,;|•·▪]+/u)
+		.map(cleanToken)
+		.filter(Boolean)
+		.map(fold);
 	if (words.length < n) return [];
-
 	const ngrams: string[] = [];
-	for (let i = 0; i <= words.length - n; i++) {
-		const gram = words.slice(i, i + n).join(' ');
-		// skip n-grams that are entirely stop words
-		const hasContent = words.slice(i, i + n).some((w) => !STOP_WORDS.has(w));
-		if (hasContent) ngrams.push(gram);
+	for (let index = 0; index <= words.length - n; index++) {
+		const slice = words.slice(index, index + n);
+		if (slice.some((word) => !STOP_WORDS.has(word))) ngrams.push(slice.join(' '));
 	}
-
 	return ngrams;
 }
 
-// extracts unique terms combining unigrams, bigrams, and trigrams
 export function extractTerms(text: string): string[] {
-	const tokens = tokenize(text);
-	const unigrams = tokens.map((t) => t.normalized);
-	const bigrams = extractNgrams(text, 2);
-	const trigrams = extractNgrams(text, 3);
-
-	const all = [...unigrams, ...bigrams, ...trigrams];
-	return [...new Set(all)];
+	return [...new Set([
+		...tokenize(text).map((token) => token.normalized),
+		...extractNgrams(text, 2),
+		...extractNgrams(text, 3)
+	])];
 }
 
-// normalizes text for comparison: lowercase, trim, collapse whitespace
 export function normalizeText(text: string): string {
-	return text.toLowerCase().trim().replace(/\s+/g, ' ');
+	return fold(text).trim().replace(/\s+/g, ' ');
 }
 
 export { STOP_WORDS };

--- a/src/lib/engine/parser/contact-extractor.ts
+++ b/src/lib/engine/parser/contact-extractor.ts
@@ -1,103 +1,90 @@
 import type { ContactInfo } from './types';
+import { normalizeContactText, normalizeTextFragment } from './text-normalizer';
 
-const EMAIL_REGEX = /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/;
-const PHONE_REGEX = /(?:\+?1[-.\s]?)?(?:\(?\d{3}\)?[-.\s]?)?\d{3}[-.\s]?\d{4}/;
-// matches linkedin.com/in/user, linkedin.com/user, and PDF-mangled variants with spaces
+const EMAIL_REGEX = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,24}\b/i;
+const PHONE_REGEX = /(?:\+\s?\d{1,3}[\s.-]*)?(?:\(?\d{2,3}\)?[\s.-]*)?\d{4,5}[\s.-]*\d{4}\b/;
 const LINKEDIN_REGEX = /(?:https?:\/\/)?(?:www\.)?linkedin\.com\/(?:in\/)?[\w-]+\/?/i;
 const GITHUB_REGEX = /(?:https?:\/\/)?(?:www\.)?github\.com\/[\w-]+\/?/i;
-const WEBSITE_REGEX =
-	/https?:\/\/(?!.*(?:linkedin|github)\.com)[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}(?:\/\S*)?/i;
+const WEBSITE_REGEX = /(?:https?:\/\/|www\.)[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}(?:\/[^\s|]*)?/i;
 
-// extracts contact info from the top ~15 lines of the resume
 export function extractContact(lines: string[]): ContactInfo {
-	const searchLines = lines.slice(0, Math.min(lines.length, 15));
-	// clean PDF artifacts: collapse multiple spaces, fix common ligature issues
-	const searchText = searchLines.map((l) => l.replace(/\s{2,}/g, ' ')).join('\n');
+	const searchLines = lines.slice(0, Math.min(lines.length, 20));
+	const searchText = normalizeContactText(searchLines);
 
 	const email = extractFirst(searchText, EMAIL_REGEX);
-	const phone = extractFirst(searchText, PHONE_REGEX);
+	const phone = normalizePhone(extractFirst(searchText, PHONE_REGEX));
 	const linkedin = extractLinkedIn(searchText);
 	const github = extractFirst(searchText, GITHUB_REGEX);
-	const website = extractFirst(searchText, WEBSITE_REGEX);
+	const websiteCandidate = extractFirst(searchText, WEBSITE_REGEX);
+	const website =
+		websiteCandidate && !/(?:linkedin|github)\.com/i.test(websiteCandidate)
+			? websiteCandidate
+			: null;
 	const name = extractName(searchLines);
 	const location = extractLocation(searchLines);
 
 	return { name, email, phone, linkedin, github, website, location };
 }
 
-// linkedin needs special handling because PDF extraction often mangles URLs
 function extractLinkedIn(text: string): string | null {
-	// try standard regex first
 	const standard = extractFirst(text, LINKEDIN_REGEX);
 	if (standard) return standard;
-
-	// fallback: look for "linkedin" keyword near a path-like string
-	// handles cases like "LinkedIn: /in/sunnypatell" or "linkedin .com/in/sunny"
 	const fallback = /linkedin\s*\.?\s*com\s*\/\s*(?:in\s*\/\s*)?([\w-]+)/i;
 	const match = text.match(fallback);
-	if (match) return `linkedin.com/in/${match[1]}`;
-
-	return null;
+	return match ? `linkedin.com/in/${match[1]}` : null;
 }
 
 function extractFirst(text: string, regex: RegExp): string | null {
 	const match = text.match(regex);
-	return match ? match[0].trim() : null;
+	return match ? match[0].trim().replace(/[),.;]+$/, '') : null;
 }
 
-// extracts candidate name from first few lines (short, non-url, 2-5 word line)
+function normalizePhone(phone: string | null): string | null {
+	if (!phone) return null;
+	const digits = phone.replace(/\D/g, '');
+	if (digits.length < 10 || digits.length > 15) return null;
+	return phone.replace(/\s+/g, ' ').trim();
+}
+
 function extractName(lines: string[]): string | null {
-	for (const line of lines.slice(0, 5)) {
-		const trimmed = line.trim();
-		if (trimmed.length === 0) continue;
-		if (trimmed.length > 50) continue;
-
-		// skip if it contains obvious non-name content
-		if (EMAIL_REGEX.test(trimmed)) continue;
-		if (PHONE_REGEX.test(trimmed)) continue;
-		if (/https?:\/\//.test(trimmed)) continue;
-		if (/linkedin|github/i.test(trimmed)) continue;
-
-		// name should have 2-5 words, all alphabetic (with possible hyphens/periods)
+	for (const original of lines.slice(0, 6)) {
+		const trimmed = normalizeTextFragment(original)
+			.replace(/^[^\p{L}]+/u, '')
+			.trim();
+		if (!trimmed || trimmed.length > 70) continue;
+		if (EMAIL_REGEX.test(trimmed) || PHONE_REGEX.test(trimmed)) continue;
+		if (/https?:\/\/|linkedin|github|whatsapp|software developer|desenvolvedor/i.test(trimmed)) {
+			continue;
+		}
 		const words = trimmed.split(/\s+/);
-		if (words.length >= 2 && words.length <= 5) {
-			const allAlpha = words.every((w) => /^[a-zA-Z][a-zA-Z.\-']*$/.test(w));
-			if (allAlpha) return trimmed;
+		if (words.length < 2 || words.length > 6) continue;
+		if (words.every((word) => /^[\p{L}][\p{L}.'-]*$/u.test(word))) {
+			return trimmed;
 		}
 	}
-
 	return null;
 }
 
-// extracts location from contact section (e.g. "City, State" or "City, ST ZIP")
 function extractLocation(lines: string[]): string | null {
-	const locationPatterns = [
-		// City, ST
-		/[A-Z][a-zA-Z\s]+,\s*[A-Z]{2}\b/,
-		// City, State
-		/[A-Z][a-zA-Z\s]+,\s*[A-Z][a-z]+(?:\s[A-Z][a-z]+)?/,
-		// City, ST ZIP
-		/[A-Z][a-zA-Z\s]+,\s*[A-Z]{2}\s+\d{5}/,
-		// City, Country
-		/[A-Z][a-zA-Z\s]+,\s*[A-Z][a-zA-Z\s]+/
+	const patterns = [
+		/\b(?:São Paulo|Rio de Janeiro|Belo Horizonte|Curitiba|Brasília|Porto Alegre|Salvador|Recife)(?:,\s*[A-Z]{2})?/iu,
+		/\b\p{Lu}[\p{L}.'-]*(?:\s+\p{Lu}?[\p{L}.'-]*){0,3},\s*[A-Z]{2}\b/u,
+		/\b\p{Lu}[\p{L}.'-]*(?:\s+\p{Lu}?[\p{L}.'-]*){0,3},\s*\p{Lu}[\p{L}.'-]*(?:\s+\p{Lu}?[\p{L}.'-]*){0,2}\b/u
 	];
-
-	for (const line of lines.slice(0, 10)) {
-		const trimmed = line.trim();
-		// skip lines that are clearly not location
-		if (EMAIL_REGEX.test(trimmed)) continue;
-		if (PHONE_REGEX.test(trimmed)) continue;
-		if (/https?:\/\//.test(trimmed)) continue;
-
-		for (const pattern of locationPatterns) {
-			const match = trimmed.match(pattern);
-			if (match) {
-				const loc = match[0].trim();
-				// filter out false positives
-				if (loc.length > 5 && loc.length < 60) return loc;
+	for (const line of lines.slice(0, 12)) {
+		const sanitized = normalizeTextFragment(line)
+			.replace(EMAIL_REGEX, ' ')
+			.replace(PHONE_REGEX, ' ')
+			.replace(LINKEDIN_REGEX, ' ')
+			.replace(GITHUB_REGEX, ' ')
+			.replace(/\b(?:email|e-mail|whatsapp|phone|telefone|linkedin|github)\s*:?/gi, ' ')
+			.replace(/\s+/g, ' ');
+		for (const pattern of patterns) {
+			const match = sanitized.match(pattern);
+			if (match && match[0].length >= 5 && match[0].length < 70) {
+				return match[0].trim();
 			}
 		}
 	}
-
 	return null;
 }

--- a/src/lib/engine/parser/content-extractors.ts
+++ b/src/lib/engine/parser/content-extractors.ts
@@ -1,0 +1,156 @@
+import { extractFirstDateRange } from './date-extractor';
+import { normalizeLines } from './text-normalizer';
+import type { CertificationEntry, ProjectEntry, ResumeSection } from './types';
+
+const BULLET = /^[\s•\-*·▪►➤○●]+/;
+
+const SKILL_ALIASES: Record<string, string> = {
+	golang: 'Go',
+	go: 'Go',
+	typescript: 'TypeScript',
+	javascript: 'JavaScript',
+	python: 'Python',
+	tsx: 'TSX',
+	react: 'React',
+	'react native': 'React Native',
+	'next.js': 'Next.js',
+	nextjs: 'Next.js',
+	'node.js': 'Node.js',
+	nodejs: 'Node.js',
+	html5: 'HTML5',
+	html: 'HTML',
+	css3: 'CSS3',
+	css: 'CSS',
+	'tailwind css': 'Tailwind CSS',
+	express: 'Express',
+	fastapi: 'FastAPI',
+	'restful apis': 'REST APIs',
+	'rest api': 'REST APIs',
+	'apis rest': 'REST APIs',
+	microservices: 'Microservices',
+	'microsservicos em go': 'Go Microservices',
+	postgresql: 'PostgreSQL',
+	mysql: 'MySQL',
+	mongodb: 'MongoDB',
+	git: 'Git',
+	github: 'GitHub',
+	docker: 'Docker',
+	postman: 'Postman',
+	selenium: 'Selenium',
+	playwright: 'Playwright',
+	beautifulsoup: 'BeautifulSoup',
+	'web scraping': 'Web Scraping'
+};
+
+export function extractSkills(sections: ResumeSection[]): string[] {
+	const found: string[] = [];
+	for (const section of sections.filter((item) => item.type === 'skills')) {
+		for (const rawLine of section.content.split('\n')) {
+			const line = rawLine.replace(BULLET, '').trim();
+			const payload = line.includes(':') ? line.slice(line.indexOf(':') + 1) : line;
+			const candidates = payload
+				.replace(/[()]/g, ',')
+				.split(/[,|;•·▪]/)
+				.map((item) => item.trim().replace(/[.]$/, ''))
+				.filter(
+					(item) =>
+						item.length >= 1 &&
+						item.length <= 40 &&
+						item.split(/\s+/).length <= 5
+				);
+			for (const candidate of candidates) {
+				const key = candidate
+					.normalize('NFKD')
+					.replace(/\p{M}/gu, '')
+					.toLowerCase();
+				const canonical = SKILL_ALIASES[key] ?? candidate;
+				if (
+					!/workflow automation|automacao de fluxos|automação de fluxos/i.test(
+						canonical
+					)
+				) {
+					found.push(canonical);
+				}
+			}
+		}
+	}
+	return deduplicate(found, (item) => item.toLowerCase());
+}
+
+export function extractProjects(sections: ResumeSection[]): ProjectEntry[] {
+	const entries: ProjectEntry[] = [];
+	for (const section of sections.filter((item) => item.type === 'projects')) {
+		for (const block of splitGenericEntries(section.content)) {
+			const lines = normalizeLines(block.split('\n'));
+			if (!lines.length) continue;
+			const name = lines[0].replace(BULLET, '').trim();
+			const bullets = lines
+				.slice(1)
+				.map((line) => line.replace(BULLET, '').trim())
+				.filter(Boolean);
+			const full = lines.join(' ');
+			const technologies = extractSkills([
+				{
+					type: 'skills',
+					header: '',
+					content: full,
+					startLine: 0,
+					endLine: 0
+				}
+			]);
+			entries.push({
+				name,
+				description: bullets.join(' '),
+				technologies,
+				bullets,
+				url: full.match(/https?:\/\/[^\s)]+/)?.[0] ?? null,
+				rawText: block
+			});
+		}
+	}
+	return entries;
+}
+
+export function extractCertifications(sections: ResumeSection[]): CertificationEntry[] {
+	const entries: CertificationEntry[] = [];
+	for (const section of sections.filter((item) => item.type === 'certifications')) {
+		for (const line of section.content
+			.split('\n')
+			.map((item) => item.replace(BULLET, '').trim())
+			.filter(Boolean)) {
+			const parts = line.split(/\s*[-–—|]\s*/);
+			entries.push({
+				name: parts[0],
+				issuer: parts[1]?.replace(/\d{4}.*/, '').trim() ?? '',
+				date: extractFirstDateRange(line)?.start ?? null,
+				rawText: line
+			});
+		}
+	}
+	return entries;
+}
+
+function splitGenericEntries(content: string): string[] {
+	const lines = content.split('\n');
+	const entries: string[] = [];
+	let current: string[] = [];
+	for (const line of lines) {
+		if (BULLET.test(line) && current.length) {
+			entries.push(current.join('\n'));
+			current = [];
+		}
+		if (line.trim()) current.push(line);
+	}
+	if (current.length) entries.push(current.join('\n'));
+	return entries;
+}
+
+function deduplicate<T>(values: T[], key: (value: T) => string): T[] {
+	const seen = new Set<string>();
+	return values.filter((value) => {
+		const current = key(value);
+		if (!current || seen.has(current)) return false;
+		seen.add(current);
+		return true;
+	});
+}

--- a/src/lib/engine/parser/date-extractor.ts
+++ b/src/lib/engine/parser/date-extractor.ts
@@ -1,154 +1,104 @@
 import type { DateRange } from './types';
 
-const MONTH_NAMES = [
-	'january',
-	'february',
-	'march',
-	'april',
-	'may',
-	'june',
-	'july',
-	'august',
-	'september',
-	'october',
-	'november',
-	'december'
+const MONTHS: Array<{ month: string; aliases: string[] }> = [
+	{ month: '01', aliases: ['january', 'jan', 'janeiro'] },
+	{ month: '02', aliases: ['february', 'feb', 'fevereiro', 'fev'] },
+	{ month: '03', aliases: ['march', 'março', 'marco', 'mar'] },
+	{ month: '04', aliases: ['april', 'apr', 'abril', 'abr'] },
+	{ month: '05', aliases: ['may', 'maio', 'mai'] },
+	{ month: '06', aliases: ['june', 'junho', 'jun'] },
+	{ month: '07', aliases: ['july', 'julho', 'jul'] },
+	{ month: '08', aliases: ['august', 'aug', 'agosto', 'ago'] },
+	{ month: '09', aliases: ['september', 'sept', 'sep', 'setembro', 'set'] },
+	{ month: '10', aliases: ['october', 'oct', 'outubro', 'out'] },
+	{ month: '11', aliases: ['november', 'nov', 'novembro'] },
+	{ month: '12', aliases: ['december', 'dec', 'dezembro', 'dez'] }
 ];
 
-const MONTH_ABBREVS = [
-	'jan',
-	'feb',
-	'mar',
-	'apr',
-	'may',
-	'jun',
-	'jul',
-	'aug',
-	'sep',
-	'oct',
-	'nov',
-	'dec'
-];
+const MONTH_TOKEN = MONTHS.flatMap((entry) => entry.aliases)
+	.sort((a, b) => b.length - a.length)
+	.join('|');
+const CURRENT_TOKEN = 'present|current|now|ongoing|today|presente|atual|hoje|em\\s+andamento';
+const SEPARATOR = '(?:-|–|—|~|\\bto\\b|\\ba\\b|\\bat[eé]\\b)';
+const CURRENT_INDICATORS = new RegExp(`\\b(?:${CURRENT_TOKEN})\\b`, 'i');
 
-const CURRENT_INDICATORS = /\b(present|current|now|ongoing|today)\b/i;
-
-// "Jan 2023 - Present", "January 2023 - December 2024", "01/2023 - 12/2024"
 const DATE_RANGE_PATTERNS = [
-	// Month Year - Month Year (or Present)
-	/(?:(?:jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:t(?:ember)?)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)\s*\.?\s*\d{4})\s*[-–—~to]+\s*(?:(?:jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:t(?:ember)?)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)\s*\.?\s*\d{4}|present|current|now|ongoing|today)/gi,
-
-	// MM/YYYY - MM/YYYY (or Present)
-	/\d{1,2}\/\d{4}\s*[-–—~to]+\s*(?:\d{1,2}\/\d{4}|present|current|now|ongoing|today)/gi,
-
-	// Year - Year (or Present)
-	/\b(20\d{2}|19\d{2})\s*[-–—~to]+\s*(?:(20\d{2}|19\d{2})|present|current|now|ongoing|today)\b/gi,
-
-	// Season Year - Season Year
-	/(?:spring|summer|fall|autumn|winter)\s*\d{4}\s*[-–—~to]+\s*(?:(?:spring|summer|fall|autumn|winter)\s*\d{4}|present|current|now)/gi,
-
-	// standalone "Month Year" (single date)
-	/(?:jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:t(?:ember)?)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)\s*\.?\s*\d{4}/gi
+	new RegExp(
+		`(?:${MONTH_TOKEN})\\.?\\s*\\/?\\s*\\d{4}\\s*${SEPARATOR}\\s*(?:(?:${MONTH_TOKEN})\\.?\\s*\\/?\\s*\\d{4}|${CURRENT_TOKEN})`,
+		'giu'
+	),
+	new RegExp(`\\d{1,2}\\/\\d{4}\\s*${SEPARATOR}\\s*(?:\\d{1,2}\\/\\d{4}|${CURRENT_TOKEN})`, 'giu'),
+	new RegExp(`\\b(?:19|20)\\d{2}\\s*${SEPARATOR}\\s*(?:(?:19|20)\\d{2}|${CURRENT_TOKEN})\\b`, 'giu'),
+	/(?:spring|summer|fall|autumn|winter)\s*\d{4}\s*(?:-|–|—|~|to)\s*(?:(?:spring|summer|fall|autumn|winter)\s*\d{4}|present|current|now)/giu,
+	new RegExp(`(?:${MONTH_TOKEN})\\.?\\s*\\/?\\s*\\d{4}`, 'giu'),
+	/\b(?:19|20)\d{2}\b/gu
 ];
 
-// extracts all date ranges from text, prioritizing ranges over standalone dates
 export function extractDateRanges(text: string): DateRange[] {
 	const ranges: DateRange[] = [];
-	// track which character positions have already been matched
 	const matchedSpans: Array<[number, number]> = [];
-
 	for (const pattern of DATE_RANGE_PATTERNS) {
-		const matches = text.matchAll(new RegExp(pattern));
-
-		for (const match of matches) {
+		for (const match of text.matchAll(new RegExp(pattern.source, pattern.flags))) {
 			const raw = match[0].trim();
-			const start = match.index!;
+			const start = match.index ?? 0;
 			const end = start + match[0].length;
-
-			// skip if this overlaps with an already-matched span
-			const overlaps = matchedSpans.some(([s, e]) => start < e && end > s);
-			if (overlaps) continue;
-
+			if (matchedSpans.some(([s, e]) => start < e && end > s)) continue;
 			const range = parseDateRange(raw);
-			if (range) {
-				ranges.push(range);
-				matchedSpans.push([start, end]);
-			}
+			if (!range) continue;
+			ranges.push(range);
+			matchedSpans.push([start, end]);
 		}
 	}
-
 	return ranges;
 }
 
-// parses a date range string into a structured DateRange
 function parseDateRange(raw: string): DateRange | null {
 	const isCurrent = CURRENT_INDICATORS.test(raw);
-
-	// split on common separators
-	const parts = raw.split(/\s*[-–—~]\s*|\s+to\s+/i);
-
+	const parts = raw.split(/\s*(?:-|–|—|~)\s*|\s+to\s+|\s+at[eé]\s+|\s+a\s+/iu);
 	if (parts.length >= 2) {
 		return {
-			start: normalizeDate(parts[0].trim()),
-			end: isCurrent ? null : normalizeDate(parts[1].trim()),
+			start: normalizeDate(parts[0]),
+			end: isCurrent ? null : normalizeDate(parts[1]),
 			isCurrent
 		};
 	}
-
-	// single date
-	return {
-		start: normalizeDate(raw),
-		end: null,
-		isCurrent: false
-	};
+	const start = normalizeDate(raw);
+	return start ? { start, end: null, isCurrent: false } : null;
 }
 
-// normalizes a date string to "YYYY-MM" or "YYYY" format
-function normalizeDate(dateStr: string): string | null {
-	const cleaned = dateStr.trim().toLowerCase();
-
+function normalizeDate(value: string): string | null {
+	const cleaned = value
+		.normalize('NFKD')
+		.replace(/\p{M}/gu, '')
+		.toLowerCase()
+		.trim();
 	if (CURRENT_INDICATORS.test(cleaned)) return null;
-
-	// try MM/YYYY
-	const slashMatch = cleaned.match(/(\d{1,2})\/(\d{4})/);
-	if (slashMatch) {
-		return `${slashMatch[2]}-${slashMatch[1].padStart(2, '0')}`;
+	const slash = cleaned.match(/\b(\d{1,2})\/(\d{4})\b/);
+	if (slash) {
+		const month = Number(slash[1]);
+		if (month >= 1 && month <= 12) return `${slash[2]}-${String(month).padStart(2, '0')}`;
 	}
-
-	// try Month Year
-	for (let i = 0; i < MONTH_NAMES.length; i++) {
-		const name = MONTH_NAMES[i];
-		const abbrev = MONTH_ABBREVS[i];
-		const monthNum = String(i + 1).padStart(2, '0');
-
-		if (cleaned.includes(name) || cleaned.startsWith(abbrev)) {
-			const yearMatch = cleaned.match(/\d{4}/);
-			if (yearMatch) return `${yearMatch[0]}-${monthNum}`;
+	for (const entry of MONTHS) {
+		if (entry.aliases.some((alias) => new RegExp(`\\b${alias.normalize('NFKD').replace(/\p{M}/gu, '')}\\b`, 'i').test(cleaned))) {
+			const year = cleaned.match(/\b(?:19|20)\d{2}\b/);
+			if (year) return `${year[0]}-${entry.month}`;
 		}
 	}
-
-	// try standalone year
-	const yearMatch = cleaned.match(/^(19|20)\d{2}$/);
-	if (yearMatch) return yearMatch[0];
-
-	// try season year
-	const seasonMatch = cleaned.match(/(spring|summer|fall|autumn|winter)\s*(\d{4})/i);
-	if (seasonMatch) {
-		const seasonMonths: Record<string, string> = {
-			spring: '03',
-			summer: '06',
-			fall: '09',
-			autumn: '09',
-			winter: '12'
-		};
-		const month = seasonMonths[seasonMatch[1].toLowerCase()];
-		return `${seasonMatch[2]}-${month}`;
+	const season = cleaned.match(/\b(spring|summer|fall|autumn|winter)\s*((?:19|20)\d{2})\b/i);
+	if (season) {
+		const seasonMonths: Record<string, string> = { spring: '03', summer: '06', fall: '09', autumn: '09', winter: '12' };
+		return `${season[2]}-${seasonMonths[season[1].toLowerCase()]}`;
 	}
-
-	return null;
+	const year = cleaned.match(/^((?:19|20)\d{2})$/);
+	return year ? year[1] : null;
 }
 
-// extracts the first date range found in a line of text
 export function extractFirstDateRange(text: string): DateRange | null {
-	const ranges = extractDateRanges(text);
-	return ranges.length > 0 ? ranges[0] : null;
+	return extractDateRanges(text)[0] ?? null;
+}
+
+export function stripDateRanges(text: string): string {
+	let result = text;
+	for (const pattern of DATE_RANGE_PATTERNS.slice(0, 4)) result = result.replace(new RegExp(pattern.source, pattern.flags), ' ');
+	return result.replace(/\s+/g, ' ').trim();
 }

--- a/src/lib/engine/parser/education-extractor.ts
+++ b/src/lib/engine/parser/education-extractor.ts
@@ -1,0 +1,104 @@
+import { extractFirstDateRange, stripDateRanges } from './date-extractor';
+import { normalizeLines } from './text-normalizer';
+import type { EducationEntry, ResumeSection } from './types';
+
+const BULLET = /^[\s•\-*·▪►➤○●]+/;
+const DEGREE_PATTERN = /\b(?:ph\.?d\.?|doctorate|doctor|doutorado|master'?s?|mestrado|mba|bachelor'?s?|bacharelado|licenciatura|associate'?s?|tecnologia|tecnologo|tecnólogo|technical degree|ensino tecnico|ensino técnico|curso tecnico|curso técnico|diploma|certificate|certificado|especializacao|especialização|pos-graduacao|pós-graduação)\b/i;
+
+export function extractEducationEntries(sections: ResumeSection[]): EducationEntry[] {
+	const entries: EducationEntry[] = [];
+	for (const section of sections.filter((item) => item.type === 'education')) {
+		for (const block of splitEntries(section.content)) {
+			const lines = normalizeLines(block.split('\n'));
+			const full = lines.join(' ');
+			const degree = full.match(DEGREE_PATTERN)?.[0] ?? '';
+			const fieldMatch = full.match(
+				/(?:\bin\b|\bem\b|\bof\b)\s+([^|—–,]+?)(?=\s+(?:faculdade|universidade|university|college|senai|instituto|institute)\b|\||—|–|\b(?:expected|previsao|previsão|completed|concluido|concluído)\b|$)/i
+			);
+			const institutionMatch = full.match(
+				/\b(?:Faculdade|Universidade|University|College|Instituto|Institute|SENAI|SENAC|IFSP|USP|UNESP|UNICAMP)[^|—–]*?(?=\s*(?:\||—|–|Expected|Previs|Completed|Conclu|\(|$))/i
+			);
+			const institution = institutionMatch?.[0].trim() ?? inferInstitution(lines, degree);
+			const field = fieldMatch?.[1].trim() ?? inferField(full, degree);
+			entries.push({
+				degree,
+				field,
+				institution,
+				dates: extractFirstDateRange(full) ?? { start: null, end: null, isCurrent: false },
+				gpa: extractGPA(full),
+				honors: lines.filter((line) =>
+					/cum laude|dean'?s list|honors?|distinction|honras?|destaque academico/i.test(line)
+				),
+				rawText: block
+			});
+		}
+	}
+	return deduplicate(
+		entries.filter((entry) => entry.degree || entry.institution),
+		(entry) => `${entry.degree}|${entry.institution}|${entry.dates.start}`.toLowerCase()
+	);
+}
+
+function splitEntries(content: string): string[] {
+	const lines = normalizeLines(content.split('\n'));
+	const entries: string[] = [];
+	let current: string[] = [];
+	for (const line of lines) {
+		const startsEntry = BULLET.test(line) && DEGREE_PATTERN.test(line.replace(BULLET, ''));
+		if (startsEntry && current.length) {
+			entries.push(current.join('\n'));
+			current = [];
+		}
+		current.push(line);
+	}
+	if (current.length) entries.push(current.join('\n'));
+	return entries.filter(
+		(entry) =>
+			DEGREE_PATTERN.test(entry) ||
+			/universidade|university|faculdade|college|senai/i.test(entry)
+	);
+}
+
+function inferInstitution(lines: string[], degree: string): string {
+	for (const line of lines) {
+		const clean = line.replace(BULLET, '').trim();
+		if (
+			clean === degree ||
+			DEGREE_PATTERN.test(clean) ||
+			/^principais|^key coursework/i.test(clean)
+		) {
+			continue;
+		}
+		if (
+			/\b(?:faculdade|universidade|university|college|senai|senac|instituto|institute)\b/i.test(clean)
+		) {
+			return stripDateRanges(clean).split(/\||—|–/)[0].trim();
+		}
+	}
+	return '';
+}
+
+function inferField(text: string, degree: string): string {
+	const clean = text.replace(degree, ' ');
+	const known = clean.match(
+		/\b(?:Systems Analysis and Development|Analise e Desenvolvimento de Sistemas|Análise e Desenvolvimento de Sistemas|Computer Science|Software Engineering|Engenharia de Software|Railway Transportation|Transporte Ferroviario|Transporte Ferroviário)\b/i
+	);
+	return known?.[0] ?? '';
+}
+
+function extractGPA(text: string): string | null {
+	const match = text.match(
+		/(?:gpa|media|média)\s*:?[ ]*(\d+[.,]?\d*)\s*(?:\/\s*(\d+[.,]?\d*))?/i
+	);
+	return match ? (match[2] ? `${match[1]}/${match[2]}` : match[1]) : null;
+}
+
+function deduplicate<T>(values: T[], key: (value: T) => string): T[] {
+	const seen = new Set<string>();
+	return values.filter((value) => {
+		const current = key(value);
+		if (!current || seen.has(current)) return false;
+		seen.add(current);
+		return true;
+	});
+}

--- a/src/lib/engine/parser/experience-extractor.ts
+++ b/src/lib/engine/parser/experience-extractor.ts
@@ -1,0 +1,180 @@
+import { extractDateRanges, extractFirstDateRange, stripDateRanges } from './date-extractor';
+import { normalizeLines } from './text-normalizer';
+import type { ExperienceEntry, ResumeSection } from './types';
+
+const BULLET = /^[\s•\-*·▪►➤○●]+/;
+const ROLE_WORDS = /\b(?:developer|engineer|analyst|assistant|manager|director|coordinator|specialist|consultant|intern|apprentice|representative|designer|architect|administrator|desenvolvedor|engenheiro|analista|auxiliar|assistente|gerente|diretor|coordenador|especialista|consultor|estagiario|estagiário|aprendiz|promotor|operador|tecnico|técnico|servicos gerais|serviços gerais)\b/i;
+
+export function extractExperienceEntries(sections: ResumeSection[]): ExperienceEntry[] {
+	const entries: ExperienceEntry[] = [];
+	for (const section of sections.filter((item) => item.type === 'experience')) {
+		for (const block of splitExperienceEntries(section.content)) {
+			const parsed = parseExperienceBlock(block);
+			if (parsed && (parsed.title || parsed.company)) entries.push(parsed);
+		}
+	}
+	return deduplicate(
+		entries,
+		(entry) => `${entry.company}|${entry.title}|${entry.dates.start}`.toLowerCase()
+	);
+}
+
+function splitExperienceEntries(content: string): string[] {
+	const lines = normalizeLines(content.split('\n'));
+	const entries: string[] = [];
+	let current: string[] = [];
+	const flush = () => {
+		if (current.some((line) => line.trim())) entries.push(current.join('\n'));
+		current = [];
+	};
+
+	for (let index = 0; index < lines.length; index++) {
+		const line = lines[index];
+		const clean = line.replace(BULLET, '').trim();
+		if (/^(additional experience|outras? experiencias? profissionais?)$/i.test(clean)) {
+			flush();
+			continue;
+		}
+
+		const combinedWithNext = `${clean} ${lines[index + 1] ?? ''}`;
+		const hasDate = extractDateRanges(clean).length > 0;
+		const isBullet = BULLET.test(line);
+		const bulletEntry =
+			isBullet &&
+			/[—–|]/.test(clean) &&
+			(hasDate || extractDateRanges(combinedWithNext).length > 0);
+		if (bulletEntry) {
+			flush();
+			current = [line];
+			continue;
+		}
+
+		const nextHasDate = Boolean(
+			lines[index + 1] && extractDateRanges(lines[index + 1]).length
+		);
+		const header = !isBullet && looksLikeJobHeader(clean) && nextHasDate;
+		if (header && current.length) flush();
+		if (
+			!isBullet &&
+			looksLikeJobHeader(clean) &&
+			current.some((value) => extractDateRanges(value).length > 0)
+		) {
+			flush();
+		}
+		current.push(line);
+	}
+	flush();
+	return entries;
+}
+
+function looksLikeJobHeader(line: string): boolean {
+	if (!line || line.length > 160 || extractDateRanges(line).length > 0) return false;
+	if (/\s(?:—|–|\|)\s/.test(line)) return true;
+	const relation = line.match(/^(.+?)\s+(?:at|na|no)\s+(.+)$/i);
+	if (relation && ROLE_WORDS.test(relation[1])) return true;
+	return ROLE_WORDS.test(line) && line.split(/\s+/).length <= 14;
+}
+
+function parseExperienceBlock(block: string): ExperienceEntry | null {
+	const lines = normalizeLines(block.split('\n'))
+		.map((line) => line.trim())
+		.filter(Boolean);
+	if (!lines.length) return null;
+	const full = lines.join(' ');
+	const dates = extractFirstDateRange(full) ?? {
+		start: null,
+		end: null,
+		isCurrent: false
+	};
+	const compactAdditional = BULLET.test(lines[0]) && dates.start !== null;
+	const dateIndex = lines.findIndex((line) => extractDateRanges(line).length > 0);
+	const rawHeader = compactAdditional ? full : lines[0].replace(BULLET, '').trim();
+	const headerWithoutDate = stripDateRanges(rawHeader)
+		.replace(BULLET, '')
+		.replace(/[()]/g, ' ')
+		.replace(/\s+/g, ' ')
+		.trim();
+	const headerParts = headerWithoutDate
+		.split(/\s+[—–]\s+/)
+		.map((part) => part.trim())
+		.filter(Boolean);
+	const headerForIdentity = headerParts.slice(0, 2).join(' — ') || headerWithoutDate;
+	const { title, company } = parseJobHeader(
+		headerForIdentity,
+		!compactAdditional && dateIndex > 1 ? lines[1] : ''
+	);
+
+	const bullets: string[] = [];
+	if (headerParts.length >= 3) bullets.push(headerParts.slice(2).join(' — '));
+	if (!compactAdditional) {
+		let activeBullet = bullets.length ? bullets.length - 1 : -1;
+		for (let index = 1; index < lines.length; index++) {
+			if (index === dateIndex) continue;
+			const original = lines[index];
+			const clean = stripDateRanges(original.replace(BULLET, ''))
+				.replace(/^[-–—|()\s]+|[-–—|()\s]+$/g, '')
+				.trim();
+			if (!clean || looksLikeJobHeader(clean)) continue;
+			if (BULLET.test(original)) {
+				bullets.push(clean);
+				activeBullet = bullets.length - 1;
+			} else if (activeBullet >= 0) {
+				bullets[activeBullet] = `${bullets[activeBullet]} ${clean}`.replace(/\s+/g, ' ');
+			} else {
+				bullets.push(clean);
+				activeBullet = 0;
+			}
+		}
+	}
+	return {
+		title,
+		company,
+		dates,
+		bullets: deduplicate(
+			bullets.map((bullet) => bullet.trim()).filter(Boolean),
+			(item) => item.toLowerCase()
+		),
+		rawText: block
+	};
+}
+
+function parseJobHeader(
+	line1: string,
+	line2: string
+): { title: string; company: string } {
+	const first = stripDateRanges(line1).replace(BULLET, '').trim();
+	const second = stripDateRanges(line2).replace(BULLET, '').trim();
+	const relation = first.match(/^(.+?)\s+(?:at|na|no)\s+(.+)$/i);
+	if (relation && ROLE_WORDS.test(relation[1])) {
+		return { title: relation[1].trim(), company: relation[2].trim() };
+	}
+	const parts = first
+		.split(/\s*(?:\||—|–)\s*/)
+		.map((part) => part.trim())
+		.filter(Boolean);
+	if (parts.length >= 2) {
+		const leftIsRole = ROLE_WORDS.test(parts[0]);
+		const rightIsRole = ROLE_WORDS.test(parts[1]);
+		if (rightIsRole && !leftIsRole) return { company: parts[0], title: parts[1] };
+		return { title: parts[0], company: parts[1] };
+	}
+	if (first && second) {
+		if (ROLE_WORDS.test(second) && !ROLE_WORDS.test(first)) {
+			return { company: first, title: second };
+		}
+		return { title: first, company: second };
+	}
+	return ROLE_WORDS.test(first)
+		? { title: first, company: '' }
+		: { title: '', company: first };
+}
+
+function deduplicate<T>(values: T[], key: (value: T) => string): T[] {
+	const seen = new Set<string>();
+	return values.filter((value) => {
+		const current = key(value);
+		if (!current || seen.has(current)) return false;
+		seen.add(current);
+		return true;
+	});
+}

--- a/src/lib/engine/parser/index.ts
+++ b/src/lib/engine/parser/index.ts
@@ -1,21 +1,26 @@
-import { detectSections } from './section-detector';
 import { extractContact } from './contact-extractor';
-import { extractDateRanges, extractFirstDateRange } from './date-extractor';
-import type {
-	ParseResult,
-	ParsedResume,
-	ExperienceEntry,
-	EducationEntry,
-	ProjectEntry,
-	CertificationEntry,
-	ResumeSection
-} from './types';
+import {
+	extractCertifications,
+	extractProjects,
+	extractSkills
+} from './content-extractors';
+import { extractEducationEntries } from './education-extractor';
+import { extractExperienceEntries } from './experience-extractor';
+import { detectSections } from './section-detector';
+import { detectLanguage, normalizeLines, textQualityScore } from './text-normalizer';
+import type { ParsedResume, ParseResult } from './types';
 
-// main entry point: parses PDF/DOCX into structured ParsedResume
+interface BaseMetadata {
+	fileType: 'pdf' | 'docx' | 'text';
+	pageCount: number;
+	hasMultipleColumns: boolean;
+	hasTables: boolean;
+	hasImages: boolean;
+	extractionMethod: 'text-layer' | 'ocr' | 'docx' | 'pasted-text';
+	baseQuality: number;
+}
+
 export async function parseResume(file: File): Promise<ParseResult> {
-	const errors: string[] = [];
-	const warnings: string[] = [];
-
 	const fileType = getFileType(file);
 	if (!fileType) {
 		return {
@@ -27,89 +32,82 @@ export async function parseResume(file: File): Promise<ParseResult> {
 	}
 
 	try {
-		let text: string;
-		let lines: string[];
+		let text = '';
+		let lines: string[] = [];
 		let pageCount = 1;
 		let hasMultipleColumns = false;
 		let hasTables = false;
 		let hasImages = false;
+		let extractionMethod: BaseMetadata['extractionMethod'] =
+			fileType === 'pdf' ? 'text-layer' : 'docx';
+		let baseQuality = 100;
+		const warnings: string[] = [];
 
-		// dynamic-import the per-format parser so pdfjs (~700kb) and mammoth
-		// (~250kb) end up in separate chunks. a user uploading a PDF never
-		// loads mammoth, and a DOCX-only user never loads pdfjs.
 		if (fileType === 'pdf') {
 			const { parsePDF } = await import('./pdf-parser');
 			const result = await parsePDF(file);
-			text = result.text;
-			lines = result.lines;
-			pageCount = result.pageCount;
-			hasMultipleColumns = result.hasMultipleColumns;
-			hasTables = result.hasTables;
-			hasImages = result.hasImages;
+			({ text, lines, pageCount, hasMultipleColumns, hasTables, hasImages } = result);
+			baseQuality = result.quality;
+
+			if (result.needsOCR) {
+				const ocr = await requestOCR(file);
+				if (ocr) {
+					text = ocr.text;
+					lines = ocr.lines;
+					pageCount = ocr.pageCount;
+					extractionMethod = 'ocr';
+					baseQuality = textQualityScore(text, lines);
+					hasMultipleColumns = false;
+					hasTables = false;
+					warnings.push(
+						'text layer was low quality; self-hosted OCR (por+eng) was used'
+					);
+				} else {
+					warnings.push('text layer quality is low and OCR was unavailable');
+				}
+			}
 		} else {
 			const { parseDOCX } = await import('./docx-parser');
 			const result = await parseDOCX(file);
-			text = result.text;
-			lines = result.lines;
-			hasTables = result.hasTables;
-			hasImages = result.hasImages;
+			({ text, lines, hasTables, hasImages } = result);
+			baseQuality = textQualityScore(text, lines);
 		}
 
-		if (text.trim().length === 0) {
+		lines = normalizeLines(lines.length ? lines : text.split(/\r?\n/));
+		text = lines.join('\n');
+		if (!text.trim()) {
 			return {
 				success: false,
 				resume: null,
-				errors: [
-					'could not extract any text from the file. it may be an image-based PDF or corrupted.'
-				],
-				warnings: []
+				errors: ['could not extract readable text from the file'],
+				warnings
 			};
 		}
 
-		if (hasMultipleColumns) {
-			warnings.push('detected multi-column layout. text extraction order may be affected.');
-		}
+		const resume = buildResume(text, lines, {
+			fileType,
+			pageCount,
+			hasMultipleColumns,
+			hasTables,
+			hasImages,
+			extractionMethod,
+			baseQuality
+		});
 
+		if (hasMultipleColumns) {
+			warnings.push('detected a probable multi-column layout');
+		}
 		if (hasTables) {
+			warnings.push('detected repeated aligned columns that resemble a table');
+		}
+		if (resume.metadata.extractionQuality < 65) {
 			warnings.push(
-				'detected tables in the document. most ATS systems struggle with tabular layouts.'
+				'some extracted fields have low confidence; review the structured result'
 			);
 		}
-
-		const contact = extractContact(lines);
-		const sections = detectSections(lines);
-		const experience = extractExperience(sections);
-		const education = extractEducation(sections);
-		const projects = extractProjects(sections);
-		const certifications = extractCertifications(sections);
-		const skills = extractSkills(sections);
-		const summary = extractSummary(sections);
-
-		const resume: ParsedResume = {
-			rawText: text,
-			lines,
-			contact,
-			sections,
-			experience,
-			education,
-			projects,
-			certifications,
-			skills,
-			summary,
-			metadata: {
-				fileType,
-				pageCount,
-				wordCount: text.split(/\s+/).filter(Boolean).length,
-				lineCount: lines.length,
-				hasMultipleColumns,
-				hasTables,
-				hasImages
-			}
-		};
-
-		return { success: true, resume, errors, warnings };
-	} catch (err) {
-		const message = err instanceof Error ? err.message : 'unknown parsing error';
+		return { success: true, resume, errors: [], warnings };
+	} catch (cause) {
+		const message = cause instanceof Error ? cause.message : 'unknown parsing error';
 		return {
 			success: false,
 			resume: null,
@@ -119,28 +117,47 @@ export async function parseResume(file: File): Promise<ParseResult> {
 	}
 }
 
+async function requestOCR(
+	file: File
+): Promise<{ text: string; lines: string[]; pageCount: number } | null> {
+	try {
+		const form = new FormData();
+		form.set('file', file);
+		const response = await fetch('/api/ocr', { method: 'POST', body: form });
+		if (!response.ok) return null;
+		const payload = (await response.json()) as {
+			text?: string;
+			lines?: string[];
+			pageCount?: number;
+		};
+		if (!payload.text) return null;
+		return {
+			text: payload.text,
+			lines: normalizeLines(payload.lines ?? payload.text.split(/\r?\n/)),
+			pageCount: payload.pageCount ?? 1
+		};
+	} catch {
+		return null;
+	}
+}
+
 function getFileType(file: File): 'pdf' | 'docx' | null {
-	if (file.type === 'application/pdf' || file.name.endsWith('.pdf')) return 'pdf';
+	const name = file.name.toLowerCase();
+	if (file.type === 'application/pdf' || name.endsWith('.pdf')) return 'pdf';
 	if (
-		file.type === 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' ||
-		file.name.endsWith('.docx')
-	)
+		file.type ===
+			'application/vnd.openxmlformats-officedocument.wordprocessingml.document' ||
+		name.endsWith('.docx')
+	) {
 		return 'docx';
+	}
 	return null;
 }
 
-// alternate entry point for users who want to paste resume text directly,
-// bypassing the PDF/DOCX file-pickup step. runs the same downstream
-// extraction pipeline (sections, experience, education, skills, etc) so
-// the resulting ParsedResume drops into scoreResume without further
-// special-casing. metadata fields that only make sense for binary
-// documents (hasMultipleColumns, hasTables, hasImages) default to false;
-// pageCount is estimated from word count using the standard 250 wpm
-// resume rule of thumb.
 export function parseResumeText(rawText: string): ParseResult {
-	const text = rawText.replace(/\r\n/g, '\n').trimEnd();
-
-	if (text.trim().length === 0) {
+	const lines = normalizeLines(rawText.replace(/\r\n/g, '\n').split('\n'));
+	const text = lines.join('\n');
+	if (!text.trim()) {
 		return {
 			success: false,
 			resume: null,
@@ -148,20 +165,48 @@ export function parseResumeText(rawText: string): ParseResult {
 			warnings: []
 		};
 	}
-
-	const lines = text.split('\n');
 	const wordCount = text.split(/\s+/).filter(Boolean).length;
+	const resume = buildResume(text, lines, {
+		fileType: 'text',
+		pageCount: Math.max(1, Math.ceil(wordCount / 500)),
+		hasMultipleColumns: false,
+		hasTables: false,
+		hasImages: false,
+		extractionMethod: 'pasted-text',
+		baseQuality: textQualityScore(text, lines)
+	});
+	return { success: true, resume, errors: [], warnings: [] };
+}
 
+function buildResume(
+	text: string,
+	lines: string[],
+	metadata: BaseMetadata
+): ParsedResume {
 	const contact = extractContact(lines);
 	const sections = detectSections(lines);
-	const experience = extractExperience(sections);
-	const education = extractEducation(sections);
+	const experience = extractExperienceEntries(sections);
+	const education = extractEducationEntries(sections);
 	const projects = extractProjects(sections);
 	const certifications = extractCertifications(sections);
 	const skills = extractSkills(sections);
-	const summary = extractSummary(sections);
+	const summary =
+		sections.find((section) => section.type === 'summary')?.content.trim() || null;
+	const knownSections = sections.filter((section) => section.type !== 'unknown').length;
+	const contactFields = Object.values(contact).filter(Boolean).length;
+	const structureScore = Math.min(
+		100,
+		knownSections * 11 +
+			Math.min(25, experience.length * 5) +
+			Math.min(15, education.length * 7) +
+			Math.min(15, skills.length) +
+			Math.min(10, contactFields * 2)
+	);
+	const extractionQuality = Math.round(
+		metadata.baseQuality * 0.55 + structureScore * 0.45
+	);
 
-	const resume: ParsedResume = {
+	return {
 		rawText: text,
 		lines,
 		contact,
@@ -173,348 +218,20 @@ export function parseResumeText(rawText: string): ParseResult {
 		skills,
 		summary,
 		metadata: {
-			fileType: 'pdf',
-			// rough resume page estimate. 500 wpm is a high-density resume,
-			// 250 is more typical, but this number only feeds a heuristic
-			// pageCount scorer so a Math.ceil is plenty.
-			pageCount: Math.max(1, Math.ceil(wordCount / 500)),
-			wordCount,
+			fileType: metadata.fileType,
+			pageCount: metadata.pageCount,
+			wordCount: text.split(/\s+/).filter(Boolean).length,
 			lineCount: lines.length,
-			hasMultipleColumns: false,
-			hasTables: false,
-			hasImages: false
+			hasMultipleColumns: metadata.hasMultipleColumns,
+			hasTables: metadata.hasTables,
+			hasImages: metadata.hasImages,
+			extractionMethod: metadata.extractionMethod,
+			extractionQuality,
+			language: detectLanguage(text)
 		}
 	};
-
-	return { success: true, resume, errors: [], warnings: [] };
 }
 
-// extracts structured experience entries from experience sections
-function extractExperience(sections: ResumeSection[]): ExperienceEntry[] {
-	const expSections = sections.filter((s) => s.type === 'experience');
-	const entries: ExperienceEntry[] = [];
-
-	for (const section of expSections) {
-		const blocks = splitIntoEntries(section.content);
-
-		for (const block of blocks) {
-			const lines = block.split('\n').filter((l) => l.trim());
-			if (lines.length === 0) continue;
-
-			const firstLine = lines[0];
-			const secondLine = lines.length > 1 ? lines[1] : '';
-			const headerText = firstLine + ' ' + secondLine;
-
-			const dateRange = extractFirstDateRange(headerText);
-			const { title, company } = parseJobHeader(firstLine, secondLine);
-
-			const bullets = lines
-				.slice(title && company ? 2 : 1)
-				.map((l) => l.replace(/^[\s•\-*·▪►➤○●]\s*/, '').trim())
-				.filter((l) => l.length > 0);
-
-			entries.push({
-				title,
-				company,
-				dates: dateRange || { start: null, end: null, isCurrent: false },
-				bullets,
-				rawText: block
-			});
-		}
-	}
-
-	return entries;
-}
-
-// parses title/company from header. handles "Title | Co", "Title at Co", "Title, Co", two-line
-function parseJobHeader(line1: string, line2: string): { title: string; company: string } {
-	// remove date patterns from lines for cleaner parsing
-	const cleanLine1 = line1
-		.replace(
-			/(?:jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)[a-z]*\.?\s*\d{4}\s*[-–—]\s*(?:(?:jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)[a-z]*\.?\s*\d{4}|present|current|now)/gi,
-			''
-		)
-		.trim();
-	const cleanLine2 = line2
-		.replace(
-			/(?:jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)[a-z]*\.?\s*\d{4}\s*[-–—]\s*(?:(?:jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)[a-z]*\.?\s*\d{4}|present|current|now)/gi,
-			''
-		)
-		.trim();
-
-	// try "Title | Company" or "Title - Company"
-	const separatorMatch = cleanLine1.match(/^(.+?)\s*[|–—]\s*(.+)$/);
-	if (separatorMatch) {
-		return { title: separatorMatch[1].trim(), company: separatorMatch[2].trim() };
-	}
-
-	// try "Title at Company"
-	const atMatch = cleanLine1.match(/^(.+?)\s+at\s+(.+)$/i);
-	if (atMatch) {
-		return { title: atMatch[1].trim(), company: atMatch[2].trim() };
-	}
-
-	// try "Title, Company"
-	const commaMatch = cleanLine1.match(/^(.+?),\s*(.+)$/);
-	if (commaMatch && commaMatch[2].length > 2) {
-		return { title: commaMatch[1].trim(), company: commaMatch[2].trim() };
-	}
-
-	// two-line format: line1 is company or title, line2 is the other
-	if (cleanLine1 && cleanLine2) {
-		return { title: cleanLine2 || cleanLine1, company: cleanLine1 };
-	}
-
-	return { title: cleanLine1, company: '' };
-}
-
-// extracts structured education entries from education sections
-function extractEducation(sections: ResumeSection[]): EducationEntry[] {
-	const eduSections = sections.filter((s) => s.type === 'education');
-	const entries: EducationEntry[] = [];
-
-	for (const section of eduSections) {
-		const blocks = splitIntoEntries(section.content);
-
-		for (const block of blocks) {
-			const lines = block.split('\n').filter((l) => l.trim());
-			if (lines.length === 0) continue;
-
-			const fullText = lines.join(' ');
-			const dateRange = extractFirstDateRange(fullText);
-			const { degree, field, institution } = parseEduHeader(lines);
-			const gpa = extractGPA(fullText);
-			const honors = extractHonors(lines);
-
-			entries.push({
-				degree,
-				field,
-				institution,
-				dates: dateRange || { start: null, end: null, isCurrent: false },
-				gpa,
-				honors,
-				rawText: block
-			});
-		}
-	}
-
-	return entries;
-}
-
-function parseEduHeader(lines: string[]): { degree: string; field: string; institution: string } {
-	const degreePatterns =
-		/\b(ph\.?d\.?|doctor|master'?s?|m\.?s\.?|m\.?a\.?|m\.?b\.?a\.?|bachelor'?s?|b\.?s\.?|b\.?a\.?|b\.?eng\.?|associate'?s?|a\.?s\.?|a\.?a\.?|diploma)\b/i;
-
-	let degree = '';
-	let field = '';
-	let institution = '';
-
-	for (const line of lines) {
-		const cleaned = line.replace(/\d{4}\s*[-–—]\s*(?:\d{4}|present|current)/gi, '').trim();
-
-		if (degreePatterns.test(cleaned) && !degree) {
-			const match = cleaned.match(degreePatterns);
-			if (match) {
-				degree = match[0];
-				// field often follows "in" or "of"
-				const fieldMatch = cleaned.match(/(?:in|of)\s+(.+?)(?:\s*[-–—,|]|$)/i);
-				if (fieldMatch) field = fieldMatch[1].trim();
-				// if degree is on a line with the institution
-				const afterDegree = cleaned
-					.replace(degreePatterns, '')
-					.replace(/(?:in|of)\s+.+/, '')
-					.trim();
-				if (afterDegree && !institution)
-					institution = afterDegree.replace(/^[-–—,|\s]+|[-–—,|\s]+$/g, '');
-			}
-		} else if (!institution && cleaned.length > 3) {
-			institution = cleaned.replace(/^[-–—,|\s]+|[-–—,|\s]+$/g, '');
-		}
-	}
-
-	// if we couldn't separate, use best guesses
-	if (!degree && !institution) {
-		institution = lines[0]?.trim() || '';
-		if (lines.length > 1) degree = lines[1]?.trim() || '';
-	}
-
-	return { degree, field, institution };
-}
-
-function extractGPA(text: string): string | null {
-	const gpaMatch = text.match(/(?:gpa|g\.p\.a\.?)\s*:?\s*(\d+\.?\d*)\s*(?:\/\s*(\d+\.?\d*))?/i);
-	if (gpaMatch) {
-		return gpaMatch[2] ? `${gpaMatch[1]}/${gpaMatch[2]}` : gpaMatch[1];
-	}
-	return null;
-}
-
-function extractHonors(lines: string[]): string[] {
-	const honorsKeywords =
-		/\b(cum laude|magna cum laude|summa cum laude|dean'?s?\s*list|honors?|distinction|valedictorian|salutatorian)\b/i;
-	return lines.filter((l) => honorsKeywords.test(l)).map((l) => l.trim());
-}
-
-// extracts project entries from project sections
-function extractProjects(sections: ResumeSection[]): ProjectEntry[] {
-	const projSections = sections.filter((s) => s.type === 'projects');
-	const entries: ProjectEntry[] = [];
-
-	for (const section of projSections) {
-		const blocks = splitIntoEntries(section.content);
-
-		for (const block of blocks) {
-			const lines = block.split('\n').filter((l) => l.trim());
-			if (lines.length === 0) continue;
-
-			const name = lines[0].replace(/^[\s•\-*]\s*/, '').trim();
-			const bullets = lines
-				.slice(1)
-				.map((l) => l.replace(/^[\s•\-*·▪►➤○●]\s*/, '').trim())
-				.filter(Boolean);
-			const fullText = lines.join(' ');
-
-			// extract technologies from parentheses or "Technologies:" prefix
-			const techMatch = fullText.match(/(?:\(([^)]+)\)|technologies?\s*:?\s*(.+?)(?:\.|$))/i);
-			const technologies = techMatch
-				? (techMatch[1] || techMatch[2])
-						.split(/[,|;]/)
-						.map((t) => t.trim())
-						.filter(Boolean)
-				: [];
-
-			const urlMatch = fullText.match(/https?:\/\/[^\s)]+/);
-
-			entries.push({
-				name,
-				description: bullets.join(' '),
-				technologies,
-				bullets,
-				url: urlMatch ? urlMatch[0] : null,
-				rawText: block
-			});
-		}
-	}
-
-	return entries;
-}
-
-// extracts certifications from certification sections
-function extractCertifications(sections: ResumeSection[]): CertificationEntry[] {
-	const certSections = sections.filter((s) => s.type === 'certifications');
-	const entries: CertificationEntry[] = [];
-
-	for (const section of certSections) {
-		const lines = section.content.split('\n').filter((l) => l.trim());
-
-		for (const line of lines) {
-			const cleaned = line.replace(/^[\s•\-*·▪►➤○●]\s*/, '').trim();
-			if (cleaned.length === 0) continue;
-
-			// try to split "Certification Name - Issuer"
-			const parts = cleaned.split(/\s*[-–—|]\s*/);
-			const dateRange = extractFirstDateRange(cleaned);
-
-			entries.push({
-				name: parts[0].trim(),
-				issuer: parts.length > 1 ? parts[1].replace(/\d{4}.*/, '').trim() : '',
-				date: dateRange?.start || null,
-				rawText: cleaned
-			});
-		}
-	}
-
-	return entries;
-}
-
-// extracts skills from skills sections. handles comma-separated, bullets, "Category: skill1, skill2"
-function extractSkills(sections: ResumeSection[]): string[] {
-	const skillSections = sections.filter((s) => s.type === 'skills');
-	const skills: string[] = [];
-
-	for (const section of skillSections) {
-		const lines = section.content.split('\n').filter((l) => l.trim());
-
-		for (const line of lines) {
-			const cleaned = line.replace(/^[\s•\-*·▪►➤○●]\s*/, '').trim();
-			if (cleaned.length === 0) continue;
-
-			// handle "Category: skill1, skill2, skill3" format
-			const colonSplit = cleaned.split(':');
-			const skillPart = colonSplit.length > 1 ? colonSplit.slice(1).join(':') : cleaned;
-
-			// split on commas, pipes, semicolons, or bullet-like separators
-			const items = skillPart
-				.split(/[,|;•·▪]/)
-				.map((s) => s.trim())
-				.filter((s) => s.length > 0 && s.length < 50);
-
-			skills.push(...items);
-		}
-	}
-
-	// deduplicate (case-insensitive)
-	const seen = new Set<string>();
-	return skills.filter((skill) => {
-		const key = skill.toLowerCase();
-		if (seen.has(key)) return false;
-		seen.add(key);
-		return true;
-	});
-}
-
-// extracts the summary/objective section text
-function extractSummary(sections: ResumeSection[]): string | null {
-	const summarySection = sections.find((s) => s.type === 'summary');
-	return summarySection ? summarySection.content.trim() : null;
-}
-
-// splits section content into entries using blank lines and date-containing headers as boundaries
-function splitIntoEntries(content: string): string[] {
-	const lines = content.split('\n');
-	const entries: string[] = [];
-	let current: string[] = [];
-
-	for (let i = 0; i < lines.length; i++) {
-		const line = lines[i];
-		const trimmed = line.trim();
-
-		// blank line might separate entries
-		if (trimmed.length === 0) {
-			if (current.length > 0) {
-				entries.push(current.join('\n'));
-				current = [];
-			}
-			continue;
-		}
-
-		// a line with a date range at the start of a new entry
-		const hasDate = extractDateRanges(trimmed).length > 0;
-		const isBullet = /^[\s•\-*·▪►➤○●]/.test(line);
-
-		if (hasDate && !isBullet && current.length > 0 && current.some((l) => l.trim().length > 0)) {
-			// check if the previous entry has bullets (indicating it's complete)
-			const prevHasBullets = current.some((l) => /^[\s•\-*·▪►➤○●]/.test(l));
-			if (prevHasBullets) {
-				entries.push(current.join('\n'));
-				current = [];
-			}
-		}
-
-		current.push(line);
-	}
-
-	if (current.length > 0) {
-		entries.push(current.join('\n'));
-	}
-
-	return entries.filter((e) => e.trim().length > 0);
-}
-
-// note: parsePDF and parseDOCX are NOT re-exported here. they are loaded
-// only via dynamic import inside parseResume so the bundler can split
-// pdfjs and mammoth into per-format chunks. external code that needs
-// them directly should import from './pdf-parser' or './docx-parser'.
 export { detectSections } from './section-detector';
 export { extractContact } from './contact-extractor';
 export { extractDateRanges, extractFirstDateRange } from './date-extractor';

--- a/src/lib/engine/parser/pdf-parser.ts
+++ b/src/lib/engine/parser/pdf-parser.ts
@@ -1,18 +1,33 @@
 import * as pdfjsLib from 'pdfjs-dist';
 import type { TextItem } from 'pdfjs-dist/types/src/display/api';
+import { normalizeLines, normalizeTextFragment, textQualityScore } from './text-normalizer';
 
 pdfjsLib.GlobalWorkerOptions.workerSrc = new URL(
 	'pdfjs-dist/build/pdf.worker.min.mjs',
 	import.meta.url
 ).toString();
 
-interface PDFTextLine {
+interface PDFTextItem {
 	text: string;
 	x: number;
 	y: number;
 	width: number;
 	height: number;
 	pageIndex: number;
+	pageWidth: number;
+	pageHeight: number;
+	hadLeadingSpace: boolean;
+	hadTrailingSpace: boolean;
+}
+
+interface ReconstructedLine {
+	text: string;
+	xStart: number;
+	xEnd: number;
+	y: number;
+	pageIndex: number;
+	pageWidth: number;
+	items: PDFTextItem[];
 }
 
 interface PDFParseResult {
@@ -22,196 +37,233 @@ interface PDFParseResult {
 	hasMultipleColumns: boolean;
 	hasTables: boolean;
 	hasImages: boolean;
+	quality: number;
+	needsOCR: boolean;
 }
 
-// extracts text from a PDF with layout-aware line reconstruction
 export async function parsePDF(file: File): Promise<PDFParseResult> {
 	const buffer = await file.arrayBuffer();
 	const pdf = await pdfjsLib.getDocument({ data: buffer }).promise;
-	const pageCount = pdf.numPages;
-
-	const allLines: PDFTextLine[] = [];
+	const allItems: PDFTextItem[] = [];
 	let hasImages = false;
 
-	for (let i = 1; i <= pageCount; i++) {
-		const page = await pdf.getPage(i);
+	for (let pageNumber = 1; pageNumber <= pdf.numPages; pageNumber++) {
+		const page = await pdf.getPage(pageNumber);
+		const viewport = page.getViewport({ scale: 1 });
 		const textContent = await page.getTextContent();
 		const operators = await page.getOperatorList();
 
-		// detect actual raster images via operator list
-		// only count paintImageXObject (real images), NOT paintXObject (which includes fonts/glyphs)
-		// LaTeX PDFs embed glyphs as XObjects, causing false positives with paintXObject
-		const imageOps = [pdfjsLib.OPS.paintImageXObject, pdfjsLib.OPS.paintImageMaskXObject];
-		for (let opIdx = 0; opIdx < operators.fnArray.length; opIdx++) {
-			if (imageOps.includes(operators.fnArray[opIdx])) {
-				// check if the image is large enough to be a real image (not a tiny glyph/icon)
-				// small images (<50px in either dimension) are likely font glyphs or bullets
-				const args = operators.argsArray[opIdx];
-				if (args && args[0]) {
-					try {
-						const imgObj = page.objs.get(args[0] as string) as {
-							width?: number;
-							height?: number;
-						} | null;
-						if (imgObj && (imgObj.width ?? 0) > 50 && (imgObj.height ?? 0) > 50) {
-							hasImages = true;
-							break;
-						}
-					} catch {
-						// if we can't inspect the image object, count it conservatively
-						hasImages = true;
-						break;
-					}
-				}
+		const imageOps = new Set([
+			pdfjsLib.OPS.paintImageXObject,
+			pdfjsLib.OPS.paintImageMaskXObject
+		]);
+		for (let index = 0; index < operators.fnArray.length; index++) {
+			if (!imageOps.has(operators.fnArray[index])) continue;
+			const objectId = operators.argsArray[index]?.[0];
+			if (!objectId) continue;
+			try {
+				const image = page.objs.get(objectId as string) as {
+					width?: number;
+					height?: number;
+				} | null;
+				const width = image?.width ?? 0;
+				const height = image?.height ?? 0;
+				const areaRatio =
+					(width * height) / Math.max(1, viewport.width * viewport.height);
+				if (width >= 80 && height >= 80 && areaRatio >= 0.03) hasImages = true;
+			} catch {
+				// Decorative glyph XObjects may not resolve synchronously. Ignoring them
+				// avoids reporting every icon as a photograph.
 			}
 		}
 
 		for (const item of textContent.items) {
 			if (!('str' in item)) continue;
 			const textItem = item as TextItem;
-			if (!textItem.str.trim()) continue;
-
-			allLines.push({
-				text: textItem.str,
+			const rawText = textItem.str;
+			const text = normalizeTextFragment(rawText);
+			if (!text) continue;
+			allItems.push({
+				text,
 				x: textItem.transform[4],
 				y: textItem.transform[5],
 				width: textItem.width,
-				height: textItem.height,
-				pageIndex: i - 1
+				height: Math.max(1, textItem.height),
+				pageIndex: pageNumber - 1,
+				pageWidth: viewport.width,
+				pageHeight: viewport.height,
+				hadLeadingSpace: /^\s/u.test(rawText),
+				hadTrailingSpace: /\s$/u.test(rawText)
 			});
 		}
 	}
 
-	const hasMultipleColumns = detectMultipleColumns(allLines);
-	const hasTables = detectTables(allLines);
-
-	// group text items into lines by y-position proximity
-	const reconstructedLines = reconstructLines(allLines);
-	const text = reconstructedLines.join('\n');
+	const reconstructed = reconstructLines(allItems);
+	const lines = normalizeLines(reconstructed.map((line) => line.text));
+	const text = lines.join('\n');
+	const quality = textQualityScore(text, lines);
 
 	return {
 		text,
-		lines: reconstructedLines,
-		pageCount,
-		hasMultipleColumns,
-		hasTables,
-		hasImages
+		lines,
+		pageCount: pdf.numPages,
+		hasMultipleColumns: detectMultipleColumns(reconstructed),
+		hasTables: detectTables(reconstructed),
+		hasImages,
+		quality,
+		needsOCR: quality < 55
 	};
 }
 
-// groups text items into lines by y-position (3px threshold), sorted top-to-bottom
-function reconstructLines(items: PDFTextLine[]): string[] {
-	if (items.length === 0) return [];
+function reconstructLines(items: PDFTextItem[]): ReconstructedLine[] {
+	const result: ReconstructedLine[] = [];
+	const pages = new Map<number, PDFTextItem[]>();
+	for (const item of items) {
+		pages.set(item.pageIndex, [...(pages.get(item.pageIndex) ?? []), item]);
+	}
 
-	// sort by page, then by y (descending = top first), then by x
-	const sorted = [...items].sort((a, b) => {
-		if (a.pageIndex !== b.pageIndex) return a.pageIndex - b.pageIndex;
-		if (Math.abs(a.y - b.y) > 3) return b.y - a.y;
-		return a.x - b.x;
-	});
+	for (const [pageIndex, pageItems] of [...pages.entries()].sort(
+		([first], [second]) => first - second
+	)) {
+		const heights = pageItems.map((item) => item.height).sort((a, b) => a - b);
+		const medianHeight = heights[Math.floor(heights.length / 2)] || 10;
+		const tolerance = Math.max(1.5, Math.min(4.5, medianHeight * 0.35));
+		const sorted = [...pageItems].sort((a, b) =>
+			Math.abs(a.y - b.y) > tolerance ? b.y - a.y : a.x - b.x
+		);
+		let current: PDFTextItem[] = [];
+		let anchorY = 0;
 
-	const lines: string[] = [];
-	let currentLine: PDFTextLine[] = [sorted[0]];
+		const flush = () => {
+			if (!current.length) return;
+			current.sort((a, b) => a.x - b.x);
+			const text = mergeItems(current);
+			if (text) {
+				result.push({
+					text,
+					xStart: current[0].x,
+					xEnd: Math.max(...current.map((item) => item.x + item.width)),
+					y: current.reduce((sum, item) => sum + item.y, 0) / current.length,
+					pageIndex,
+					pageWidth: current[0].pageWidth,
+					items: [...current]
+				});
+			}
+			current = [];
+		};
 
-	for (let i = 1; i < sorted.length; i++) {
-		const item = sorted[i];
-		const prev = currentLine[currentLine.length - 1];
-
-		const samePage = item.pageIndex === prev.pageIndex;
-		const sameLine = Math.abs(item.y - prev.y) <= 3;
-
-		if (samePage && sameLine) {
-			currentLine.push(item);
-		} else {
-			lines.push(mergeLine(currentLine));
-			currentLine = [item];
+		for (const item of sorted) {
+			if (!current.length) {
+				current = [item];
+				anchorY = item.y;
+				continue;
+			}
+			if (Math.abs(item.y - anchorY) <= tolerance) {
+				current.push(item);
+				anchorY =
+					current.reduce((sum, entry) => sum + entry.y, 0) / current.length;
+			} else {
+				flush();
+				current = [item];
+				anchorY = item.y;
+			}
 		}
+		flush();
 	}
-
-	if (currentLine.length > 0) {
-		lines.push(mergeLine(currentLine));
-	}
-
-	return lines.filter((line) => line.trim().length > 0);
-}
-
-// merges text items on the same line, inserting spaces at significant gaps
-function mergeLine(items: PDFTextLine[]): string {
-	if (items.length === 0) return '';
-	if (items.length === 1) return items[0].text;
-
-	const sorted = [...items].sort((a, b) => a.x - b.x);
-	let result = sorted[0].text;
-
-	for (let i = 1; i < sorted.length; i++) {
-		const gap = sorted[i].x - (sorted[i - 1].x + sorted[i - 1].width);
-		// insert space if gap is larger than ~half a character width
-		const charWidth = sorted[i].height * 0.5;
-		if (gap > charWidth) {
-			result += ' ';
-		}
-		result += sorted[i].text;
-	}
-
 	return result;
 }
 
-// detects multi-column layouts by checking for distinct x-position clusters
-function detectMultipleColumns(items: PDFTextLine[]): boolean {
-	if (items.length < 20) return false;
-
-	const xPositions = items.map((item) => Math.round(item.x / 10) * 10);
-	const xCounts = new Map<number, number>();
-
-	for (const x of xPositions) {
-		xCounts.set(x, (xCounts.get(x) || 0) + 1);
+function mergeItems(items: PDFTextItem[]): string {
+	if (!items.length) return '';
+	let value = items[0].text;
+	for (let index = 1; index < items.length; index++) {
+		const previous = items[index - 1];
+		const current = items[index];
+		const gap = current.x - (previous.x + previous.width);
+		const previousCharWidth = previous.width / Math.max(1, previous.text.length);
+		const currentCharWidth = current.width / Math.max(1, current.text.length);
+		const threshold = Math.max(
+			1.2,
+			Math.min(previousCharWidth, currentCharWidth) * 0.25
+		);
+		if (shouldInsertSpace(previous, current, value, gap, threshold)) value += ' ';
+		value += current.text;
 	}
+	return normalizeTextFragment(value);
+}
 
-	// find distinct x-clusters with significant item counts
-	const significantClusters = [...xCounts.entries()]
-		.filter(([_, count]) => count > items.length * 0.05)
-		.map(([x]) => x)
-		.sort((a, b) => a - b);
+function shouldInsertSpace(
+	previous: PDFTextItem,
+	current: PDFTextItem,
+	assembled: string,
+	gap: number,
+	threshold: number
+): boolean {
+	if (/^[,.;:)]/.test(current.text)) return false;
+	if (/[-/@#_.+]$/.test(assembled)) return false;
+	if (previous.hadTrailingSpace || current.hadLeadingSpace) return true;
+	if (gap > threshold) return true;
+	if (gap < -0.8) return false;
 
-	if (significantClusters.length < 2) return false;
+	// Several office/PDF generators emit adjacent text runs with no geometric gap,
+	// even when a visual word boundary exists. Infer that boundary conservatively.
+	const previousEndsWord = /[\p{L}\p{N}):%]$/u.test(previous.text);
+	const currentStartsWord = /^[\p{L}\p{N}(]/u.test(current.text);
+	const previousIsBullet = /^[•·▪►➤○●]$/u.test(previous.text);
+	return (previousEndsWord && currentStartsWord) || previousIsBullet;
+}
 
-	// check if clusters are far enough apart to be separate columns
-	for (let i = 1; i < significantClusters.length; i++) {
-		const gap = significantClusters[i] - significantClusters[i - 1];
-		if (gap > 150) return true;
+function detectMultipleColumns(lines: ReconstructedLine[]): boolean {
+	const pages = new Map<number, ReconstructedLine[]>();
+	for (const line of lines) {
+		pages.set(line.pageIndex, [...(pages.get(line.pageIndex) ?? []), line]);
 	}
-
+	for (const pageLines of pages.values()) {
+		const candidates = pageLines.filter(
+			(line) => line.text.length >= 12 && line.xEnd - line.xStart >= 50
+		);
+		if (candidates.length < 12) continue;
+		const counts = new Map<number, number>();
+		for (const line of candidates) {
+			const bucket = Math.round(line.xStart / 20) * 20;
+			counts.set(bucket, (counts.get(bucket) ?? 0) + 1);
+		}
+		const clusters = [...counts.entries()]
+			.filter(([, count]) => count >= Math.max(4, candidates.length * 0.18))
+			.sort((a, b) => a[0] - b[0]);
+		for (let first = 0; first < clusters.length; first++) {
+			for (let second = first + 1; second < clusters.length; second++) {
+				const gap = clusters[second][0] - clusters[first][0];
+				const pageWidth = candidates[0].pageWidth;
+				if (
+					gap >= Math.max(170, pageWidth * 0.3) &&
+					clusters[second][0] >= pageWidth * 0.42
+				) {
+					return true;
+				}
+			}
+		}
+	}
 	return false;
 }
 
-// detects table-like structures by looking for aligned columns with consistent gaps
-function detectTables(items: PDFTextLine[]): boolean {
-	if (items.length < 10) return false;
-
-	// group items by y-position (same line)
-	const lineGroups = new Map<number, PDFTextLine[]>();
-	for (const item of items) {
-		const roundedY = Math.round(item.y / 3) * 3;
-		if (!lineGroups.has(roundedY)) {
-			lineGroups.set(roundedY, []);
+function detectTables(lines: ReconstructedLine[]): boolean {
+	const signatures = new Map<string, number>();
+	for (const line of lines) {
+		if (line.items.length < 3) continue;
+		const sorted = [...line.items].sort((a, b) => a.x - b.x);
+		const anchors = [sorted[0].x];
+		for (let index = 1; index < sorted.length; index++) {
+			const gap =
+				sorted[index].x - (sorted[index - 1].x + sorted[index - 1].width);
+			if (gap >= 35) anchors.push(sorted[index].x);
 		}
-		lineGroups.get(roundedY)!.push(item);
+		if (anchors.length < 3) continue;
+		const signature = anchors
+			.slice(0, 4)
+			.map((x) => Math.round(x / 20) * 20)
+			.join(':');
+		signatures.set(signature, (signatures.get(signature) ?? 0) + 1);
 	}
-
-	// count lines with 3+ separate text items (potential table rows)
-	let tableRowCount = 0;
-	for (const [, lineItems] of lineGroups) {
-		if (lineItems.length >= 3) {
-			const sorted = lineItems.sort((a, b) => a.x - b.x);
-			const gaps = [];
-			for (let i = 1; i < sorted.length; i++) {
-				gaps.push(sorted[i].x - (sorted[i - 1].x + sorted[i - 1].width));
-			}
-			// if there are large, consistent gaps, it looks like a table
-			const largeGaps = gaps.filter((g) => g > 30);
-			if (largeGaps.length >= 2) tableRowCount++;
-		}
-	}
-
-	return tableRowCount >= 3;
+	return [...signatures.values()].some((count) => count >= 4);
 }

--- a/src/lib/engine/parser/section-detector.ts
+++ b/src/lib/engine/parser/section-detector.ts
@@ -1,66 +1,100 @@
 import type { ResumeSection, SectionType } from './types';
 
-// maps common resume section headers to canonical types
+// Normalize headings before matching. PDF generators frequently prefix headings
+// with emoji/icons and may emit accented characters in decomposed form.
+function normalizeHeader(header: string): string {
+	return header
+		.normalize('NFKD')
+		.replace(/\p{M}/gu, '')
+		.replace(/[^\p{L}\p{N}&/+\s]/gu, ' ')
+		.replace(/\s+/g, ' ')
+		.trim();
+}
+
+// Maps common English and Portuguese resume section headers to canonical types.
 const SECTION_PATTERNS: Record<SectionType, RegExp[]> = {
-	contact: [/^(contact\s*(info(rmation)?)?|personal\s*(info(rmation)?|details))$/i],
+	contact: [
+		/^(contact\s*(info(rmation)?)?|personal\s*(info(rmation)?|details))$/i,
+		/^(contato|informacoes?\s*(pessoais|de\s*contato)|dados\s*pessoais)$/i
+	],
 	summary: [
-		/^(summary|profile|about(\s*me)?|objective|professional\s*summary|career\s*summary|executive\s*summary|personal\s*statement)$/i
+		/^(summary|profile|about(\s*me)?|objective|professional\s*summary|career\s*summary|executive\s*summary|personal\s*statement)$/i,
+		/^(resumo(\s*profissional)?|perfil\s*profissional|objetivo(\s*profissional)?|sobre\s*mim|apresentacao\s*profissional)$/i
 	],
 	experience: [
-		/^(experience|work\s*experience|professional\s*experience|employment(\s*history)?|work\s*history|relevant\s*experience|career\s*history)$/i
+		/^(experience|work\s*experience|professional\s*experience|employment(\s*history)?|work\s*history|relevant\s*experience|career\s*history)$/i,
+		/^(experiencia(\s*profissional)?|historico\s*profissional|historico\s*de\s*trabalho|trajetoria\s*profissional)$/i
 	],
 	education: [
-		/^(education|academic(\s*background)?|educational\s*background|qualifications|academic\s*qualifications)$/i
+		/^(education|academic(\s*background)?|educational\s*background|qualifications|academic\s*qualifications)$/i,
+		/^(formacao(\s*academica)?|educacao|escolaridade|qualificacoes\s*academicas)$/i
 	],
 	skills: [
-		/^(skills|technical\s*skills|core\s*competencies|competencies|areas?\s*of\s*expertise|proficiencies|technologies|tools?\s*(&|and)\s*technologies)$/i
+		/^(skills|technical\s*skills|core\s*competencies|competencies|areas?\s*of\s*expertise|proficiencies|technologies|tools?\s*(&|and)\s*technologies)$/i,
+		/^(competencias(\s*tecnicas)?|habilidades(\s*tecnicas)?|conhecimentos(\s*tecnicos)?|tecnologias|ferramentas|tecnologias\s*(&|e)\s*ferramentas)$/i
 	],
 	projects: [
-		/^(projects|personal\s*projects|academic\s*projects|notable\s*projects|selected\s*projects|key\s*projects|side\s*projects)$/i
+		/^(projects|personal\s*projects|academic\s*projects|notable\s*projects|selected\s*projects|key\s*projects|side\s*projects|technical\s*repositories|projects\s*(&|and)\s*(technical\s*)?repositories)$/i,
+		/^(projetos|projetos\s*pessoais|projetos\s*academicos|projetos\s*tecnicos|repositorios\s*tecnicos|repositorios\s*(&|e)\s*projetos\s*tecnicos)$/i
 	],
 	certifications: [
-		/^(certifications?|licenses?(\s*(&|and)\s*certifications?)?|professional\s*certifications?|accreditations?)$/i
+		/^(certifications?|licenses?(\s*(&|and)\s*certifications?)?|professional\s*certifications?|accreditations?)$/i,
+		/^(certificacoes?|licencas?(\s*(&|e)\s*certificacoes?)?|cursos\s*(&|e)\s*certificacoes?)$/i
 	],
-	awards: [/^(awards?|honors?(\s*(&|and)\s*awards?)?|achievements?|recognition|scholarships?)$/i],
-	publications: [/^(publications?|research|papers?|presentations?)$/i],
+	awards: [
+		/^(awards?|honors?(\s*(&|and)\s*awards?)?|achievements?|recognition|scholarships?)$/i,
+		/^(premios?|honras?|conquistas?|reconhecimentos?)$/i
+	],
+	publications: [
+		/^(publications?|research|papers?|presentations?)$/i,
+		/^(publicacoes?|pesquisas?|artigos?|apresentacoes?)$/i
+	],
 	volunteer: [
-		/^(volunteer(ing)?(\s*experience)?|community\s*(service|involvement)|extracurricular(\s*activities)?)$/i
+		/^(volunteer(ing)?(\s*experience)?|community\s*(service|involvement)|extracurricular(\s*activities)?)$/i,
+		/^(voluntariado|experiencia\s*voluntaria|trabalho\s*voluntario|atividades\s*extracurriculares)$/i
 	],
-	languages: [/^(languages?|language\s*proficiency)$/i],
-	interests: [/^(interests?|hobbies(\s*(&|and)\s*interests?)?)$/i],
+	languages: [
+		/^(languages?|language\s*proficiency)$/i,
+		/^(idiomas?|proficiencia\s*em\s*idiomas?)$/i
+	],
+	interests: [
+		/^(interests?|hobbies(\s*(&|and)\s*interests?)?)$/i,
+		/^(interesses?|hobbies(\s*(&|e)\s*interesses?)?)$/i
+	],
 	unknown: []
 };
 
-// checks if a line is a section header using pattern matching and heuristics
+// Checks if a line is a section header using pattern matching and heuristics.
 function isSectionHeader(line: string, prevLine: string | null, nextLine: string | null): boolean {
 	const trimmed = line.trim();
+	if (trimmed.length === 0 || trimmed.length > 100) return false;
 
-	if (trimmed.length === 0 || trimmed.length > 80) return false;
+	const cleaned = normalizeHeader(trimmed);
+	if (!cleaned) return false;
 
-	// check against known patterns
-	const cleaned = trimmed.replace(/[:\-_|]/g, '').trim();
 	for (const patterns of Object.values(SECTION_PATTERNS)) {
 		if (patterns.some((p) => p.test(cleaned))) return true;
 	}
 
-	// heuristic: all caps, short, and looks like a header
-	const isAllCaps = trimmed === trimmed.toUpperCase() && /[A-Z]/.test(trimmed);
-	const isShort = trimmed.split(/\s+/).length <= 5;
-	const hasNoNumbers = !/\d{3,}/.test(trimmed); // avoid matching phone numbers, dates
+	// Heuristic: all caps, short, and looks like a header.
+	const isAllCaps = cleaned === cleaned.toUpperCase() && /\p{L}/u.test(cleaned);
+	const isShort = cleaned.split(/\s+/).length <= 6;
+	const hasNoNumbers = !/\d{3,}/.test(cleaned);
 	const prevIsBlank = prevLine === null || prevLine.trim().length === 0;
 
 	if (isAllCaps && isShort && hasNoNumbers && prevIsBlank) return true;
 
-	// heuristic: title case, ends with colon
+	// Heuristic: title case, ends with colon.
 	if (trimmed.endsWith(':') && isShort) return true;
 
-	// heuristic: line is visually separated and looks like a category label
-	// must be preceded by blank line AND have content after it
-	const isAlphaOnly = /^[a-zA-Z\s&,/]+$/.test(cleaned);
+	// Heuristic: visually separated category label.
+	const isAlphaOnly = /^[\p{L}\s&,/]+$/u.test(cleaned);
 	const wordCount = cleaned.split(/\s+/).length;
 	const nextIsContent = nextLine !== null && nextLine.trim().length > 0;
-	// avoid matching personal names (typically 2-3 title-case words at document start)
-	const isLikelyName = wordCount >= 2 && wordCount <= 3 && /^[A-Z][a-z]+ [A-Z]/.test(cleaned);
+	const isLikelyName =
+		wordCount >= 2 &&
+		wordCount <= 5 &&
+		/^\p{Lu}[\p{L}'-]+(?:\s+\p{Lu}[\p{L}'-]+)+$/u.test(cleaned);
 
 	if (isAlphaOnly && isShort && prevIsBlank && nextIsContent && !isLikelyName && cleaned.length > 2)
 		return true;
@@ -68,25 +102,21 @@ function isSectionHeader(line: string, prevLine: string | null, nextLine: string
 	return false;
 }
 
-// classifies a section header string into a canonical SectionType
 function classifySection(header: string): SectionType {
-	const cleaned = header.replace(/[:\-_|]/g, '').trim();
+	const cleaned = normalizeHeader(header);
 
 	for (const [type, patterns] of Object.entries(SECTION_PATTERNS)) {
-		if (patterns.some((p: RegExp) => p.test(cleaned))) {
-			return type as SectionType;
-		}
+		if (patterns.some((p: RegExp) => p.test(cleaned))) return type as SectionType;
 	}
 
 	return 'unknown';
 }
 
-// detects and extracts sections from resume lines with type, header, content, and line ranges
+// Detects and extracts sections from resume lines with type, header, content, and line ranges.
 export function detectSections(lines: string[]): ResumeSection[] {
 	const sections: ResumeSection[] = [];
 	const headerIndices: { index: number; header: string; type: SectionType }[] = [];
 
-	// first pass: identify all section headers
 	for (let i = 0; i < lines.length; i++) {
 		const prevLine = i > 0 ? lines[i - 1] : null;
 		const nextLine = i < lines.length - 1 ? lines[i + 1] : null;
@@ -97,7 +127,6 @@ export function detectSections(lines: string[]): ResumeSection[] {
 		}
 	}
 
-	// if no headers detected, treat the entire text as a single unknown section
 	if (headerIndices.length === 0) {
 		return [
 			{
@@ -110,8 +139,7 @@ export function detectSections(lines: string[]): ResumeSection[] {
 		];
 	}
 
-	// extract content between headers
-	// content before first header is often contact info
+	// Content before the first header is normally the contact block.
 	if (headerIndices[0].index > 0) {
 		const contactContent = lines.slice(0, headerIndices[0].index).join('\n').trim();
 		if (contactContent.length > 0) {
@@ -128,7 +156,6 @@ export function detectSections(lines: string[]): ResumeSection[] {
 	for (let i = 0; i < headerIndices.length; i++) {
 		const current = headerIndices[i];
 		const nextIndex = i < headerIndices.length - 1 ? headerIndices[i + 1].index : lines.length;
-
 		const contentLines = lines.slice(current.index + 1, nextIndex);
 		const content = contentLines.join('\n').trim();
 

--- a/src/lib/engine/parser/section-detector.ts
+++ b/src/lib/engine/parser/section-detector.ts
@@ -1,9 +1,8 @@
 import type { ResumeSection, SectionType } from './types';
+import { normalizeTextFragment } from './text-normalizer';
 
-// Normalize headings before matching. PDF generators frequently prefix headings
-// with emoji/icons and may emit accented characters in decomposed form.
-function normalizeHeader(header: string): string {
-	return header
+export function normalizeHeader(header: string): string {
+	return normalizeTextFragment(header)
 		.normalize('NFKD')
 		.replace(/\p{M}/gu, '')
 		.replace(/[^\p{L}\p{N}&/+\s]/gu, ' ')
@@ -11,7 +10,6 @@ function normalizeHeader(header: string): string {
 		.trim();
 }
 
-// Maps common English and Portuguese resume section headers to canonical types.
 const SECTION_PATTERNS: Record<SectionType, RegExp[]> = {
 	contact: [
 		/^(contact\s*(info(rmation)?)?|personal\s*(info(rmation)?|details))$/i,
@@ -22,8 +20,8 @@ const SECTION_PATTERNS: Record<SectionType, RegExp[]> = {
 		/^(resumo(\s*profissional)?|perfil\s*profissional|objetivo(\s*profissional)?|sobre\s*mim|apresentacao\s*profissional)$/i
 	],
 	experience: [
-		/^(experience|work\s*experience|professional\s*experience|employment(\s*history)?|work\s*history|relevant\s*experience|career\s*history)$/i,
-		/^(experiencia(\s*profissional)?|historico\s*profissional|historico\s*de\s*trabalho|trajetoria\s*profissional)$/i
+		/^(experience|work\s*experience|professional\s*experience|employment(\s*history)?|work\s*history|relevant\s*experience|career\s*history|additional\s*experience)$/i,
+		/^(experiencia(s)?(\s*profissional(is)?)?|historico\s*profissional|historico\s*de\s*trabalho|trajetoria\s*profissional|outras?\s*experiencias?\s*profissionais?)$/i
 	],
 	education: [
 		/^(education|academic(\s*background)?|educational\s*background|qualifications|academic\s*qualifications)$/i,
@@ -38,8 +36,8 @@ const SECTION_PATTERNS: Record<SectionType, RegExp[]> = {
 		/^(projetos|projetos\s*pessoais|projetos\s*academicos|projetos\s*tecnicos|repositorios\s*tecnicos|repositorios\s*(&|e)\s*projetos\s*tecnicos)$/i
 	],
 	certifications: [
-		/^(certifications?|licenses?(\s*(&|and)\s*certifications?)?|professional\s*certifications?|accreditations?)$/i,
-		/^(certificacoes?|licencas?(\s*(&|e)\s*certificacoes?)?|cursos\s*(&|e)\s*certificacoes?)$/i
+		/^(certifications?|licenses?(\s*(&|and)\s*certifications?)?|professional\s*certifications?|accreditations?|courses?\s*(&|and)\s*certifications?)$/i,
+		/^(certificacoes?|licencas?(\s*(&|e)\s*certificacoes?)?|cursos(\s*(&|e)\s*certificacoes?)?)$/i
 	],
 	awards: [
 		/^(awards?|honors?(\s*(&|and)\s*awards?)?|achievements?|recognition|scholarships?)$/i,
@@ -64,109 +62,74 @@ const SECTION_PATTERNS: Record<SectionType, RegExp[]> = {
 	unknown: []
 };
 
-// Checks if a line is a section header using pattern matching and heuristics.
-function isSectionHeader(line: string, prevLine: string | null, nextLine: string | null): boolean {
-	const trimmed = line.trim();
-	if (trimmed.length === 0 || trimmed.length > 100) return false;
-
-	const cleaned = normalizeHeader(trimmed);
-	if (!cleaned) return false;
-
-	for (const patterns of Object.values(SECTION_PATTERNS)) {
-		if (patterns.some((p) => p.test(cleaned))) return true;
-	}
-
-	// Heuristic: all caps, short, and looks like a header.
-	const isAllCaps = cleaned === cleaned.toUpperCase() && /\p{L}/u.test(cleaned);
-	const isShort = cleaned.split(/\s+/).length <= 6;
-	const hasNoNumbers = !/\d{3,}/.test(cleaned);
-	const prevIsBlank = prevLine === null || prevLine.trim().length === 0;
-
-	if (isAllCaps && isShort && hasNoNumbers && prevIsBlank) return true;
-
-	// Heuristic: title case, ends with colon.
-	if (trimmed.endsWith(':') && isShort) return true;
-
-	// Heuristic: visually separated category label.
-	const isAlphaOnly = /^[\p{L}\s&,/]+$/u.test(cleaned);
-	const wordCount = cleaned.split(/\s+/).length;
-	const nextIsContent = nextLine !== null && nextLine.trim().length > 0;
-	const isLikelyName =
-		wordCount >= 2 &&
-		wordCount <= 5 &&
-		/^\p{Lu}[\p{L}'-]+(?:\s+\p{Lu}[\p{L}'-]+)+$/u.test(cleaned);
-
-	if (isAlphaOnly && isShort && prevIsBlank && nextIsContent && !isLikelyName && cleaned.length > 2)
-		return true;
-
-	return false;
-}
-
 function classifySection(header: string): SectionType {
 	const cleaned = normalizeHeader(header);
-
 	for (const [type, patterns] of Object.entries(SECTION_PATTERNS)) {
-		if (patterns.some((p: RegExp) => p.test(cleaned))) return type as SectionType;
+		if (patterns.some((pattern) => pattern.test(cleaned))) return type as SectionType;
 	}
-
 	return 'unknown';
 }
 
-// Detects and extracts sections from resume lines with type, header, content, and line ranges.
+function looksLikePersonName(line: string, index: number): boolean {
+	if (index > 4) return false;
+	const cleaned = normalizeHeader(line);
+	const words = cleaned.split(/\s+/).filter(Boolean);
+	if (words.length < 2 || words.length > 6) return false;
+	if (/\d|@|linkedin|github|developer|desenvolvedor|engineer/i.test(cleaned)) return false;
+	return words.every((word) => /^\p{L}[\p{L}'-]*$/u.test(word));
+}
+
+function isSectionHeader(lines: string[], index: number): boolean {
+	const line = lines[index] ?? '';
+	const trimmed = line.trim();
+	if (!trimmed || trimmed.length > 100) return false;
+	const cleaned = normalizeHeader(trimmed);
+	if (!cleaned) return false;
+	if (classifySection(cleaned) !== 'unknown') return true;
+	if (looksLikePersonName(trimmed, index)) return false;
+	if (index < 3) return false;
+	const previousBlank = index === 0 || !lines[index - 1]?.trim();
+	const nextHasContent = Boolean(lines[index + 1]?.trim());
+	const short = cleaned.split(/\s+/).length <= 5;
+	const allCaps = cleaned === cleaned.toUpperCase() && /\p{L}/u.test(cleaned);
+	const colonHeading = trimmed.endsWith(':');
+	return previousBlank && nextHasContent && short && (allCaps || colonHeading);
+}
+
 export function detectSections(lines: string[]): ResumeSection[] {
 	const sections: ResumeSection[] = [];
-	const headerIndices: { index: number; header: string; type: SectionType }[] = [];
-
-	for (let i = 0; i < lines.length; i++) {
-		const prevLine = i > 0 ? lines[i - 1] : null;
-		const nextLine = i < lines.length - 1 ? lines[i + 1] : null;
-
-		if (isSectionHeader(lines[i], prevLine, nextLine)) {
-			const type = classifySection(lines[i]);
-			headerIndices.push({ index: i, header: lines[i].trim(), type });
-		}
+	const headers: Array<{ index: number; header: string; type: SectionType }> = [];
+	for (let index = 0; index < lines.length; index++) {
+		if (!isSectionHeader(lines, index)) continue;
+		headers.push({ index, header: lines[index].trim(), type: classifySection(lines[index]) });
 	}
-
-	if (headerIndices.length === 0) {
-		return [
-			{
-				type: 'unknown',
-				header: '',
-				content: lines.join('\n'),
-				startLine: 0,
-				endLine: lines.length - 1
-			}
-		];
+	if (headers.length === 0) {
+		return [{ type: 'unknown', header: '', content: lines.join('\n'), startLine: 0, endLine: Math.max(0, lines.length - 1) }];
 	}
-
-	// Content before the first header is normally the contact block.
-	if (headerIndices[0].index > 0) {
-		const contactContent = lines.slice(0, headerIndices[0].index).join('\n').trim();
-		if (contactContent.length > 0) {
-			sections.push({
-				type: 'contact',
-				header: '',
-				content: contactContent,
-				startLine: 0,
-				endLine: headerIndices[0].index - 1
-			});
-		}
+	if (headers[0].index > 0) {
+		const content = lines.slice(0, headers[0].index).join('\n').trim();
+		if (content) sections.push({ type: 'contact', header: '', content, startLine: 0, endLine: headers[0].index - 1 });
 	}
-
-	for (let i = 0; i < headerIndices.length; i++) {
-		const current = headerIndices[i];
-		const nextIndex = i < headerIndices.length - 1 ? headerIndices[i + 1].index : lines.length;
-		const contentLines = lines.slice(current.index + 1, nextIndex);
-		const content = contentLines.join('\n').trim();
-
+	for (let i = 0; i < headers.length; i++) {
+		const current = headers[i];
+		const end = i + 1 < headers.length ? headers[i + 1].index : lines.length;
 		sections.push({
 			type: current.type,
 			header: current.header,
-			content,
+			content: lines.slice(current.index + 1, end).join('\n').trim(),
 			startLine: current.index,
-			endLine: nextIndex - 1
+			endLine: end - 1
 		});
 	}
-
-	return sections;
+	const merged: ResumeSection[] = [];
+	for (const section of sections.filter((section) => section.content || section.type === 'contact')) {
+		const previous = merged[merged.length - 1];
+		if (previous && previous.type === section.type && section.type !== 'unknown') {
+			previous.content = [previous.content, section.content].filter(Boolean).join('\n');
+			previous.endLine = section.endLine;
+			continue;
+		}
+		merged.push(section);
+	}
+	return merged;
 }

--- a/src/lib/engine/parser/text-normalizer.ts
+++ b/src/lib/engine/parser/text-normalizer.ts
@@ -1,0 +1,87 @@
+const LABELS = [
+	'Email',
+	'E-mail',
+	'GitHub',
+	'LinkedIn',
+	'WhatsApp',
+	'Telefone',
+	'Phone',
+	'Mobile',
+	'Celular'
+];
+
+const LIGATURES: Record<string, string> = {
+	'ﬁ': 'fi',
+	'ﬂ': 'fl',
+	'ﬀ': 'ff',
+	'ﬃ': 'ffi',
+	'ﬄ': 'ffl'
+};
+
+export function normalizeTextFragment(value: string): string {
+	let text = value.normalize('NFKC');
+	for (const [from, to] of Object.entries(LIGATURES)) text = text.replaceAll(from, to);
+	return text
+		.replace(/[\u200B-\u200D\u2060\uFEFF]/g, '')
+		.replace(/[‐‑‒]/g, '-')
+		.replace(/[“”]/g, '"')
+		.replace(/[‘’]/g, "'")
+		.replace(/\u00a0/g, ' ')
+		.replace(/[ \t]+/g, ' ')
+		.trim();
+}
+
+export function normalizeLines(lines: string[]): string[] {
+	const normalized = lines.map(normalizeTextFragment).filter(Boolean);
+	return repairWrappedTokens(normalized);
+}
+
+function repairWrappedTokens(lines: string[]): string[] {
+	const result: string[] = [];
+	for (const line of lines) {
+		const previous = result[result.length - 1];
+		if (
+			previous &&
+			/[A-Za-zÀ-ÿ0-9]-$/.test(previous) &&
+			/^[a-zà-ÿ]/.test(line) &&
+			!/@|https?:|www\./i.test(previous)
+		) {
+			result[result.length - 1] = previous.slice(0, -1) + line;
+			continue;
+		}
+		result.push(line);
+	}
+	return result;
+}
+
+export function normalizeContactText(lines: string[]): string {
+	let text = normalizeLines(lines).join(' | ');
+	const labels = LABELS.join('|').replace('-', '\\-');
+	text = text.replace(new RegExp(`(?<=[A-Za-z0-9._%+@/-])(?=(?:${labels})\\s*:?)`, 'gi'), ' | ');
+	text = text.replace(/\s*\|\s*/g, ' | ');
+	return text;
+}
+
+export function detectLanguage(text: string): 'pt-BR' | 'en' {
+	const normalized = text.toLocaleLowerCase('pt-BR');
+	const pt = (normalized.match(/\b(?:experiência|formação|habilidades|competências|desenvolvimento|atuação|curso|presente|conclusão|dados|projetos)\b/g) || []).length;
+	const en = (normalized.match(/\b(?:experience|education|skills|development|present|summary|projects|degree|responsibilities|professional)\b/g) || []).length;
+	return pt > en ? 'pt-BR' : 'en';
+}
+
+export function textQualityScore(text: string, lines: string[]): number {
+	if (!text.trim()) return 0;
+	const chars = text.length;
+	const words = text.split(/\s+/).filter(Boolean).length;
+	const replacement = (text.match(/�/g) || []).length;
+	const controls = (text.match(/[\u0000-\u0008\u000B\u000C\u000E-\u001F]/g) || []).length;
+	const alphaNumeric = (text.match(/[\p{L}\p{N}]/gu) || []).length;
+	const readableRatio = alphaNumeric / Math.max(1, chars);
+	let score = 100;
+	if (chars < 120) score -= 45;
+	if (words < 25) score -= 30;
+	if (lines.length < 6) score -= 20;
+	score -= Math.min(30, replacement * 5 + controls * 3);
+	if (readableRatio < 0.45) score -= 25;
+	return Math.max(0, Math.min(100, Math.round(score)));
+}

--- a/src/lib/engine/parser/types.ts
+++ b/src/lib/engine/parser/types.ts
@@ -90,6 +90,9 @@ export interface ParsedResume {
 		hasMultipleColumns: boolean;
 		hasTables: boolean;
 		hasImages: boolean;
+		extractionMethod: 'text-layer' | 'ocr' | 'docx' | 'pasted-text';
+		extractionQuality: number;
+		language: 'pt-BR' | 'en';
 	};
 }
 

--- a/src/lib/engine/scorer/education-scorer.ts
+++ b/src/lib/engine/scorer/education-scorer.ts
@@ -3,123 +3,57 @@ interface EducationScore {
 	notes: string[];
 }
 
-const DEGREE_LEVELS: Record<string, number> = {
-	phd: 5,
-	'ph.d': 5,
-	doctor: 5,
-	doctorate: 5,
-	master: 4,
-	"master's": 4,
-	mba: 4,
-	ms: 4,
-	'm.s': 4,
-	ma: 4,
-	'm.a': 4,
-	'm.b.a': 4,
-	bachelor: 3,
-	"bachelor's": 3,
-	bs: 3,
-	'b.s': 3,
-	ba: 3,
-	'b.a': 3,
-	'b.eng': 3,
-	associate: 2,
-	"associate's": 2,
-	as: 2,
-	'a.s': 2,
-	aa: 2,
-	'a.a': 2,
-	diploma: 1,
-	certificate: 1,
-	certification: 1
-};
+const DEGREE_PATTERNS: Array<{ label: string; level: number; pattern: RegExp }> = [
+	{ label: 'doctorate', level: 5, pattern: /\b(?:ph\.?d\.?|doctorate|doctor|doutorado)\b/i },
+	{ label: 'master', level: 4, pattern: /\b(?:master'?s?|mestrado|mba|m\.?s\.?|m\.?b\.?a\.?)\b/i },
+	{ label: 'bachelor', level: 3, pattern: /\b(?:bachelor'?s?|bacharelado|licenciatura|b\.?s\.?|b\.?a\.?|b\.?eng\.?)\b/i },
+	{ label: 'associate/technology', level: 2, pattern: /\b(?:associate'?s?|tecnologia|tecnologo|tecnólogo|a\.?s\.?|a\.?a\.?)\b/i },
+	{ label: 'technical/diploma', level: 1, pattern: /\b(?:technical degree|ensino tecnico|ensino técnico|curso tecnico|curso técnico|diploma|certificate|certification|certificado)\b/i }
+];
 
-// scores education section: degree, institution, dates, GPA, honors
-export function scoreEducation(educationText: string): EducationScore {
-	if (!educationText || educationText.trim().length === 0) {
-		return {
-			score: 20,
-			notes: ['no education section found. most positions require at least a degree listing.']
-		};
+export function scoreEducation(educationText: string, locale: 'pt-BR' | 'en' = 'en'): EducationScore {
+	if (!educationText?.trim()) {
+		return { score: 0, notes: [locale === 'pt-BR' ? 'nenhuma formação acadêmica foi detectada' : 'no education section found'] };
 	}
 
 	const notes: string[] = [];
 	let score = 0;
-	const lowerText = educationText.toLowerCase();
-
-	// check for degree mention
-	let highestDegree = 0;
 	let degreeFound = '';
-	for (const [degree, level] of Object.entries(DEGREE_LEVELS)) {
-		if (lowerText.includes(degree) && level > highestDegree) {
-			highestDegree = level;
-			degreeFound = degree;
+	let highestLevel = 0;
+	for (const degree of DEGREE_PATTERNS) {
+		if (degree.pattern.test(educationText) && degree.level > highestLevel) {
+			highestLevel = degree.level;
+			degreeFound = degree.label;
 		}
 	}
-
-	if (highestDegree > 0) {
+	if (degreeFound) {
 		score += 30;
-		notes.push(`degree detected: ${degreeFound}`);
+		notes.push(locale === 'pt-BR' ? `nível de formação detectado: ${degreeFound}` : `degree level detected: ${degreeFound}`);
 	} else {
-		notes.push('no clear degree type found. ensure your degree is explicitly stated.');
+		notes.push(locale === 'pt-BR' ? 'tipo de formação não identificado claramente' : 'no clear degree type found');
 	}
 
-	// check for institution name (heuristic: capitalized multi-word phrase)
-	const hasInstitution = /[A-Z][a-zA-Z]+(?:\s+[A-Z][a-zA-Z]+)+/.test(educationText);
-	if (hasInstitution) {
-		score += 20;
-	} else {
-		notes.push('institution name may not be clearly parseable');
-	}
+	const hasInstitution = /\b(?:university|college|institute|school|faculdade|universidade|instituto|senai|senac|ifsp|usp|unesp|unicamp)\b/i.test(educationText);
+	if (hasInstitution) score += 20;
+	else notes.push(locale === 'pt-BR' ? 'instituição não identificada claramente' : 'institution name may not be clearly parseable');
 
-	// check for dates
-	const hasYear = /\b(19|20)\d{2}\b/.test(educationText);
-	if (hasYear) {
-		score += 15;
-	} else {
-		notes.push('no graduation date found. include your graduation year.');
-	}
+	const hasYear = /\b(?:19|20)\d{2}\b/.test(educationText);
+	if (hasYear) score += 15;
+	else notes.push(locale === 'pt-BR' ? 'ano de conclusão não encontrado' : 'no graduation year found');
 
-	// check for field of study
-	const fieldIndicators = /\b(?:in|of)\s+[A-Z]/;
-	const hasField =
-		fieldIndicators.test(educationText) ||
-		/(?:computer science|engineering|business|mathematics|biology|chemistry|physics|psychology|economics|finance|accounting|marketing|nursing|law|education|design)/i.test(
-			educationText
-		);
+	const hasField = /\b(?:computer science|software engineering|systems analysis and development|railway transportation|analise e desenvolvimento de sistemas|análise e desenvolvimento de sistemas|engenharia de software|ciencia da computacao|ciência da computação|transporte ferroviario|transporte ferroviário|administracao|administração|marketing|finance|financas|finanças|accounting|contabilidade|nursing|enfermagem|law|direito|design)\b/i.test(educationText) || /\b(?:in|of|em)\s+[\p{Lu}]/u.test(educationText);
 	if (hasField) {
-		score += 15;
-		notes.push('field of study detected');
-	} else {
-		notes.push('consider explicitly stating your field of study');
-	}
+		score += 20;
+		notes.push(locale === 'pt-BR' ? 'área de estudo detectada' : 'field of study detected');
+	} else notes.push(locale === 'pt-BR' ? 'área de estudo pouco explícita' : 'field of study is not explicit');
 
-	// check for GPA
-	const hasGPA = /\bgpa\b/i.test(educationText) || /\b[34]\.\d{1,2}\s*\/?\s*4/i.test(educationText);
+	const hasGPA = /\b(?:gpa|media|média)\b/i.test(educationText) || /\b[34][.,]\d{1,2}\s*\/?\s*4\b/i.test(educationText);
 	if (hasGPA) {
-		score += 10;
-		notes.push('GPA listed');
-		// check if GPA is strong
-		const gpaMatch = educationText.match(/(\d\.\d{1,2})/);
-		if (gpaMatch) {
-			const gpa = parseFloat(gpaMatch[1]);
-			if (gpa >= 3.5) notes.push(`strong GPA (${gpa})`);
-			else if (gpa < 3.0) notes.push(`consider removing GPA below 3.0 unless required`);
-		}
+		score += 5;
+		notes.push(locale === 'pt-BR' ? 'média acadêmica informada' : 'GPA listed');
 	}
+	const hasHonors = /\b(?:cum laude|magna cum laude|summa cum laude|dean'?s? list|honors?|distinction|honras?|destaque academico|destaque acadêmico)\b/i.test(educationText);
+	if (hasHonors) score += 10;
 
-	// check for honors
-	const hasHonors =
-		/\b(cum laude|magna cum laude|summa cum laude|dean'?s?\s*list|honors?|distinction)\b/i.test(
-			educationText
-		);
-	if (hasHonors) {
-		score += 10;
-		notes.push('academic honors detected');
-	}
-
-	return {
-		score: Math.min(100, score),
-		notes
-	};
+	return { score: Math.min(100, score), notes };
 }

--- a/src/lib/engine/scorer/engine.ts
+++ b/src/lib/engine/scorer/engine.ts
@@ -1,3 +1,4 @@
+import { parseResumeText } from '$engine/parser';
 import type { ATSProfile, ScoringInput, ScoreResult, ScoreBreakdown } from './types';
 import { ALL_PROFILES } from './profiles';
 import { scoreFormatting } from './format-scorer';
@@ -5,48 +6,147 @@ import { scoreSections } from './section-scorer';
 import { scoreExperience } from './experience-scorer';
 import { scoreEducation } from './education-scorer';
 import { matchKeywords } from './keyword-matcher';
+import { scoreGupyAlignment } from './gupy-alignment';
 
-// scores a resume against all 6 ATS profiles. deterministic: same input = same output
 export function scoreResume(input: ScoringInput): ScoreResult[] {
-	return ALL_PROFILES.map((profile) => scoreAgainstProfile(input, profile));
+	const enriched = enrichStructuredInput(input);
+	return ALL_PROFILES.map((profile) => scoreAgainstProfile(enriched, profile));
 }
 
-// scores a resume against a single ATS profile
-export function scoreAgainstProfile(input: ScoringInput, profile: ATSProfile): ScoreResult {
-	const breakdown = computeBreakdown(input, profile);
-	const weightedScore = computeWeightedScore(breakdown, profile);
+function enrichStructuredInput(input: ScoringInput): ScoringInput {
+	if (input.experienceEntries?.length && input.educationEntries?.length) return input;
+	const parsed = parseResumeText(input.resumeText).resume;
+	if (!parsed) return input;
+	return {
+		...input,
+		experienceEntries:
+			input.experienceEntries ??
+			parsed.experience.map((entry) => ({
+				title: entry.title,
+				company: entry.company,
+				start: entry.dates.start,
+				end: entry.dates.end,
+				isCurrent: entry.dates.isCurrent,
+				text: entry.rawText
+			})),
+		educationEntries:
+			input.educationEntries ??
+			parsed.education.map((entry) => ({
+				degree: entry.degree,
+				field: entry.field,
+				institution: entry.institution,
+				text: entry.rawText
+			}))
+	};
+}
 
-	// apply quirk penalties/bonuses
-	const quirkAdjustment = computeQuirkAdjustment(input, profile);
+export function scoreAgainstProfile(input: ScoringInput, profile: ATSProfile): ScoreResult {
+	const normalizedInput = { ...input, locale: input.locale ?? detectLocale(input.resumeText) };
+	const breakdown = computeBreakdown(normalizedInput, profile);
+	const weightedScore = computeWeightedScore(
+		breakdown,
+		profile,
+		Boolean(input.jobDescription?.trim())
+	);
+	const quirkAdjustment = computeQuirkAdjustment(normalizedInput, profile);
+	const confidencePenalty =
+		input.extractionQuality !== undefined && input.extractionQuality < 60
+			? Math.min(12, (60 - input.extractionQuality) * 0.25)
+			: 0;
 	const overallScore = Math.max(
 		0,
-		Math.min(100, Math.round(weightedScore + quirkAdjustment.totalAdjustment))
+		Math.min(
+			100,
+			Math.round(weightedScore + quirkAdjustment.totalAdjustment - confidencePenalty)
+		)
 	);
-
-	const suggestions = generateSuggestions(breakdown, profile, quirkAdjustment.messages);
-
 	return {
 		system: profile.name,
 		vendor: profile.vendor,
 		overallScore,
 		passesFilter: overallScore >= profile.passingScore,
 		breakdown,
-		suggestions
+		suggestions: generateSuggestions(
+			breakdown,
+			profile,
+			quirkAdjustment.messages,
+			normalizedInput
+		)
 	};
 }
 
-// runs each individual scorer and assembles the breakdown
+function detectLocale(text: string): 'pt-BR' | 'en' {
+	const normalized = text
+		.normalize('NFKD')
+		.replace(/\p{M}/gu, '')
+		.toLowerCase();
+	const pt = (
+		normalized.match(
+			/\b(?:experiencia|formacao|habilidades|competencias|desenvolvimento|atuacao|presente|conclusao)\b/g
+		) || []
+	).length;
+	const en = (
+		normalized.match(
+			/\b(?:experience|education|skills|development|present|summary|degree|responsibilities)\b/g
+		) || []
+	).length;
+	return pt > en ? 'pt-BR' : 'en';
+}
+
 function computeBreakdown(input: ScoringInput, profile: ATSProfile): ScoreBreakdown {
+	const locale = input.locale ?? 'en';
 	const formatting = scoreFormatting(input, profile.parsingStrictness);
 	const sections = scoreSections(input.resumeSections, profile.requiredSections);
-	const experience = scoreExperience(input.experienceBullets);
-	const education = scoreEducation(input.educationText);
+	const experience = scoreExperience(input.experienceBullets, locale);
+	const education = scoreEducation(input.educationText, locale);
+	const hasJob = Boolean(input.jobDescription?.trim());
+
+	if (profile.name === 'Gupy-like' && hasJob) {
+		const alignment = scoreGupyAlignment(input, experience.score, education.score);
+		return {
+			formatting: {
+				score: formatting.score,
+				issues: formatting.issues,
+				details: formatting.details
+			},
+			keywordMatch: {
+				score: alignment.keywordScore,
+				matched: alignment.matchedSkills,
+				missing: alignment.missingSkills,
+				synonymMatched: alignment.preferredMatched
+			},
+			sections: {
+				score: sections.score,
+				present: sections.present,
+				missing: sections.missing
+			},
+			experience: {
+				score: alignment.experienceScore,
+				quantifiedBullets: experience.quantifiedBullets,
+				totalBullets: experience.totalBullets,
+				actionVerbCount: experience.actionVerbCount,
+				highlights: [...experience.highlights, ...alignment.experienceNotes]
+			},
+			education: {
+				score: alignment.educationScore,
+				notes: [...education.notes, ...alignment.educationNotes]
+			}
+		};
+	}
+
+	const keywordCorpus =
+		profile.name === 'Gupy-like'
+			? [
+					input.resumeSkills.join(' '),
+					input.experienceBullets.join(' '),
+					input.educationText
+				].join('\n')
+			: input.resumeText;
 	const keywords = matchKeywords(
-		input.resumeText,
+		keywordCorpus,
 		input.jobDescription || '',
 		profile.keywordStrategy
 	);
-
 	return {
 		formatting: {
 			score: formatting.score,
@@ -71,125 +171,162 @@ function computeBreakdown(input: ScoringInput, profile: ATSProfile): ScoreBreakd
 			actionVerbCount: experience.actionVerbCount,
 			highlights: experience.highlights
 		},
-		education: {
-			score: education.score,
-			notes: education.notes
-		}
+		education: { score: education.score, notes: education.notes }
 	};
 }
 
-// applies profile weights to produce a single 0-100 score
-function computeWeightedScore(breakdown: ScoreBreakdown, profile: ATSProfile): number {
+function computeWeightedScore(
+	breakdown: ScoreBreakdown,
+	profile: ATSProfile,
+	hasJobDescription: boolean
+): number {
 	const { weights } = profile;
-
-	// quantification is derived from the experience scorer's quantification ratio
 	const quantificationScore =
 		breakdown.experience.totalBullets > 0
 			? Math.round(
-					(breakdown.experience.quantifiedBullets / breakdown.experience.totalBullets) * 100
+					(breakdown.experience.quantifiedBullets /
+						breakdown.experience.totalBullets) *
+						100
 				)
 			: 0;
-
-	const weighted =
-		breakdown.formatting.score * weights.formatting +
-		breakdown.keywordMatch.score * weights.keywordMatch +
-		breakdown.sections.score * weights.sectionCompleteness +
-		breakdown.experience.score * weights.experienceRelevance +
-		breakdown.education.score * weights.educationMatch +
-		quantificationScore * weights.quantification;
-
-	return weighted;
+	const components = [
+		{ score: breakdown.formatting.score, weight: weights.formatting },
+		{ score: breakdown.sections.score, weight: weights.sectionCompleteness },
+		{ score: breakdown.experience.score, weight: weights.experienceRelevance },
+		{ score: breakdown.education.score, weight: weights.educationMatch },
+		{ score: quantificationScore, weight: weights.quantification }
+	];
+	if (hasJobDescription) {
+		components.push({
+			score: breakdown.keywordMatch.score,
+			weight: weights.keywordMatch
+		});
+	}
+	const activeWeight = components.reduce(
+		(sum, component) => sum + component.weight,
+		0
+	);
+	return activeWeight > 0
+		? components.reduce(
+				(sum, component) => sum + component.score * component.weight,
+				0
+			) / activeWeight
+		: 0;
 }
 
-// runs quirk checks for a profile. negative penalty = bonus, positive = deduction
 function computeQuirkAdjustment(
 	input: ScoringInput,
 	profile: ATSProfile
 ): { totalAdjustment: number; messages: string[] } {
 	let totalAdjustment = 0;
 	const messages: string[] = [];
-
 	for (const quirk of profile.quirks) {
 		const result = quirk.check(input);
-		if (result) {
-			totalAdjustment -= result.penalty;
-			messages.push(result.message);
-		}
+		if (!result) continue;
+		totalAdjustment -= result.penalty;
+		messages.push(result.message);
 	}
-
 	return { totalAdjustment, messages };
 }
 
-// generates rule-based suggestions. LLM enhancement is layered on top separately
 function generateSuggestions(
 	breakdown: ScoreBreakdown,
 	profile: ATSProfile,
-	quirkMessages: string[]
+	quirkMessages: string[],
+	input: ScoringInput
 ): string[] {
+	const pt = input.locale === 'pt-BR';
 	const suggestions: string[] = [];
-
-	// formatting suggestions
+	if (input.extractionQuality !== undefined && input.extractionQuality < 70) {
+		suggestions.push(
+			pt
+				? `revise os campos extraídos: confiança de leitura em ${input.extractionQuality}%`
+				: `review extracted fields: reading confidence is ${input.extractionQuality}%`
+		);
+	}
 	if (breakdown.formatting.score < 70) {
-		if (breakdown.formatting.issues.some((i) => i.includes('multi-column'))) {
-			suggestions.push('switch to a single-column resume layout for better ATS parsing');
+		if (
+			breakdown.formatting.issues.some((issue) => issue.includes('multi-column'))
+		) {
+			suggestions.push(
+				pt ? 'use um layout de coluna única' : 'switch to a single-column resume layout'
+			);
 		}
-		if (breakdown.formatting.issues.some((i) => i.includes('tables'))) {
-			suggestions.push('remove tables and use plain text formatting instead');
+		if (breakdown.formatting.issues.some((issue) => issue.includes('tables'))) {
+			suggestions.push(
+				pt
+					? 'remova tabelas e use blocos de texto simples'
+					: 'remove tables and use plain text blocks'
+			);
 		}
-		if (breakdown.formatting.issues.some((i) => i.includes('images'))) {
-			suggestions.push('remove images, logos, and graphics from your resume');
+		if (breakdown.formatting.issues.some((issue) => issue.includes('images'))) {
+			suggestions.push(
+				pt
+					? 'remova imagens que contenham informações relevantes'
+					: 'remove images that contain relevant information'
+			);
 		}
 	}
-
-	// keyword suggestions
-	if (breakdown.keywordMatch.score < 60 && breakdown.keywordMatch.missing.length > 0) {
-		const topMissing = breakdown.keywordMatch.missing.slice(0, 5);
+	if (
+		input.jobDescription?.trim() &&
+		breakdown.keywordMatch.score < 60 &&
+		breakdown.keywordMatch.missing.length
+	) {
+		const topMissing = breakdown.keywordMatch.missing.slice(0, 8);
 		suggestions.push(
-			`add these missing keywords from the job description: ${topMissing.join(', ')}`
+			pt
+				? `competências obrigatórias ausentes em relação à vaga: ${topMissing.join(', ')}`
+				: `required skills missing from the job: ${topMissing.join(', ')}`
 		);
-
 		if (profile.keywordStrategy === 'exact') {
 			suggestions.push(
-				`${profile.name} uses exact keyword matching. use the exact terms from the job posting, not synonyms.`
+				pt
+					? `${profile.name} valoriza os termos exatos usados na vaga`
+					: `${profile.name} favors exact terms used in the posting`
 			);
 		}
 	}
-
-	// section suggestions
-	if (breakdown.sections.missing.length > 0) {
+	if (breakdown.sections.missing.length) {
 		suggestions.push(
-			`add missing sections: ${breakdown.sections.missing.join(', ')}. ${profile.name} requires these for proper parsing.`
+			pt
+				? `seções ausentes: ${breakdown.sections.missing.join(', ')}`
+				: `missing sections: ${breakdown.sections.missing.join(', ')}`
 		);
 	}
-
-	// experience suggestions
 	if (breakdown.experience.totalBullets > 0) {
-		const quantRatio = breakdown.experience.quantifiedBullets / breakdown.experience.totalBullets;
+		const quantRatio =
+			breakdown.experience.quantifiedBullets /
+			breakdown.experience.totalBullets;
+		const actionRatio =
+			breakdown.experience.actionVerbCount /
+			breakdown.experience.totalBullets;
 		if (quantRatio < 0.3) {
 			suggestions.push(
-				'add more quantified achievements (numbers, percentages, dollar amounts) to your experience bullets'
+				pt
+					? 'adicione resultados mensuráveis às experiências'
+					: 'add measurable outcomes to experience bullets'
 			);
 		}
-		if (breakdown.experience.actionVerbCount / breakdown.experience.totalBullets < 0.5) {
+		if (actionRatio < 0.5) {
 			suggestions.push(
-				'start more bullet points with strong action verbs (led, developed, increased, delivered)'
+				pt
+					? 'inicie mais tópicos com verbos de ação'
+					: 'start more bullets with action verbs'
 			);
 		}
 	} else {
-		suggestions.push('add detailed experience bullets with measurable achievements');
-	}
-
-	// education suggestions
-	if (breakdown.education.score < 50) {
 		suggestions.push(
-			'ensure your education section includes degree type, institution, and graduation date'
+			pt
+				? 'descreva responsabilidades e entregas nas experiências'
+				: 'describe responsibilities and outcomes in experience entries'
 		);
 	}
-
-	// quirk-specific suggestions (from profile checks)
-	for (const message of quirkMessages) {
-		suggestions.push(message);
+	if (breakdown.education.score < 50) {
+		suggestions.push(
+			pt
+				? 'informe tipo de curso, instituição, área e período'
+				: 'include degree type, institution, field and dates'
+		);
 	}
-
-	return suggestions;
+	return [...new Set([...suggestions, ...quirkMessages])];
 }

--- a/src/lib/engine/scorer/experience-scorer.ts
+++ b/src/lib/engine/scorer/experience-scorer.ts
@@ -1,115 +1,19 @@
-// strong action verbs that ATS systems and recruiters look for in bullet points
-const STRONG_ACTION_VERBS = new Set([
-	'achieved',
-	'accelerated',
-	'administered',
-	'advanced',
-	'analyzed',
-	'architected',
-	'automated',
-	'built',
-	'centralized',
-	'championed',
-	'collaborated',
-	'conceptualized',
-	'consolidated',
-	'contributed',
-	'converted',
-	'coordinated',
-	'created',
-	'decreased',
-	'delivered',
-	'designed',
-	'developed',
-	'directed',
-	'drove',
-	'eliminated',
-	'enabled',
-	'engineered',
-	'established',
-	'exceeded',
-	'executed',
-	'expanded',
-	'facilitated',
-	'founded',
-	'generated',
-	'grew',
-	'headed',
-	'identified',
-	'implemented',
-	'improved',
-	'increased',
-	'influenced',
-	'initiated',
-	'innovated',
-	'integrated',
-	'introduced',
-	'launched',
-	'led',
-	'leveraged',
-	'managed',
-	'maximized',
-	'mentored',
-	'migrated',
-	'modernized',
-	'negotiated',
-	'operated',
-	'optimized',
-	'orchestrated',
-	'organized',
-	'outperformed',
-	'overhauled',
-	'oversaw',
-	'pioneered',
-	'planned',
-	'presented',
-	'prioritized',
-	'produced',
-	'programmed',
-	'proposed',
-	'published',
-	'raised',
-	'recommended',
-	'redesigned',
-	'reduced',
-	'refactored',
-	'reformed',
-	're-engineered',
-	'reorganized',
-	'replaced',
-	'researched',
-	'resolved',
-	'restructured',
-	'revamped',
-	'revolutionized',
-	'scaled',
-	'secured',
-	'simplified',
-	'spearheaded',
-	'standardized',
-	'streamlined',
-	'strengthened',
-	'supervised',
-	'surpassed',
-	'synchronized',
-	'trained',
-	'transformed',
-	'translated',
-	'unified',
-	'upgraded'
+const ACTION_VERBS = new Set([
+	'achieved','accelerated','administered','advanced','analyzed','architected','automated','built','centralized','collaborated','consolidated','coordinated','created','decreased','delivered','designed','developed','directed','drove','enabled','engineered','established','executed','expanded','generated','implemented','improved','increased','integrated','launched','led','managed','mentored','migrated','modernized','operated','optimized','organized','planned','produced','programmed','reduced','refactored','resolved','scaled','secured','simplified','standardized','streamlined','supervised','trained','transformed','upgraded',
+	'alcancei','acelerei','administrei','analisei','arquitetei','automatizei','construí','colaborei','consolidei','coordenei','criei','reduzi','entreguei','projetei','desenvolvi','dirigi','executei','expandi','gerei','implementei','melhorei','aumentei','integrei','lancei','liderei','gerenciei','mentorei','migrei','modernizei','operei','otimizei','organizei','planejei','produzi','programei','refatorei','resolvi','escalei','protegi','simplifiquei','padronizei','supervisionei','treinei','transformei','atualizei',
+	'atuou','construiu','desenvolveu','implementou','criou','organizou','estruturou','processou','gerou','aplicou','executou','operou','manteve','realizou'
 ]);
 
-// patterns indicating quantified achievements (measurable impact boosts ATS scores)
 const QUANTIFICATION_PATTERNS = [
-	/\d+%/, // percentages: "increased by 30%"
-	/\$[\d,]+/, // dollar amounts: "$1.2M"
-	/\d+\s*(?:x|times)/i, // multipliers: "3x improvement"
-	/\d+\+?\s*(?:users?|customers?|clients?|employees?|members?|team)/i, // people counts
-	/\d+\+?\s*(?:projects?|products?|applications?|systems?|services?)/i, // thing counts
-	/(?:top|first|#)\s*\d+/i, // rankings: "top 5%", "#1"
-	/\d+\s*(?:hours?|days?|weeks?|months?|years?)/i, // time durations
-	/\d{1,3}(?:,\d{3})+/, // large numbers: "100,000"
-	/\d+\s*(?:million|billion|thousand|k|m|b)\b/i // scaled numbers
+	/\d+(?:[.,]\d+)?\s*%/,
+	/(?:R\$|US\$|\$|€|£)\s*[\d.,]+/i,
+	/\d+(?:[.,]\d+)?\s*(?:x|vezes)/i,
+	/\d+\+?\s*(?:users?|customers?|clients?|employees?|members?|pessoas?|usuarios?|usuários?|clientes?|colaboradores?|membros?|equipe)/i,
+	/\d+\+?\s*(?:projects?|products?|applications?|systems?|services?|projetos?|produtos?|aplicacoes?|aplicações?|sistemas?|servicos?|serviços?)/i,
+	/(?:top|first|primeiro|#)\s*\d+/i,
+	/\d+\s*(?:hours?|days?|weeks?|months?|years?|horas?|dias?|semanas?|meses?|anos?)/i,
+	/\d{1,3}(?:[.,]\d{3})+/,
+	/\d+(?:[.,]\d+)?\s*(?:million|billion|thousand|milhao|milhão|milhoes|milhões|mil|k|m|b)\b/i
 ];
 
 interface ExperienceScore {
@@ -120,83 +24,51 @@ interface ExperienceScore {
 	highlights: string[];
 }
 
-// scores experience quality: quantified achievements, action verbs, bullet density
-export function scoreExperience(bullets: string[]): ExperienceScore {
+export function scoreExperience(bullets: string[], locale: 'pt-BR' | 'en' = 'en'): ExperienceScore {
 	if (bullets.length === 0) {
 		return {
 			score: 0,
 			quantifiedBullets: 0,
 			totalBullets: 0,
 			actionVerbCount: 0,
-			highlights: ['no experience bullets found']
+			highlights: [locale === 'pt-BR' ? 'nenhum tópico de experiência foi detectado' : 'no experience bullets found']
 		};
 	}
 
-	const highlights: string[] = [];
 	let quantifiedBullets = 0;
 	let actionVerbCount = 0;
-
 	for (const bullet of bullets) {
-		// check for quantification
-		const isQuantified = QUANTIFICATION_PATTERNS.some((p) => p.test(bullet));
-		if (isQuantified) quantifiedBullets++;
-
-		// check for strong action verbs
+		if (QUANTIFICATION_PATTERNS.some((pattern) => pattern.test(bullet))) quantifiedBullets++;
 		const firstWord = bullet
+			.normalize('NFKD')
+			.replace(/\p{M}/gu, '')
 			.trim()
 			.split(/\s+/)[0]
 			?.toLowerCase()
 			.replace(/[^a-z]/g, '');
-		if (firstWord && STRONG_ACTION_VERBS.has(firstWord)) {
-			actionVerbCount++;
-		}
+		if (firstWord && ACTION_VERBS.has(firstWord)) actionVerbCount++;
 	}
 
 	const totalBullets = bullets.length;
-
-	// scoring components
 	const quantificationRatio = quantifiedBullets / totalBullets;
 	const actionVerbRatio = actionVerbCount / totalBullets;
-
-	// ideal: 40%+ quantified, 70%+ action verbs
 	const quantScore = Math.min(1, quantificationRatio / 0.4) * 40;
 	const actionScore = Math.min(1, actionVerbRatio / 0.7) * 30;
+	const bulletCountScore = totalBullets >= 8 ? 30 : totalBullets >= 5 ? 25 : totalBullets >= 3 ? 20 : 10;
+	const highlights: string[] = [];
 
-	// bullet count: penalize too few, reward good amount
-	const bulletCountScore =
-		totalBullets >= 8 ? 30 : totalBullets >= 5 ? 25 : totalBullets >= 3 ? 20 : 10;
-
-	// generate highlights
-	if (quantificationRatio >= 0.4) {
-		highlights.push(
-			`${Math.round(quantificationRatio * 100)}% of bullets are quantified (excellent)`
-		);
-	} else if (quantificationRatio >= 0.2) {
-		highlights.push(
-			`${Math.round(quantificationRatio * 100)}% of bullets are quantified (good, aim for 40%+)`
-		);
+	if (locale === 'pt-BR') {
+		highlights.push(`${Math.round(quantificationRatio * 100)}% dos tópicos têm resultados mensuráveis (meta: 40%+)`);
+		highlights.push(`${Math.round(actionVerbRatio * 100)}% dos tópicos começam com verbos de ação (meta: 70%+)`);
+		if (totalBullets < 5) highlights.push(`apenas ${totalBullets} tópicos de experiência foram detectados`);
 	} else {
-		highlights.push(
-			`only ${Math.round(quantificationRatio * 100)}% of bullets are quantified (add numbers, percentages, dollar amounts)`
-		);
+		highlights.push(`${Math.round(quantificationRatio * 100)}% of bullets are quantified (aim for 40%+)`);
+		highlights.push(`${Math.round(actionVerbRatio * 100)}% of bullets start with action verbs (aim for 70%+)`);
+		if (totalBullets < 5) highlights.push(`only ${totalBullets} experience bullets were detected`);
 	}
-
-	if (actionVerbRatio >= 0.7) {
-		highlights.push('strong use of action verbs');
-	} else {
-		highlights.push(
-			`${Math.round(actionVerbRatio * 100)}% bullets start with action verbs (aim for 70%+)`
-		);
-	}
-
-	if (totalBullets < 5) {
-		highlights.push(`only ${totalBullets} experience bullets. consider adding more detail.`);
-	}
-
-	const score = Math.round(Math.min(100, quantScore + actionScore + bulletCountScore));
 
 	return {
-		score,
+		score: Math.round(Math.min(100, quantScore + actionScore + bulletCountScore)),
 		quantifiedBullets,
 		totalBullets,
 		actionVerbCount,

--- a/src/lib/engine/scorer/format-scorer.ts
+++ b/src/lib/engine/scorer/format-scorer.ts
@@ -6,122 +6,80 @@ interface FormatScore {
 	details: string[];
 }
 
-// scores resume formatting and parseability; strict ATS systems penalize heavily
 export function scoreFormatting(input: ScoringInput, strictness: number): FormatScore {
 	const issues: string[] = [];
 	const details: string[] = [];
 	let deductions = 0;
 
-	// multi-column layout detection
 	if (input.hasMultipleColumns) {
 		const penalty = 15 * strictness;
 		deductions += penalty;
 		issues.push('multi-column layout detected');
-		details.push(
-			`multi-column layouts confuse most ATS parsers. text may be read out of order. (-${Math.round(penalty)})`
-		);
+		details.push(`multi-column reading order may be ambiguous (-${Math.round(penalty)})`);
 	}
-
-	// table detection
 	if (input.hasTables) {
 		const penalty = 12 * strictness;
 		deductions += penalty;
 		issues.push('tables detected in resume');
-		details.push(
-			`tables are poorly supported by many ATS systems. content inside tables may be skipped entirely. (-${Math.round(penalty)})`
-		);
+		details.push(`repeated aligned columns resemble a table (-${Math.round(penalty)})`);
 	}
-
-	// image detection
 	if (input.hasImages) {
 		const penalty = 8 * strictness;
 		deductions += penalty;
 		issues.push('images or graphics detected');
-		details.push(
-			`ATS systems cannot read text embedded in images. logos, icons, and headshots add no value. (-${Math.round(penalty)})`
-		);
+		details.push(`large raster graphics can hide text from parsers (-${Math.round(penalty)})`);
 	}
-
-	// page count
 	if (input.pageCount > 2) {
 		const penalty = 5 * strictness;
 		deductions += penalty;
 		issues.push(`resume is ${input.pageCount} pages`);
-		details.push(
-			`most ATS systems and recruiters prefer 1-2 pages. longer resumes may be truncated. (-${Math.round(penalty)})`
-		);
+		details.push(`content beyond two pages may receive less attention (-${Math.round(penalty)})`);
 	}
-
-	// word count (too short or too long)
 	if (input.wordCount < 150) {
 		const penalty = 10 * strictness;
 		deductions += penalty;
 		issues.push('resume appears very short');
-		details.push(
-			`only ${input.wordCount} words detected. this may indicate parsing issues or insufficient content. (-${Math.round(penalty)})`
-		);
+		details.push(`only ${input.wordCount} words detected (-${Math.round(penalty)})`);
 	} else if (input.wordCount > 1500) {
 		const penalty = 3 * strictness;
 		deductions += penalty;
 		issues.push('resume is quite long');
-		details.push(
-			`${input.wordCount} words is above average. consider trimming to the most relevant content. (-${Math.round(penalty)})`
-		);
+		details.push(`${input.wordCount} words is above the usual range (-${Math.round(penalty)})`);
 	}
 
-	// check for common formatting red flags in text
 	const text = input.resumeText;
-
-	// excessive special characters (often from bad PDF extraction)
-	const specialCharRatio =
-		(text.match(/[^\w\s.,;:!?@#$%&*()\-+=/\\'"]/g) || []).length / text.length;
-	if (specialCharRatio > 0.05) {
+	const unusualCharacters = text.match(/[^\p{L}\p{N}\s.,;:!?@#$%&*()\-+=/\\'"\[\]{}<>•·▪►➤○●–—]/gu) || [];
+	const specialCharRatio = unusualCharacters.length / Math.max(1, text.length);
+	if (specialCharRatio > 0.08) {
 		const penalty = 8 * strictness;
 		deductions += penalty;
 		issues.push('unusual characters detected');
-		details.push(
-			`high density of special characters suggests formatting issues or encoding problems. (-${Math.round(penalty)})`
-		);
+		details.push(`high symbol density may indicate encoding problems (-${Math.round(penalty)})`);
 	}
 
-	// all-caps sections (besides headers)
 	const lines = text.split('\n');
-	const allCapsLines = lines.filter(
-		(l) => l.trim().length > 30 && l === l.toUpperCase() && /[A-Z]/.test(l)
-	);
+	const allCapsLines = lines.filter((line) => {
+		const trimmed = line.trim();
+		return trimmed.length > 30 && trimmed === trimmed.toLocaleUpperCase() && /\p{L}/u.test(trimmed);
+	});
 	if (allCapsLines.length > 3) {
 		const penalty = 3 * strictness;
 		deductions += penalty;
 		issues.push('excessive use of all-caps text');
-		details.push(
-			`${allCapsLines.length} lines are fully uppercase. this can cause parsing confusion. (-${Math.round(penalty)})`
-		);
+		details.push(`${allCapsLines.length} long lines are uppercase (-${Math.round(penalty)})`);
 	}
 
-	// check for consistent bullet point usage
-	const bulletLines = lines.filter((l) => /^\s*[-•*·▪►➤○●]\s/.test(l));
-	const bulletTypes = new Set(bulletLines.map((l) => l.match(/^\s*([-•*·▪►➤○●])/)?.[1]));
+	const bulletLines = lines.filter((line) => /^\s*[-•*·▪►➤○●]\s/.test(line));
+	const bulletTypes = new Set(bulletLines.map((line) => line.match(/^\s*([-•*·▪►➤○●])/)?.[1]));
 	if (bulletTypes.size > 2) {
 		const penalty = 2 * strictness;
 		deductions += penalty;
 		issues.push('inconsistent bullet point styles');
-		details.push(
-			`${bulletTypes.size} different bullet styles detected. use a consistent format. (-${Math.round(penalty)})`
-		);
+		details.push(`${bulletTypes.size} bullet styles detected (-${Math.round(penalty)})`);
 	}
 
-	// positive signals
-	if (!input.hasMultipleColumns && !input.hasTables && !input.hasImages) {
-		details.push('clean single-column layout detected (good)');
-	}
-	if (input.pageCount <= 2) {
-		details.push('appropriate page length (good)');
-	}
-	if (input.wordCount >= 300 && input.wordCount <= 800) {
-		details.push('word count is in the ideal range (good)');
-	}
-
-	const score = Math.max(0, Math.min(100, 100 - deductions));
-
-	return { score, issues, details };
+	if (!input.hasMultipleColumns && !input.hasTables && !input.hasImages) details.push('clean parseable layout detected');
+	if (input.pageCount <= 2) details.push('appropriate page length');
+	if (input.wordCount >= 300 && input.wordCount <= 800) details.push('word count is in the usual range');
+	return { score: Math.max(0, Math.min(100, 100 - deductions)), issues, details };
 }

--- a/src/lib/engine/scorer/gupy-alignment.ts
+++ b/src/lib/engine/scorer/gupy-alignment.ts
@@ -1,0 +1,292 @@
+import { parseJobDescription } from '$engine/job-parser';
+import type { ParsedJobDescription } from '$engine/job-parser/types';
+import type { ScoringEducationEntry, ScoringExperienceEntry, ScoringInput } from './types';
+
+export interface GupyAlignmentResult {
+	keywordScore: number;
+	matchedSkills: string[];
+	missingSkills: string[];
+	preferredMatched: string[];
+	experienceScore: number;
+	experienceNotes: string[];
+	educationScore: number;
+	educationNotes: string[];
+	parsedJob: ParsedJobDescription;
+}
+
+export function scoreGupyAlignment(
+	input: ScoringInput,
+	baseExperienceScore: number,
+	baseEducationScore: number
+): GupyAlignmentResult {
+	const parsedJob = parseJobDescription(input.jobDescription ?? '');
+	const skillResult = matchStructuredSkills(
+		input.resumeSkills,
+		parsedJob.requiredSkills,
+		parsedJob.preferredSkills
+	);
+	const entries = input.experienceEntries ?? [];
+	const educationEntries = input.educationEntries ?? [];
+	const durationMonths = totalNonOverlappingMonths(entries);
+	const requiredMonths =
+		parsedJob.minimumExperienceYears === null
+			? null
+			: parsedJob.minimumExperienceYears * 12;
+	const durationScore =
+		requiredMonths === null
+			? entries.length > 0
+				? 75
+				: 0
+			: Math.round(
+					Math.min(100, (durationMonths / Math.max(1, requiredMonths)) * 100)
+				);
+	const roleScore = scoreRoleAlignment(entries, parsedJob.roleType);
+	const experienceScore = Math.round(
+		baseExperienceScore * 0.45 + durationScore * 0.35 + roleScore * 0.2
+	);
+	const experienceNotes = buildExperienceNotes(
+		input.locale ?? parsedJob.language,
+		durationMonths,
+		requiredMonths,
+		roleScore,
+		parsedJob.experienceLevel
+	);
+	const education = scoreEducationRequirement(
+		educationEntries,
+		parsedJob.educationRequirement,
+		baseEducationScore,
+		input.locale ?? parsedJob.language
+	);
+
+	return {
+		keywordScore: skillResult.score,
+		matchedSkills: skillResult.matched,
+		missingSkills: skillResult.missing,
+		preferredMatched: skillResult.preferredMatched,
+		experienceScore,
+		experienceNotes,
+		educationScore: education.score,
+		educationNotes: education.notes,
+		parsedJob
+	};
+}
+
+function fold(value: string): string {
+	return value
+		.normalize('NFKD')
+		.replace(/\p{M}/gu, '')
+		.toLowerCase()
+		.replace(/[^a-z0-9+#.]+/g, ' ')
+		.replace(/\s+/g, ' ')
+		.trim();
+}
+
+function canonical(value: string): string {
+	const normalized = fold(value);
+	const aliases: Record<string, string> = {
+		golang: 'go',
+		'node js': 'node.js',
+		nodejs: 'node.js',
+		nextjs: 'next.js',
+		'restful api': 'rest api',
+		'restful apis': 'rest api',
+		'rest apis': 'rest api',
+		'apis rest': 'rest api',
+		microsservicos: 'microservices',
+		'microsservicos em go': 'microservices',
+		lideranca: 'leadership',
+		comunicacao: 'communication',
+		'gestao de projetos': 'project management',
+		'metodologias ageis': 'agile'
+	};
+	return aliases[normalized] ?? normalized;
+}
+
+function matchStructuredSkills(
+	resumeSkills: string[],
+	requiredSkills: string[],
+	preferredSkills: string[]
+): { score: number; matched: string[]; missing: string[]; preferredMatched: string[] } {
+	const resume = new Set(resumeSkills.map(canonical));
+	const required = requiredSkills.map((skill) => ({ raw: skill, canonical: canonical(skill) }));
+	const preferred = preferredSkills.map((skill) => ({ raw: skill, canonical: canonical(skill) }));
+	const matched = required
+		.filter((skill) => resume.has(skill.canonical))
+		.map((skill) => skill.raw);
+	const missing = required
+		.filter((skill) => !resume.has(skill.canonical))
+		.map((skill) => skill.raw);
+	const preferredMatched = preferred
+		.filter((skill) => resume.has(skill.canonical))
+		.map((skill) => skill.raw);
+
+	if (required.length === 0 && preferred.length === 0) {
+		return { score: 0, matched: [], missing: [], preferredMatched: [] };
+	}
+	const requiredScore = required.length ? matched.length / required.length : 1;
+	const preferredScore = preferred.length
+		? preferredMatched.length / preferred.length
+		: 1;
+	const requiredWeight = required.length ? 0.8 : 0;
+	const preferredWeight = preferred.length ? 0.2 : 0;
+	const totalWeight = requiredWeight + preferredWeight;
+	return {
+		score: Math.round(
+			((requiredScore * requiredWeight + preferredScore * preferredWeight) /
+				Math.max(0.01, totalWeight)) *
+				100
+		),
+		matched,
+		missing,
+		preferredMatched
+	};
+}
+
+function parseMonth(value: string | null, isEnd = false): number | null {
+	if (!value) return null;
+	const match = value.match(/^(\d{4})(?:-(\d{2}))?$/);
+	if (!match) return null;
+	const year = Number(match[1]);
+	const month = match[2] ? Number(match[2]) - 1 : isEnd ? 11 : 0;
+	return year * 12 + month;
+}
+
+export function totalNonOverlappingMonths(entries: ScoringExperienceEntry[]): number {
+	const now = new Date();
+	const currentMonth = now.getUTCFullYear() * 12 + now.getUTCMonth();
+	const intervals = entries
+		.map((entry) => {
+			const start = parseMonth(entry.start);
+			const end = entry.isCurrent
+				? currentMonth
+				: (parseMonth(entry.end, true) ?? start);
+			return start === null || end === null || end < start
+				? null
+				: ([start, end] as const);
+		})
+		.filter((interval): interval is readonly [number, number] => interval !== null)
+		.sort((a, b) => a[0] - b[0]);
+	if (!intervals.length) return 0;
+	let [start, end] = intervals[0];
+	let total = 0;
+	for (const [nextStart, nextEnd] of intervals.slice(1)) {
+		if (nextStart <= end + 1) {
+			end = Math.max(end, nextEnd);
+		} else {
+			total += end - start + 1;
+			start = nextStart;
+			end = nextEnd;
+		}
+	}
+	return total + (end - start + 1);
+}
+
+function scoreRoleAlignment(entries: ScoringExperienceEntry[], roleType: string): number {
+	if (roleType === 'other') return entries.length ? 75 : 0;
+	const corpus = fold(
+		entries.map((entry) => `${entry.title} ${entry.text}`).join(' ')
+	);
+	const patterns: Record<string, RegExp> = {
+		engineering:
+			/\b(?:developer|engineer|software|programmer|desenvolvedor|engenheiro|programador|api|web|backend|frontend)\b/,
+		sales: /\b(?:sales|account executive|vendas|comercial|promotor|cliente)\b/,
+		marketing: /\b(?:marketing|brand|content|seo|social media|conteudo|midias sociais)\b/,
+		finance: /\b(?:finance|financial|accounting|financeiro|contabilidade|auditoria)\b/,
+		healthcare: /\b(?:nurse|clinical|patient|enfermeiro|clinico|saude)\b/,
+		legal: /\b(?:legal|attorney|compliance|juridico|advogado)\b/,
+		operations:
+			/\b(?:operations|logistics|operacao|logistica|ferroviaria|processos operacionais)\b/,
+		design: /\b(?:design|ux|ui|graphic|criativo)\b/
+	};
+	const pattern = patterns[roleType];
+	if (!pattern) return 60;
+	const matches = corpus.match(new RegExp(pattern.source, 'g'))?.length ?? 0;
+	return Math.min(100, matches * 20);
+}
+
+function buildExperienceNotes(
+	locale: 'pt-BR' | 'en',
+	durationMonths: number,
+	requiredMonths: number | null,
+	roleScore: number,
+	level: string
+): string[] {
+	const years = durationMonths / 12;
+	if (locale === 'pt-BR') {
+		return [
+			`experiência cronológica detectada: ${years.toFixed(1)} ano(s)`,
+			requiredMonths === null
+				? 'a vaga não informa tempo mínimo explícito'
+				: `tempo mínimo da vaga: ${(requiredMonths / 12).toFixed(1)} ano(s)`,
+			`aderência dos cargos e descrições à área: ${roleScore}%`,
+			`senioridade indicada na vaga: ${level}`
+		];
+	}
+	return [
+		`detected chronological experience: ${years.toFixed(1)} year(s)`,
+		requiredMonths === null
+			? 'the job does not state an explicit minimum duration'
+			: `job minimum: ${(requiredMonths / 12).toFixed(1)} year(s)`,
+		`role and description alignment: ${roleScore}%`,
+		`job seniority: ${level}`
+	];
+}
+
+function educationLevel(entries: ScoringEducationEntry[]): number {
+	const corpus = fold(
+		entries.map((entry) => `${entry.degree} ${entry.field} ${entry.text}`).join(' ')
+	);
+	if (/\b(?:doctorate|phd|doutorado)\b/.test(corpus)) return 5;
+	if (/\b(?:master|mba|mestrado|pos graduacao)\b/.test(corpus)) return 4;
+	if (/\b(?:bachelor|bacharelado|graduacao|licenciatura)\b/.test(corpus)) return 3;
+	if (/\b(?:associate|tecnologia|tecnologo)\b/.test(corpus)) return 2;
+	if (/\b(?:technical|tecnico|diploma|certificate)\b/.test(corpus)) return 1;
+	return 0;
+}
+
+function requiredEducationLevel(requirement: string): number {
+	const levels: Record<string, number> = {
+		doctorate: 5,
+		master: 4,
+		bachelor: 3,
+		associate: 2,
+		technical: 1
+	};
+	return levels[requirement] ?? 0;
+}
+
+function scoreEducationRequirement(
+	entries: ScoringEducationEntry[],
+	requirement: string,
+	baseScore: number,
+	locale: 'pt-BR' | 'en'
+): { score: number; notes: string[] } {
+	const current = educationLevel(entries);
+	const required = requiredEducationLevel(requirement);
+	if (required === 0) {
+		return {
+			score: baseScore,
+			notes: [
+				locale === 'pt-BR'
+					? 'a vaga não informa formação mínima explícita'
+					: 'the job does not state an explicit education minimum'
+			]
+		};
+	}
+	const matchScore = current >= required ? 100 : Math.round((current / required) * 100);
+	return {
+		score: Math.round(baseScore * 0.45 + matchScore * 0.55),
+		notes: [
+			locale === 'pt-BR'
+				? `nível de formação detectado ${current}; exigido ${required}`
+				: `detected education level ${current}; required ${required}`,
+			locale === 'pt-BR'
+				? current >= required
+					? 'requisito de formação atendido'
+					: 'requisito de formação parcialmente atendido'
+				: current >= required
+					? 'education requirement met'
+					: 'education requirement partially met'
+		]
+	};
+}

--- a/src/lib/engine/scorer/keyword-matcher.ts
+++ b/src/lib/engine/scorer/keyword-matcher.ts
@@ -9,102 +9,65 @@ interface KeywordMatchResult {
 	synonymMatched: string[];
 }
 
-// matches resume keywords against JD keywords using exact, fuzzy, or semantic strategy
-// strategy reflects real ATS strictness (exact for Workday/Taleo, semantic for Greenhouse/Lever)
 export function matchKeywords(
 	resumeText: string,
 	jobDescription: string,
 	strategy: 'exact' | 'fuzzy' | 'semantic'
 ): KeywordMatchResult {
-	if (!jobDescription || jobDescription.trim().length === 0) {
-		return { score: 100, matched: [], missing: [], synonymMatched: [] };
-	}
+	// Keyword compatibility is undefined without a target job. The scoring engine
+	// removes this dimension and re-normalizes the remaining weights.
+	if (!jobDescription?.trim()) return { score: 0, matched: [], missing: [], synonymMatched: [] };
 
-	// extract tokens from both texts
 	const resumeTokens = tokenize(resumeText);
 	const jdTokens = tokenize(jobDescription);
-
-	const resumeTerms = new Set(resumeTokens.map((t) => t.normalized));
-	const jdTerms = [...new Set(jdTokens.map((t) => t.normalized))];
-
-	// also extract canonical forms for synonym matching
-	const resumeCanonicals = new Set(resumeTokens.map((t) => getCanonical(t.normalized)));
-
+	const resumeTerms = new Set(resumeTokens.map((token) => token.normalized));
+	const jdFrequency = new Map<string, number>();
+	for (const token of jdTokens) jdFrequency.set(token.normalized, (jdFrequency.get(token.normalized) ?? 0) + 1);
+	const jdTerms = [...jdFrequency.keys()].filter((term) => term.length >= 2);
+	const resumeCanonicals = new Set(resumeTokens.map((token) => getCanonical(token.normalized)));
 	const matched: string[] = [];
 	const missing: string[] = [];
 	const synonymMatched: string[] = [];
 
 	for (const jdTerm of jdTerms) {
-		// exact match
 		if (resumeTerms.has(jdTerm)) {
 			matched.push(jdTerm);
 			continue;
 		}
-
 		if (strategy === 'exact') {
 			missing.push(jdTerm);
 			continue;
 		}
-
-		// fuzzy: check synonym database
-		const jdCanonical = getCanonical(jdTerm);
-		if (resumeCanonicals.has(jdCanonical)) {
+		const canonical = getCanonical(jdTerm);
+		if (resumeCanonicals.has(canonical) || [...resumeTerms].some((term) => areSynonyms(term, jdTerm))) {
 			synonymMatched.push(jdTerm);
 			continue;
 		}
-
-		// also check if any resume term is a synonym of the JD term
-		let foundSynonym = false;
-		for (const resumeTerm of resumeTerms) {
-			if (areSynonyms(resumeTerm, jdTerm)) {
+		if (strategy === 'semantic') {
+			const partial = [...resumeTerms].some((term) => {
+				const shortest = Math.min(term.length, jdTerm.length);
+				return shortest >= 4 && (term.includes(jdTerm) || jdTerm.includes(term));
+			});
+			if (partial) {
 				synonymMatched.push(jdTerm);
-				foundSynonym = true;
-				break;
+				continue;
 			}
 		}
-		if (foundSynonym) continue;
-
-		if (strategy === 'fuzzy') {
-			missing.push(jdTerm);
-			continue;
-		}
-
-		// semantic: partial string matching (contains, prefix)
-		let foundPartial = false;
-		for (const resumeTerm of resumeTerms) {
-			// check if either term contains the other
-			if (resumeTerm.includes(jdTerm) || jdTerm.includes(resumeTerm)) {
-				if (Math.min(resumeTerm.length, jdTerm.length) >= 3) {
-					synonymMatched.push(jdTerm);
-					foundPartial = true;
-					break;
-				}
-			}
-		}
-		if (foundPartial) continue;
-
-		// also check the full resume text for multi-word JD terms
-		if (jdTerm.length >= 4 && resumeText.toLowerCase().includes(jdTerm)) {
-			matched.push(jdTerm);
-			continue;
-		}
-
 		missing.push(jdTerm);
 	}
 
-	// calculate score
-	const totalJdTerms = jdTerms.length;
-	if (totalJdTerms === 0) return { score: 100, matched, missing, synonymMatched };
-
-	// exact matches count full, synonym matches count 80%
-	const effectiveMatches = matched.length + synonymMatched.length * 0.8;
-	const score = Math.round(Math.min(100, (effectiveMatches / totalJdTerms) * 100));
-
-	return { score, matched, missing, synonymMatched };
+	const totalWeight = jdTerms.reduce((sum, term) => sum + Math.min(3, jdFrequency.get(term) ?? 1), 0);
+	if (!totalWeight) return { score: 0, matched, missing, synonymMatched };
+	const exactWeight = matched.reduce((sum, term) => sum + Math.min(3, jdFrequency.get(term) ?? 1), 0);
+	const synonymWeight = synonymMatched.reduce((sum, term) => sum + Math.min(3, jdFrequency.get(term) ?? 1) * 0.8, 0);
+	return {
+		score: Math.round(Math.min(100, ((exactWeight + synonymWeight) / totalWeight) * 100)),
+		matched,
+		missing,
+		synonymMatched
+	};
 }
 
-// quick keyword overlap check without synonym matching, used for no-JD scoring mode
 export function quickKeywordScore(resumeText: string, referenceText: string): number {
-	const overlap = computeKeywordOverlap(resumeText, referenceText);
-	return Math.round(overlap.score * 100);
+	return Math.round(computeKeywordOverlap(resumeText, referenceText).score * 100);
 }

--- a/src/lib/engine/scorer/profiles/gupy.ts
+++ b/src/lib/engine/scorer/profiles/gupy.ts
@@ -1,0 +1,39 @@
+import type { ATSProfile } from './types';
+
+// Deterministic simulation based only on Gupy's public candidate guidance.
+// It is not the proprietary Gupy ranking model and is deliberately labeled as such.
+export const GUPY_PROFILE: ATSProfile = {
+	name: 'Gupy-like',
+	vendor: 'Public-guidance simulation',
+	marketShare: 'Brazil-focused benchmark',
+	description: 'prioritizes experiences, skills, education and job alignment while excluding sensitive data',
+	parsingStrictness: 0.85,
+	keywordStrategy: 'fuzzy',
+	weights: {
+		formatting: 0.08,
+		keywordMatch: 0.3,
+		sectionCompleteness: 0.1,
+		experienceRelevance: 0.32,
+		educationMatch: 0.15,
+		quantification: 0.05
+	},
+	requiredSections: ['contact', 'experience', 'education', 'skills'],
+	preferredDateFormats: ['MM/YYYY', 'Mês/YYYY', 'Month YYYY'],
+	quirks: [
+		{
+			id: 'gupy-structured-profile',
+			description: 'public guidance emphasizes complete structured experiences and skills',
+			check: (input) => {
+				const missingCore = ['experience', 'skills'].filter((section) => !input.resumeSections.includes(section));
+				if (!missingCore.length) return null;
+				return {
+					penalty: 8,
+					message: input.locale === 'pt-BR'
+						? `simulação Gupy-like: complete os campos ${missingCore.join(' e ')}`
+						: `Gupy-like simulation: complete ${missingCore.join(' and ')} fields`
+				};
+			}
+		}
+	],
+	passingScore: 70
+};

--- a/src/lib/engine/scorer/profiles/index.ts
+++ b/src/lib/engine/scorer/profiles/index.ts
@@ -4,6 +4,7 @@ export { ICIMS_PROFILE } from './icims';
 export { GREENHOUSE_PROFILE } from './greenhouse';
 export { LEVER_PROFILE } from './lever';
 export { SUCCESSFACTORS_PROFILE } from './successfactors';
+export { GUPY_PROFILE } from './gupy';
 export type { ATSProfile, ATSQuirk } from './types';
 
 import type { ATSProfile } from './types';
@@ -13,9 +14,10 @@ import { ICIMS_PROFILE } from './icims';
 import { GREENHOUSE_PROFILE } from './greenhouse';
 import { LEVER_PROFILE } from './lever';
 import { SUCCESSFACTORS_PROFILE } from './successfactors';
+import { GUPY_PROFILE } from './gupy';
 
-// all ATS profiles ordered by market share/strictness
 export const ALL_PROFILES: ATSProfile[] = [
+	GUPY_PROFILE,
 	WORKDAY_PROFILE,
 	TALEO_PROFILE,
 	SUCCESSFACTORS_PROFILE,
@@ -24,7 +26,6 @@ export const ALL_PROFILES: ATSProfile[] = [
 	LEVER_PROFILE
 ];
 
-// lookup a profile by name (case-insensitive)
 export function getProfile(name: string): ATSProfile | undefined {
-	return ALL_PROFILES.find((p) => p.name.toLowerCase() === name.toLowerCase());
+	return ALL_PROFILES.find((profile) => profile.name.toLowerCase() === name.toLowerCase());
 }

--- a/src/lib/engine/scorer/types.ts
+++ b/src/lib/engine/scorer/types.ts
@@ -1,20 +1,7 @@
 export interface ScoreBreakdown {
-	formatting: {
-		score: number;
-		issues: string[];
-		details: string[];
-	};
-	keywordMatch: {
-		score: number;
-		matched: string[];
-		missing: string[];
-		synonymMatched: string[];
-	};
-	sections: {
-		score: number;
-		present: string[];
-		missing: string[];
-	};
+	formatting: { score: number; issues: string[]; details: string[] };
+	keywordMatch: { score: number; matched: string[]; missing: string[]; synonymMatched: string[] };
+	sections: { score: number; present: string[]; missing: string[] };
 	experience: {
 		score: number;
 		quantifiedBullets: number;
@@ -22,10 +9,7 @@ export interface ScoreBreakdown {
 		actionVerbCount: number;
 		highlights: string[];
 	};
-	education: {
-		score: number;
-		notes: string[];
-	};
+	education: { score: number; notes: string[] };
 }
 
 export interface StructuredSuggestion {
@@ -46,18 +30,38 @@ export interface ScoreResult {
 	suggestions: Suggestion[];
 }
 
+export interface ScoringExperienceEntry {
+	title: string;
+	company: string;
+	start: string | null;
+	end: string | null;
+	isCurrent: boolean;
+	text: string;
+}
+
+export interface ScoringEducationEntry {
+	degree: string;
+	field: string;
+	institution: string;
+	text: string;
+}
+
 export interface ScoringInput {
 	resumeText: string;
 	resumeSkills: string[];
 	resumeSections: string[];
 	experienceBullets: string[];
 	educationText: string;
+	experienceEntries?: ScoringExperienceEntry[];
+	educationEntries?: ScoringEducationEntry[];
 	hasMultipleColumns: boolean;
 	hasTables: boolean;
 	hasImages: boolean;
 	pageCount: number;
 	wordCount: number;
 	jobDescription?: string;
+	locale?: 'pt-BR' | 'en';
+	extractionQuality?: number;
 }
 
 export interface ATSQuirk {

--- a/src/lib/stores/locale.svelte.ts
+++ b/src/lib/stores/locale.svelte.ts
@@ -1,0 +1,145 @@
+import { browser } from '$app/environment';
+
+export type AppLocale = 'pt-BR' | 'en';
+
+type Dictionary = Record<string, string>;
+
+const MESSAGES: Record<AppLocale, Dictionary> = {
+	'pt-BR': {
+		'scanner.badge': 'Analisador de currículo',
+		'scanner.title': 'Analise seu currículo em sistemas ATS',
+		'scanner.subtitle':
+			'Extração local, OCR próprio e pontuação determinística. Nenhuma API de IA é usada.',
+		'scanner.upload': 'Enviar',
+		'scanner.parse': 'Extrair',
+		'scanner.scan': 'Analisar',
+		'scanner.results': 'Resultados',
+		'scanner.pasteToggle': 'Ou cole o texto do currículo',
+		'scanner.pastePlaceholder':
+			'Cole o texto do currículo. Títulos claros como Experiência, Formação e Competências melhoram a estruturação.',
+		'scanner.characters': 'caracteres',
+		'scanner.useText': 'Usar este texto',
+		'scanner.startOver': 'Recomeçar',
+		'scanner.scoring': 'Analisando...',
+		'scanner.rescan': 'Analisar novamente',
+		'scanner.scanResume': 'Analisar currículo',
+		'scanner.parsed': 'Currículo extraído com sucesso',
+		'uploader.aria': 'Enviar currículo em PDF ou DOCX',
+		'uploader.invalid': 'Envie um arquivo PDF ou DOCX.',
+		'uploader.large': 'Arquivo maior que 10 MB.',
+		'uploader.parsing': 'Extraindo currículo...',
+		'uploader.parsingHint': 'Lendo texto, seções, campos e metadados',
+		'uploader.title': 'Arraste seu currículo aqui',
+		'uploader.hint': 'ou toque para procurar. PDF ou DOCX, até 10 MB.',
+		'uploader.privacy':
+			'PDFs com texto são processados no navegador. OCR é enviado somente ao seu próprio servidor.',
+		'jd.show': 'Adicionar descrição da vaga para análise direcionada',
+		'jd.hide': 'Ocultar descrição da vaga',
+		'jd.placeholder': 'Cole a descrição da vaga para comparar requisitos, competências e experiência...',
+		'jd.active': 'Modo direcionado ativo: a pontuação será comparada com esta vaga.',
+		'jd.detected': 'Detectado na vaga',
+		'jd.inResume': 'no currículo',
+		'overview.title': 'Visão geral da extração',
+		'overview.words': 'Palavras',
+		'overview.pages': 'Páginas',
+		'overview.sections': 'Seções',
+		'overview.skills': 'Competências',
+		'overview.positions': 'Experiências',
+		'overview.education': 'Formações',
+		'overview.confidence': 'Confiança',
+		'overview.method': 'Método',
+		'overview.detectedSections': 'Seções detectadas',
+		'overview.extractedSkills': 'Competências extraídas',
+		'overview.contact': 'Contato',
+		'overview.layout': 'Múltiplas colunas',
+		'overview.tables': 'Tabelas',
+		'overview.images': 'Imagens/gráficos',
+		'overview.yes': 'detectado',
+		'overview.no': 'não detectado',
+		'language.label': 'Idioma'
+	},
+	en: {
+		'scanner.badge': 'Resume scanner',
+		'scanner.title': 'Scan your resume across ATS systems',
+		'scanner.subtitle':
+			'Local extraction, self-hosted OCR and deterministic scoring. No AI API is used.',
+		'scanner.upload': 'Upload',
+		'scanner.parse': 'Parse',
+		'scanner.scan': 'Scan',
+		'scanner.results': 'Results',
+		'scanner.pasteToggle': 'Or paste resume text',
+		'scanner.pastePlaceholder':
+			'Paste resume text. Clear headings such as Experience, Education and Skills improve structuring.',
+		'scanner.characters': 'characters',
+		'scanner.useText': 'Use this text',
+		'scanner.startOver': 'Start over',
+		'scanner.scoring': 'Scoring...',
+		'scanner.rescan': 'Re-scan',
+		'scanner.scanResume': 'Scan resume',
+		'scanner.parsed': 'Resume parsed successfully',
+		'uploader.aria': 'Upload a PDF or DOCX resume',
+		'uploader.invalid': 'Upload a PDF or DOCX file.',
+		'uploader.large': 'File is larger than 10 MB.',
+		'uploader.parsing': 'Parsing resume...',
+		'uploader.parsingHint': 'Reading text, sections, fields and metadata',
+		'uploader.title': 'Drag your resume here',
+		'uploader.hint': 'or click to browse. PDF or DOCX, up to 10 MB.',
+		'uploader.privacy':
+			'Text PDFs are processed in the browser. OCR is sent only to your own server.',
+		'jd.show': 'Add job description for targeted scoring',
+		'jd.hide': 'Hide job description',
+		'jd.placeholder': 'Paste the job description to compare requirements, skills and experience...',
+		'jd.active': 'Targeted mode is active: scoring will be compared with this job.',
+		'jd.detected': 'Detected from job',
+		'jd.inResume': 'in resume',
+		'overview.title': 'Extraction overview',
+		'overview.words': 'Words',
+		'overview.pages': 'Pages',
+		'overview.sections': 'Sections',
+		'overview.skills': 'Skills',
+		'overview.positions': 'Positions',
+		'overview.education': 'Education',
+		'overview.confidence': 'Confidence',
+		'overview.method': 'Method',
+		'overview.detectedSections': 'Detected sections',
+		'overview.extractedSkills': 'Extracted skills',
+		'overview.contact': 'Contact',
+		'overview.layout': 'Multiple columns',
+		'overview.tables': 'Tables',
+		'overview.images': 'Images/graphics',
+		'overview.yes': 'detected',
+		'overview.no': 'not detected',
+		'language.label': 'Language'
+	}
+};
+
+class LocaleStore {
+	locale = $state<AppLocale>('pt-BR');
+	initialized = $state(false);
+
+	init() {
+		if (!browser || this.initialized) return;
+		const saved = localStorage.getItem('ats_locale');
+		this.locale = saved === 'en' || saved === 'pt-BR'
+			? saved
+			: navigator.language.toLowerCase().startsWith('pt')
+				? 'pt-BR'
+				: 'en';
+		document.documentElement.lang = this.locale;
+		this.initialized = true;
+	}
+
+	set(locale: AppLocale) {
+		this.locale = locale;
+		if (browser) {
+			localStorage.setItem('ats_locale', locale);
+			document.documentElement.lang = locale;
+		}
+	}
+
+	t(key: string): string {
+		return MESSAGES[this.locale][key] ?? MESSAGES.en[key] ?? key;
+	}
+}
+
+export const localeStore = new LocaleStore();

--- a/src/routes/api/ocr/+server.ts
+++ b/src/routes/api/ocr/+server.ts
@@ -1,0 +1,118 @@
+import { execFile } from 'node:child_process';
+import { mkdtemp, readdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+
+const execFileAsync = promisify(execFile);
+const MAX_FILE_BYTES = 10 * 1024 * 1024;
+const MAX_PAGES = 6;
+const MAX_CONCURRENT_JOBS = 2;
+let activeJobs = 0;
+
+export const prerender = false;
+
+export const POST: RequestHandler = async ({ request }) => {
+	if (process.env.OCR_ENABLED === 'false') {
+		return json({ error: 'OCR is disabled' }, { status: 503 });
+	}
+	if (activeJobs >= MAX_CONCURRENT_JOBS) {
+		return json(
+			{ error: 'OCR capacity is busy. Try again shortly.' },
+			{ status: 429, headers: { 'Retry-After': '10' } }
+		);
+	}
+
+	const contentLength = Number(request.headers.get('content-length') ?? 0);
+	if (contentLength > MAX_FILE_BYTES + 1_000_000) {
+		return json({ error: 'Request is too large' }, { status: 413 });
+	}
+	const form = await request.formData();
+	const file = form.get('file');
+	if (!(file instanceof File)) {
+		return json({ error: 'PDF file is required' }, { status: 400 });
+	}
+	if (file.type !== 'application/pdf' && !file.name.toLowerCase().endsWith('.pdf')) {
+		return json({ error: 'Only PDF files are supported by OCR' }, { status: 415 });
+	}
+	if (file.size === 0 || file.size > MAX_FILE_BYTES) {
+		return json(
+			{ error: `PDF must be between 1 byte and ${MAX_FILE_BYTES} bytes` },
+			{ status: 413 }
+		);
+	}
+
+	activeJobs++;
+	const directory = await mkdtemp(join(tmpdir(), 'ats-ocr-'));
+	try {
+		const input = join(directory, 'input.pdf');
+		await writeFile(input, Buffer.from(await file.arrayBuffer()));
+
+		const { stdout: info } = await execFileAsync('pdfinfo', [input], {
+			timeout: 10_000,
+			maxBuffer: 512 * 1024
+		});
+		const pageCount = Number(info.match(/^Pages:\s+(\d+)/m)?.[1] ?? 0);
+		if (!pageCount) {
+			return json({ error: 'Could not determine PDF page count' }, { status: 422 });
+		}
+		if (pageCount > MAX_PAGES) {
+			return json({ error: `OCR supports up to ${MAX_PAGES} pages` }, { status: 413 });
+		}
+
+		await execFileAsync(
+			'pdftoppm',
+			['-png', '-r', '200', '-f', '1', '-l', String(pageCount), input, join(directory, 'page')],
+			{ timeout: 60_000, maxBuffer: 2 * 1024 * 1024 }
+		);
+
+		const images = (await readdir(directory))
+			.filter((name) => /^page-\d+\.png$/.test(name))
+			.sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
+		if (images.length !== pageCount) {
+			return json({ error: 'Not all PDF pages could be rendered' }, { status: 422 });
+		}
+
+		const pages: string[] = [];
+		for (const image of images) {
+			const { stdout } = await execFileAsync(
+				'tesseract',
+				[
+					join(directory, image),
+					'stdout',
+					'-l',
+					'por+eng',
+					'--oem',
+					'1',
+					'--psm',
+					'3',
+					'quiet'
+				],
+				{ timeout: 45_000, maxBuffer: 8 * 1024 * 1024 }
+			);
+			pages.push(stdout.trim());
+		}
+
+		const text = pages.filter(Boolean).join('\n\n');
+		if (!text) {
+			return json({ error: 'OCR did not find readable text' }, { status: 422 });
+		}
+		return json({
+			text,
+			lines: text
+				.split(/\r?\n/)
+				.map((line) => line.trim())
+				.filter(Boolean),
+			pageCount,
+			method: 'tesseract-por+eng'
+		});
+	} catch (cause) {
+		const message = cause instanceof Error ? cause.message : 'OCR failed';
+		return json({ error: message }, { status: 500 });
+	} finally {
+		activeJobs--;
+		await rm(directory, { recursive: true, force: true });
+	}
+};

--- a/src/routes/scanner/+page.svelte
+++ b/src/routes/scanner/+page.svelte
@@ -1,433 +1,216 @@
 <script lang="ts">
-	import ResumeUploader from '$components/upload/ResumeUploader.svelte';
+	import { onMount } from 'svelte';
 	import JobDescriptionInput from '$components/upload/JobDescriptionInput.svelte';
-	import ScoreDashboard from '$components/scoring/ScoreDashboard.svelte';
-	import ScanningAnimation from '$components/scoring/ScanningAnimation.svelte';
+	import ResumeUploader from '$components/upload/ResumeUploader.svelte';
 	import ResumeStats from '$components/scoring/ResumeStats.svelte';
 	import ScanHistory from '$components/scoring/ScanHistory.svelte';
+	import ScanningAnimation from '$components/scoring/ScanningAnimation.svelte';
+	import ScoreDashboard from '$components/scoring/ScoreDashboard.svelte';
 	import SeoHead from '$components/seo/SeoHead.svelte';
+	import { authStore } from '$stores/auth.svelte';
+	import { localeStore, type AppLocale } from '$stores/locale.svelte';
 	import { resumeStore } from '$stores/resume.svelte';
 	import { scoresStore } from '$stores/scores.svelte';
-	import { authStore } from '$stores/auth.svelte';
 	import type { ScoringInput } from '$engine/scorer/types';
 
-	// load history once the user is allowed to use the scanner. authenticated
-	// users on hosted firebase pull from firestore; self-host installs (auth
-	// disabled) pull from localStorage. scoresStore.loadHistory handles the
-	// branch internally.
-	$effect(() => {
-		if (authStore.disabled || authStore.isAuthenticated) {
-			scoresStore.loadHistory();
-		}
-	});
-
-	// tracks whether results should be visible (scan clicked or loaded from history)
 	let hasScanned = $state(false);
-
-	// component-local buffer for the paste-resume-text textarea
 	let pastedText = $state('');
 
-	// if results are loaded from history, show the dashboard
+	onMount(() => localeStore.init());
+
+	$effect(() => {
+		if (authStore.disabled || authStore.isAuthenticated) scoresStore.loadHistory();
+	});
+
 	$effect(() => {
 		if (scoresStore.hasResults) hasScanned = true;
 	});
 
-	// re-derive readiness from stores so the scan button reacts to changes
-	const canScan = $derived(resumeStore.isReady && !scoresStore.isScoring);
-
-	// triggered when the user uploads a file via ResumeUploader
-	// runs the parser immediately so results are ready when they hit "scan"
-	async function handleFileReady() {
-		if (!resumeStore.file) return;
-
-		resumeStore.startParsing();
-		try {
-			// dynamic import: pdfjs-dist + parser only loaded when user uploads a file
-			const { parseResume } = await import('$engine/parser');
-			const result = await parseResume(resumeStore.file);
-			resumeStore.finishParsing(result);
-		} catch (err) {
-			const msg = err instanceof Error ? err.message : 'failed to parse resume';
-			resumeStore.setError(msg);
-		}
-	}
-
-	// builds the ScoringInput from parsed resume data
-	function buildScoringInput(): ScoringInput {
-		const resume = resumeStore.resume!;
-		return {
-			resumeText: resume.rawText,
-			resumeSkills: resume.skills,
-			resumeSections: resume.sections.map((s) => s.type),
-			experienceBullets: resume.experience.flatMap((e) => e.bullets),
-			// join all education entries into one string for the scorer
-			educationText: resume.education.map((e) => e.rawText).join('\n'),
-			hasMultipleColumns: resume.metadata.hasMultipleColumns,
-			hasTables: resume.metadata.hasTables,
-			hasImages: resume.metadata.hasImages,
-			pageCount: resume.metadata.pageCount,
-			wordCount: resume.metadata.wordCount,
-			// only pass JD if user actually typed something
-			jobDescription: scoresStore.hasJobDescription ? scoresStore.jobDescription : undefined
-		};
-	}
-
-	// runs scoring: LLM-powered (primary) → rule-based (fallback)
-	// startScoring returns a signal so a rescan/reset aborts the prior in-flight request
-	async function handleScan() {
-		if (!resumeStore.isReady) return;
-
-		hasScanned = true;
-		const signal = scoresStore.startScoring();
-
-		try {
-			const resume = resumeStore.resume!;
-			const jd = scoresStore.hasJobDescription ? scoresStore.jobDescription : undefined;
-
-			// dynamic import: LLM client only loaded when scoring starts
-			const { scoreLLM } = await import('$engine/llm');
-			const llmResult = await scoreLLM(resume.rawText, jd, { signal });
-
-			// user cancelled mid-flight (rescan or reset) - leave state to the new handler
-			if (llmResult.status === 'cancelled' || signal.aborted) return;
-
-			if (llmResult.status === 'ok' && llmResult.results.length > 0) {
-				scoresStore.finishScoring(llmResult.results, resumeStore.file?.name);
-				scoresStore.finishAnalyzing(null, false);
-				return;
-			}
-
-			// all LLM providers failed (or rate-limited), fall back to deterministic rule-based scoring
-			const { scoreResume } = await import('$engine/scorer/engine');
-			const input = buildScoringInput();
-			const results = scoreResume(input);
-			if (signal.aborted) return;
-			scoresStore.finishScoring(results, resumeStore.file?.name);
-			// when rate-limited, surface the retry timestamp so the toast can show a countdown
-			const retryAtMs =
-				llmResult.status === 'rate_limited' ? Date.now() + llmResult.retryAfterSec * 1000 : null;
-			scoresStore.finishAnalyzing(null, true, retryAtMs);
-		} catch (err) {
-			if (signal.aborted) return;
-			const msg = err instanceof Error ? err.message : 'scoring failed';
-			scoresStore.setError(msg);
-		}
-	}
-
-	// resets everything so the user can start fresh
-	function handleReset() {
-		resumeStore.reset();
-		scoresStore.reset();
-		hasScanned = false;
-	}
-
-	// auto-parse whenever a new file is set
 	$effect(() => {
 		if (resumeStore.file && !resumeStore.isParsing && !resumeStore.parseResult) {
 			handleFileReady();
 		}
 	});
 
-	// screen-reader-only live announcement of scoring state. polite priority
-	// so it does not interrupt other speech, atomic so the entire string is
-	// re-read when it changes. only a meaningful state transition produces a
-	// new string, so the announcement does not fire on every store tick.
+	const canScan = $derived(resumeStore.isReady && !scoresStore.isScoring);
+	const hasInput = $derived(resumeStore.file !== null || resumeStore.isReady);
+
+	function setLocale(locale: AppLocale) {
+		localeStore.set(locale);
+	}
+
+	async function handleFileReady() {
+		if (!resumeStore.file) return;
+		resumeStore.startParsing();
+		try {
+			const { parseResume } = await import('$engine/parser');
+			resumeStore.finishParsing(await parseResume(resumeStore.file));
+		} catch (error) {
+			resumeStore.setError(error instanceof Error ? error.message : 'failed to parse resume');
+		}
+	}
+
+	function buildScoringInput(): ScoringInput {
+		const resume = resumeStore.resume!;
+		return {
+			resumeText: resume.rawText,
+			resumeSkills: resume.skills,
+			resumeSections: resume.sections.map((section) => section.type),
+			experienceBullets: resume.experience.flatMap((entry) => entry.bullets),
+			educationText: resume.education.map((entry) => entry.rawText).join('\n'),
+			hasMultipleColumns: resume.metadata.hasMultipleColumns,
+			hasTables: resume.metadata.hasTables,
+			hasImages: resume.metadata.hasImages,
+			pageCount: resume.metadata.pageCount,
+			wordCount: resume.metadata.wordCount,
+			jobDescription: scoresStore.hasJobDescription ? scoresStore.jobDescription : undefined,
+			locale: resume.metadata.language,
+			extractionQuality: resume.metadata.extractionQuality
+		};
+	}
+
+	async function handleScan() {
+		if (!resumeStore.isReady) return;
+		hasScanned = true;
+		const signal = scoresStore.startScoring();
+		try {
+			const { scoreResume } = await import('$engine/scorer/engine');
+			const results = scoreResume(buildScoringInput());
+			if (signal.aborted) return;
+			scoresStore.finishScoring(results, resumeStore.file?.name);
+			scoresStore.finishAnalyzing(null, false);
+		} catch (error) {
+			if (!signal.aborted) {
+				scoresStore.setError(error instanceof Error ? error.message : 'scoring failed');
+			}
+		}
+	}
+
+	function usePastedText() {
+		resumeStore.setText(pastedText);
+		scoresStore.reset();
+		hasScanned = false;
+	}
+
+	function handleReset() {
+		resumeStore.reset();
+		scoresStore.reset();
+		pastedText = '';
+		hasScanned = false;
+	}
+
 	const announcement = $derived.by(() => {
-		if (scoresStore.error) return `Scan failed: ${scoresStore.error}`;
-		if (scoresStore.isScoring) return 'Scanning your resume.';
+		const pt = localeStore.locale === 'pt-BR';
+		if (scoresStore.error) return pt ? `Falha na análise: ${scoresStore.error}` : `Scan failed: ${scoresStore.error}`;
+		if (scoresStore.isScoring) return pt ? 'Analisando currículo.' : 'Scanning resume.';
 		if (scoresStore.hasResults && !scoresStore.isFromHistory) {
 			const total = scoresStore.results.length;
 			const passing = scoresStore.passingCount;
-			const avg = scoresStore.averageScore;
-			return `Scan complete. Average score ${avg} out of 100. ${passing} of ${total} ATS systems passed.`;
+			const average = scoresStore.averageScore;
+			return pt
+				? `Análise concluída. Nota média ${average} de 100. ${passing} de ${total} sistemas aprovados.`
+				: `Scan complete. Average score ${average} out of 100. ${passing} of ${total} systems passed.`;
 		}
 		return '';
 	});
 </script>
 
 <SeoHead
-	title="Resume Scanner | ATS Screener"
-	description="Upload your resume and get scored by 6 real ATS platforms. See exactly how Workday, Taleo, iCIMS, Greenhouse, Lever, and SuccessFactors parse your resume."
+	title={localeStore.locale === 'pt-BR' ? 'Analisador ATS determinístico' : 'Deterministic ATS Scanner'}
+	description={localeStore.t('scanner.subtitle')}
 />
 
 <main class="scanner">
-	<!--
-		live region for screen-reader users. role=status implies aria-live=polite
-		and aria-atomic=true. positioned via the global .sr-only utility so it is
-		visually hidden but always present in the accessibility tree.
-	-->
 	<div class="sr-only" role="status">{announcement}</div>
-
-	<!-- subtle background mesh -->
-	<div class="scanner-bg">
-		<div class="bg-orb orb-1"></div>
-		<div class="bg-orb orb-2"></div>
-	</div>
+	<div class="background" aria-hidden="true"></div>
 
 	{#if authStore.loading}
-		<div class="auth-gate">
-			<div class="auth-gate-card">
-				<div class="spinner-lg"></div>
-				<p class="auth-gate-text">Loading...</p>
-			</div>
-		</div>
-		<!-- gate hidden when auth is disabled (self-host: firebase not configured)
-		     so anonymous local visitors land straight on the scanner. -->
+		<div class="gate"><div class="loader"></div></div>
 	{:else if !authStore.disabled && !authStore.isAuthenticated}
-		<div class="auth-gate">
-			<div class="auth-gate-card">
-				<svg
-					width="48"
-					height="48"
-					viewBox="0 0 24 24"
-					fill="none"
-					stroke="var(--accent-cyan)"
-					stroke-width="1.5"
-					style="margin-bottom: 1rem;"
-				>
-					<rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
-					<path d="M7 11V7a5 5 0 0 1 10 0v4" />
-				</svg>
-				<h2 class="auth-gate-title">Sign In to Scan</h2>
-				<p class="auth-gate-text">
-					Create a free account to scan your resume across 6 real ATS platforms. Your scan history
-					will be saved automatically.
-				</p>
-				<a href="/login" class="auth-gate-btn"> Sign In or Create Account </a>
-			</div>
+		<div class="gate card">
+			<h2>{localeStore.locale === 'pt-BR' ? 'Entre para analisar' : 'Sign in to scan'}</h2>
+			<p>{localeStore.locale === 'pt-BR' ? 'Acesse sua conta para salvar o histórico.' : 'Access your account to save scan history.'}</p>
+			<a href="/login">{localeStore.locale === 'pt-BR' ? 'Entrar' : 'Sign in'}</a>
 		</div>
 	{:else}
 		<div class="container">
-			<div class="scanner-header">
-				<div class="page-badge">
-					<svg
-						width="14"
-						height="14"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						stroke-width="2"
-					>
-						<path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
-						<polyline points="14,2 14,8 20,8" />
-						<path d="M12 18v-6" />
-						<path d="M9 15l3 3 3-3" />
-					</svg>
-					<span>Resume Scanner</span>
-				</div>
-				<h1 class="page-title">
-					Scan Your Resume Against
-					<span class="gradient-text">Real ATS Systems</span>
-				</h1>
-				<p class="page-subtitle">
-					Upload your resume and optionally paste a job description for targeted scoring. Files are
-					parsed client-side. Only extracted text is sent for AI analysis.
-				</p>
-
-				<!-- step progress -->
-				<div class="steps-progress">
-					<div class="step-dot" class:active={true} class:done={resumeStore.file !== null}>
-						<span class="step-num">1</span>
-					</div>
-					<div class="step-line" class:done={resumeStore.file !== null}></div>
-					<div
-						class="step-dot"
-						class:active={resumeStore.file !== null}
-						class:done={resumeStore.isReady}
-					>
-						<span class="step-num">2</span>
-					</div>
-					<div class="step-line" class:done={resumeStore.isReady && hasScanned}></div>
-					<div class="step-dot" class:active={hasScanned} class:done={scoresStore.hasResults}>
-						<span class="step-num">3</span>
-					</div>
-					<div class="step-line" class:done={scoresStore.hasResults}></div>
-					<div
-						class="step-dot"
-						class:active={scoresStore.hasResults}
-						class:done={scoresStore.hasResults}
-					>
-						<span class="step-num">4</span>
+			<header class="hero">
+				<div class="topline">
+					<span class="badge">{localeStore.t('scanner.badge')}</span>
+					<div class="language" aria-label={localeStore.t('language.label')}>
+						<button class:active={localeStore.locale === 'pt-BR'} onclick={() => setLocale('pt-BR')}>PT</button>
+						<button class:active={localeStore.locale === 'en'} onclick={() => setLocale('en')}>EN</button>
 					</div>
 				</div>
-				<div class="steps-labels">
-					<span class:active={true}>Upload</span>
-					<span class:active={resumeStore.file !== null}>Parse</span>
-					<span class:active={hasScanned}>Scan</span>
-					<span class:active={scoresStore.hasResults}>Results</span>
+				<h1>{localeStore.t('scanner.title')}</h1>
+				<p>{localeStore.t('scanner.subtitle')}</p>
+				<div class="steps" aria-label="progress">
+					<div class:done={hasInput}><strong>1</strong><span>{localeStore.t('scanner.upload')}</span></div>
+					<div class:done={resumeStore.isReady}><strong>2</strong><span>{localeStore.t('scanner.parse')}</span></div>
+					<div class:done={hasScanned}><strong>3</strong><span>{localeStore.t('scanner.scan')}</span></div>
+					<div class:done={scoresStore.hasResults}><strong>4</strong><span>{localeStore.t('scanner.results')}</span></div>
 				</div>
-			</div>
+			</header>
 
-			<div class="scanner-body">
-				<!-- upload section -->
-				<section class="upload-section">
-					<ResumeUploader />
+			<section class="workspace">
+				<ResumeUploader />
 
-					<!--
-						alternate input: paste resume text directly. closed by default
-						so the file uploader stays the primary affordance. textarea
-						content lives in component-local $state; the "Use this text"
-						button hands it off to resumeStore.setText which runs the
-						same downstream extraction the file path uses.
-					-->
-					<details class="paste-block">
-						<summary class="paste-toggle">Or paste resume text instead</summary>
-						<textarea
-							class="paste-textarea"
-							placeholder="Paste your resume text here. Plain text works best; section headings (Experience, Education, Skills) help us identify structure."
-							bind:value={pastedText}
-							rows="10"
-							aria-label="Paste resume text"
-						></textarea>
-						<div class="paste-actions">
-							<span class="paste-count">{pastedText.length} characters</span>
-							<button
-								type="button"
-								class="paste-btn"
-								disabled={pastedText.trim().length < 50}
-								onclick={() => resumeStore.setText(pastedText)}
-							>
-								Use this text
-							</button>
-						</div>
-					</details>
-
-					<JobDescriptionInput />
-
-					{#if resumeStore.warnings.length > 0}
-						<div class="warnings">
-							{#each resumeStore.warnings as warning}
-								<div class="warning-item">
-									<svg
-										width="16"
-										height="16"
-										viewBox="0 0 24 24"
-										fill="none"
-										stroke="currentColor"
-										stroke-width="2"
-									>
-										<path
-											d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"
-										/>
-										<line x1="12" y1="9" x2="12" y2="13" />
-										<line x1="12" y1="17" x2="12.01" y2="17" />
-									</svg>
-									<span>{warning}</span>
-								</div>
-							{/each}
-						</div>
-					{/if}
-
-					<div class="actions">
-						{#if scoresStore.hasResults}
-							<button class="btn-secondary" onclick={handleReset}>
-								<svg
-									width="16"
-									height="16"
-									viewBox="0 0 24 24"
-									fill="none"
-									stroke="currentColor"
-									stroke-width="2"
-								>
-									<polyline points="1,4 1,10 7,10" />
-									<path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10" />
-								</svg>
-								Start Over
-							</button>
-						{/if}
-
-						<button class="btn-scan" disabled={!canScan} onclick={handleScan}>
-							{#if scoresStore.isScoring}
-								<span class="spinner-inline"></span>
-								Scoring...
-							{:else if scoresStore.hasResults}
-								<svg
-									width="18"
-									height="18"
-									viewBox="0 0 24 24"
-									fill="none"
-									stroke="currentColor"
-									stroke-width="2"
-								>
-									<polyline points="23,4 23,10 17,10" />
-									<path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10" />
-								</svg>
-								Re-Scan
-							{:else}
-								<svg
-									width="18"
-									height="18"
-									viewBox="0 0 24 24"
-									fill="none"
-									stroke="currentColor"
-									stroke-width="2"
-								>
-									<path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
-									<polyline points="14,2 14,8 20,8" />
-									<path d="M12 18v-6" />
-									<path d="M9 15l3 3 3-3" />
-								</svg>
-								Scan Resume
-							{/if}
+				<details class="paste">
+					<summary>{localeStore.t('scanner.pasteToggle')}</summary>
+					<textarea
+						rows="9"
+						bind:value={pastedText}
+						placeholder={localeStore.t('scanner.pastePlaceholder')}
+						aria-label="Paste resume text"
+					></textarea>
+					<div class="paste-actions">
+						<span>{pastedText.length} {localeStore.t('scanner.characters')}</span>
+						<button disabled={pastedText.trim().length < 50} onclick={usePastedText}>
+							{localeStore.t('scanner.useText')}
 						</button>
 					</div>
+				</details>
 
-					{#if scoresStore.error}
-						<div class="error">
-							<svg
-								width="16"
-								height="16"
-								viewBox="0 0 24 24"
-								fill="none"
-								stroke="currentColor"
-								stroke-width="2"
-							>
-								<circle cx="12" cy="12" r="10" />
-								<line x1="15" y1="9" x2="9" y2="15" />
-								<line x1="9" y1="9" x2="15" y2="15" />
-							</svg>
-							<span>{scoresStore.error}</span>
-						</div>
+				<JobDescriptionInput />
+
+				{#if resumeStore.warnings.length > 0}
+					<div class="warnings">
+						{#each resumeStore.warnings as warning}<p>⚠ {warning}</p>{/each}
+					</div>
+				{/if}
+
+				<div class="actions">
+					{#if scoresStore.hasResults}
+						<button class="secondary" onclick={handleReset}>{localeStore.t('scanner.startOver')}</button>
 					{/if}
+					<button class="primary" disabled={!canScan} onclick={handleScan}>
+						{scoresStore.isScoring
+							? localeStore.t('scanner.scoring')
+							: scoresStore.hasResults
+								? localeStore.t('scanner.rescan')
+								: localeStore.t('scanner.scanResume')}
+					</button>
+				</div>
+
+				{#if scoresStore.error}<p class="error">{scoresStore.error}</p>{/if}
+			</section>
+
+			<ScanHistory />
+
+			{#if resumeStore.isReady && !scoresStore.hasResults}
+				<section class="preview">
+					<h2>✓ {localeStore.t('scanner.parsed')}</h2>
+					<ResumeStats />
 				</section>
+			{/if}
 
-				<!-- scan history: collapsible, shows past scans -->
-				<ScanHistory />
+			{#if scoresStore.isScoring}
+				<section class="results"><ScanningAnimation /></section>
+			{/if}
 
-				<!-- resume overview: shows immediately after parsing, before scanning -->
-				{#if resumeStore.isReady && !scoresStore.hasResults}
-					<section class="preview-section">
-						<div class="preview-header">
-							<svg
-								width="16"
-								height="16"
-								viewBox="0 0 24 24"
-								fill="none"
-								stroke="currentColor"
-								stroke-width="2"
-							>
-								<polyline points="20,6 9,17 4,12" />
-							</svg>
-							<span>Resume Parsed Successfully</span>
-						</div>
-						<ResumeStats />
-					</section>
-				{/if}
-
-				<!-- scanning animation: shown while LLM is processing -->
-				{#if scoresStore.isScoring}
-					<section class="results-section">
-						<ScanningAnimation />
-					</section>
-				{/if}
-
-				<!-- results section: fades in smoothly after scanning -->
-				{#if hasScanned && scoresStore.hasResults}
-					<section class="results-section">
-						<ScoreDashboard />
-					</section>
-				{/if}
-			</div>
+			{#if hasScanned && scoresStore.hasResults}
+				<section class="results"><ScoreDashboard /></section>
+			{/if}
 		</div>
 	{/if}
 </main>
@@ -435,486 +218,248 @@
 <style>
 	.scanner {
 		position: relative;
-		min-height: 100dvh;
-		padding: 7rem 2rem 4rem;
+		min-height: 100vh;
+		padding: 5rem 1rem 4rem;
 		overflow: hidden;
 	}
 
-	/* subtle background gradient orbs */
-	.scanner-bg {
-		position: absolute;
+	.background {
+		position: fixed;
 		inset: 0;
-		overflow: hidden;
-		pointer-events: none;
-	}
-
-	.bg-orb {
-		position: absolute;
-		border-radius: 50%;
-		filter: blur(120px);
-	}
-
-	.orb-1 {
-		width: 500px;
-		height: 500px;
-		background: rgba(6, 182, 212, 0.06);
-		top: 5%;
-		right: -10%;
-	}
-
-	.orb-2 {
-		width: 400px;
-		height: 400px;
-		background: rgba(139, 92, 246, 0.04);
-		bottom: 10%;
-		left: -10%;
+		z-index: -1;
+		background:
+			radial-gradient(circle at 15% 10%, rgba(6, 182, 212, 0.08), transparent 34%),
+			radial-gradient(circle at 85% 15%, rgba(124, 58, 237, 0.08), transparent 34%);
 	}
 
 	.container {
-		position: relative;
-		max-width: 1400px;
+		width: min(1080px, 100%);
 		margin: 0 auto;
 	}
 
-	.scanner-header {
-		margin-bottom: 3rem;
+	.hero {
+		margin-bottom: 2rem;
 	}
 
-	.page-badge {
-		display: inline-flex;
-		align-items: center;
-		gap: 0.5rem;
-		padding: 0.4rem 1rem;
-		background: var(--glass-bg);
-		border: 1px solid var(--glass-border);
-		border-radius: var(--radius-full);
-		font-size: 0.8rem;
-		color: var(--text-secondary);
-		margin-bottom: 1.5rem;
-		backdrop-filter: blur(12px);
-	}
-
-	.page-badge svg {
-		color: var(--accent-cyan);
-	}
-
-	.page-title {
-		font-size: clamp(2rem, 5vw, 3.25rem);
-		font-weight: 800;
-		letter-spacing: -0.03em;
-		margin-bottom: 0.75rem;
-		color: var(--text-primary);
-		line-height: 1.15;
-	}
-
-	.gradient-text {
-		background: var(--gradient-primary);
-		-webkit-background-clip: text;
-		-webkit-text-fill-color: transparent;
-		background-clip: text;
-	}
-
-	.page-subtitle {
-		font-size: clamp(1rem, 2vw, 1.15rem);
-		color: var(--text-secondary);
-		line-height: 1.6;
-		max-width: 760px;
-	}
-
-	.upload-section {
-		max-width: 760px;
-	}
-
-	.paste-block {
-		margin-top: 1rem;
-		background: transparent;
-		border: 1px dashed rgba(6, 182, 212, 0.25);
-		border-radius: var(--radius-md, 10px);
-		overflow: hidden;
-		transition:
-			border-color 0.2s ease,
-			background 0.2s ease;
-	}
-
-	.paste-block:hover,
-	.paste-block[open] {
-		border-color: rgba(6, 182, 212, 0.5);
-		background: rgba(6, 182, 212, 0.04);
-	}
-
-	.paste-toggle {
-		padding: 0.75rem 1rem;
-		font-size: 0.85rem;
-		font-weight: 500;
-		color: var(--accent-cyan);
-		cursor: pointer;
-		list-style: none;
+	.topline {
 		display: flex;
 		align-items: center;
-		gap: 0.55rem;
-		transition: color 0.15s ease;
+		justify-content: space-between;
+		gap: 1rem;
 	}
 
-	.paste-toggle::-webkit-details-marker {
-		display: none;
-	}
-
-	.paste-toggle::before {
-		content: '+';
+	.badge {
+		padding: 0.35rem 0.7rem;
+		border: 1px solid rgba(6, 182, 212, 0.25);
+		border-radius: 999px;
+		background: rgba(6, 182, 212, 0.06);
 		color: var(--accent-cyan);
-		font-weight: 600;
-		font-size: 1.05rem;
-		transition: transform 0.2s ease;
+		font-size: 0.75rem;
 	}
 
-	.paste-block[open] .paste-toggle::before {
-		content: '\2212';
+	.language {
+		display: flex;
+		padding: 0.2rem;
+		border: 1px solid var(--glass-border);
+		border-radius: 999px;
+		background: var(--glass-bg);
 	}
 
-	.paste-toggle:hover {
-		color: var(--text-primary);
-		filter: brightness(1.15);
-	}
-
-	.paste-textarea {
-		width: 100%;
-		min-height: 220px;
-		padding: 0.85rem 1rem;
-		background: rgba(0, 0, 0, 0.2);
-		border: none;
-		border-top: 1px solid var(--glass-border);
-		color: var(--text-primary);
-		font-family: var(--font-mono, ui-monospace, 'SF Mono', Menlo, monospace);
-		font-size: 0.85rem;
-		line-height: 1.55;
-		resize: vertical;
-		outline: none;
-	}
-
-	.paste-textarea::placeholder {
+	.language button {
+		padding: 0.35rem 0.65rem;
+		border: 0;
+		border-radius: 999px;
+		background: transparent;
 		color: var(--text-tertiary);
-		opacity: 0.7;
+		cursor: pointer;
+		font-weight: 700;
+	}
+
+	.language button.active {
+		background: var(--accent-cyan);
+		color: #07111f;
+	}
+
+	h1 {
+		max-width: 820px;
+		margin-top: 1.2rem;
+		font-size: clamp(2rem, 6vw, 4rem);
+		line-height: 1.05;
+		color: var(--text-primary);
+	}
+
+	.hero > p {
+		max-width: 760px;
+		margin-top: 1rem;
+		color: var(--text-secondary);
+		line-height: 1.65;
+	}
+
+	.steps {
+		display: grid;
+		grid-template-columns: repeat(4, 1fr);
+		gap: 0.7rem;
+		margin-top: 1.5rem;
+	}
+
+	.steps div {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		padding: 0.65rem;
+		border: 1px solid var(--glass-border);
+		border-radius: var(--radius-md);
+		color: var(--text-tertiary);
+		font-size: 0.75rem;
+	}
+
+	.steps div.done {
+		border-color: rgba(34, 197, 94, 0.35);
+		color: #22c55e;
+	}
+
+	.steps strong {
+		display: grid;
+		place-items: center;
+		width: 23px;
+		height: 23px;
+		border: 1px solid currentColor;
+		border-radius: 50%;
+	}
+
+	.workspace,
+	.preview,
+	.results {
+		margin-top: 1.2rem;
+	}
+
+	.paste {
+		margin-top: 0.8rem;
+		border: 1px solid var(--glass-border);
+		border-radius: var(--radius-lg);
+		background: var(--glass-bg);
+	}
+
+	.paste summary {
+		padding: 0.85rem 1rem;
+		color: var(--accent-cyan);
+		cursor: pointer;
+	}
+
+	.paste textarea {
+		width: calc(100% - 2rem);
+		margin: 0 1rem;
+		padding: 0.9rem;
+		resize: vertical;
+		border: 1px solid var(--glass-border);
+		border-radius: var(--radius-md);
+		background: rgba(0, 0, 0, 0.18);
+		color: var(--text-primary);
+		font: inherit;
+		line-height: 1.5;
 	}
 
 	.paste-actions {
 		display: flex;
+		align-items: center;
 		justify-content: space-between;
-		align-items: center;
-		padding: 0.6rem 1rem;
-		border-top: 1px solid var(--glass-border);
 		gap: 1rem;
-	}
-
-	.paste-count {
-		font-size: 0.78rem;
+		padding: 0.8rem 1rem 1rem;
 		color: var(--text-tertiary);
+		font-size: 0.75rem;
 	}
 
-	.paste-btn {
-		padding: 0.45rem 0.9rem;
-		background: var(--accent-cyan);
-		color: #0a0a1a;
-		border: none;
-		border-radius: var(--radius-md, 8px);
-		font-weight: 600;
-		font-size: 0.85rem;
-		cursor: pointer;
-		transition: opacity 0.15s ease;
-	}
-
-	.paste-btn:disabled {
-		opacity: 0.4;
-		cursor: not-allowed;
-	}
-
-	.paste-btn:not(:disabled):hover {
-		opacity: 0.9;
-	}
-
-	.warnings {
-		margin-top: 1rem;
-		display: flex;
-		flex-direction: column;
-		gap: 0.5rem;
-	}
-
-	.warning-item {
-		display: flex;
-		align-items: center;
-		gap: 0.5rem;
-		font-size: 0.85rem;
-		color: #eab308;
-		padding: 0.6rem 1rem;
-		background: rgba(234, 179, 8, 0.06);
-		border: 1px solid rgba(234, 179, 8, 0.15);
+	.paste-actions button,
+	.actions button,
+	.gate a {
+		padding: 0.65rem 1rem;
+		border: 1px solid var(--glass-border);
 		border-radius: var(--radius-md);
+		cursor: pointer;
+		font-weight: 700;
+		text-decoration: none;
+	}
+
+	.paste-actions button,
+	.actions .primary {
+		border: 0;
+		background: linear-gradient(135deg, var(--accent-cyan), #7c3aed);
+		color: white;
+	}
+
+	button:disabled {
+		cursor: not-allowed;
+		opacity: 0.45;
 	}
 
 	.actions {
 		display: flex;
-		gap: 1rem;
-		margin-top: 2rem;
+		gap: 0.75rem;
+		margin-top: 1rem;
 	}
 
-	.btn-scan {
-		display: inline-flex;
-		align-items: center;
-		gap: 0.6rem;
-		padding: 0.9rem 2.25rem;
-		font-size: 1rem;
-		font-weight: 600;
-		color: var(--color-bg-primary);
-		background: var(--gradient-primary);
-		border: none;
-		border-radius: var(--radius-lg);
-		cursor: pointer;
-		transition:
-			transform 0.25s ease,
-			box-shadow 0.25s ease,
-			opacity 0.2s ease;
-	}
-
-	.btn-scan:hover:not(:disabled) {
-		transform: translateY(-2px);
-		box-shadow:
-			0 0 30px rgba(6, 182, 212, 0.3),
-			0 0 60px rgba(59, 130, 246, 0.15);
-	}
-
-	.btn-scan:disabled {
-		opacity: 0.4;
-		cursor: not-allowed;
-	}
-
-	.btn-secondary {
-		display: inline-flex;
-		align-items: center;
-		gap: 0.5rem;
-		padding: 0.9rem 1.5rem;
-		font-size: 1rem;
-		font-weight: 600;
+	.actions .secondary {
+		background: transparent;
 		color: var(--text-secondary);
-		background: var(--glass-bg);
-		border: 1px solid var(--glass-border);
-		border-radius: var(--radius-lg);
-		cursor: pointer;
-		backdrop-filter: blur(var(--glass-blur));
-		transition:
-			border-color 0.2s ease,
-			color 0.2s ease;
 	}
 
-	.btn-secondary:hover {
-		border-color: var(--accent-cyan);
-		color: var(--text-primary);
-	}
-
-	/* small inline spinner for the scoring state */
-	.spinner-inline {
-		width: 16px;
-		height: 16px;
-		border: 2px solid rgba(0, 0, 0, 0.2);
-		border-top-color: var(--color-bg-primary);
-		border-radius: 50%;
-		animation: spin 0.6s linear infinite;
-	}
-
-	@keyframes spin {
-		to {
-			transform: rotate(360deg);
-		}
+	.warnings,
+	.error {
+		margin-top: 0.9rem;
+		padding: 0.8rem 1rem;
+		border: 1px solid rgba(234, 179, 8, 0.25);
+		border-radius: var(--radius-md);
+		background: rgba(234, 179, 8, 0.05);
+		color: #eab308;
+		font-size: 0.82rem;
 	}
 
 	.error {
-		display: flex;
-		align-items: center;
-		gap: 0.5rem;
-		margin-top: 1rem;
-		color: #ef4444;
-		font-size: 0.9rem;
-		padding: 0.6rem 1rem;
+		border-color: rgba(239, 68, 68, 0.3);
 		background: rgba(239, 68, 68, 0.06);
-		border: 1px solid rgba(239, 68, 68, 0.15);
-		border-radius: var(--radius-md);
+		color: #ef4444;
 	}
 
-	.preview-section {
-		margin-top: 3rem;
-		animation: fadeIn 0.5s cubic-bezier(0.16, 1, 0.3, 1);
-	}
-
-	.preview-header {
-		display: flex;
-		align-items: center;
-		gap: 0.5rem;
-		margin-bottom: 1rem;
+	.preview h2 {
+		margin-bottom: 0.65rem;
+		color: #22c55e;
 		font-size: 0.9rem;
-		font-weight: 600;
-		color: #22c55e;
 	}
 
-	.results-section {
-		margin-top: 4rem;
-		/* fade in smoothly when results appear */
-		animation: fadeIn 0.5s cubic-bezier(0.16, 1, 0.3, 1);
-	}
-
-	@keyframes fadeIn {
-		from {
-			opacity: 0;
-			transform: translateY(16px);
-		}
-		to {
-			opacity: 1;
-			transform: translateY(0);
-		}
-	}
-
-	/* step progress indicator */
-	.steps-progress {
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		gap: 0;
-		margin-top: 2.5rem;
-	}
-
-	.step-dot {
-		width: 32px;
-		height: 32px;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		border-radius: 50%;
-		background: var(--glass-bg);
-		border: 2px solid var(--glass-border);
-		transition:
-			border-color 0.4s ease,
-			background 0.4s ease,
-			box-shadow 0.4s ease;
-	}
-
-	.step-dot.active {
-		border-color: rgba(6, 182, 212, 0.4);
-	}
-
-	.step-dot.done {
-		border-color: rgba(34, 197, 94, 0.5);
-		background: rgba(34, 197, 94, 0.08);
-		box-shadow: 0 0 12px rgba(34, 197, 94, 0.15);
-	}
-
-	.step-num {
-		font-size: 0.7rem;
-		font-weight: 700;
-		color: var(--text-tertiary);
-		transition: color 0.4s ease;
-	}
-
-	.step-dot.active .step-num {
-		color: var(--accent-cyan);
-	}
-
-	.step-dot.done .step-num {
-		color: #22c55e;
-	}
-
-	.step-line {
-		width: 60px;
-		height: 2px;
-		background: var(--glass-border);
-		transition: background 0.6s ease;
-	}
-
-	.step-line.done {
-		background: linear-gradient(90deg, rgba(34, 197, 94, 0.5), rgba(6, 182, 212, 0.3));
-	}
-
-	.steps-labels {
-		display: flex;
-		justify-content: center;
-		gap: 4.5rem;
-		margin-top: 0.5rem;
-	}
-
-	.steps-labels span {
-		font-size: 0.7rem;
-		font-weight: 500;
-		color: var(--text-tertiary);
-		text-transform: uppercase;
-		letter-spacing: 0.06em;
-		transition: color 0.3s ease;
-	}
-
-	.steps-labels span.active {
-		color: var(--text-secondary);
-	}
-
-	/* auth gate */
-	.auth-gate {
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		min-height: 60vh;
-		position: relative;
-	}
-
-	.auth-gate-card {
-		display: flex;
-		flex-direction: column;
-		align-items: center;
+	.gate {
+		display: grid;
+		place-items: center;
+		min-height: 50vh;
 		text-align: center;
-		max-width: 420px;
-		padding: 3rem 2.5rem;
-		background: var(--glass-bg);
+	}
+
+	.gate.card {
+		width: min(480px, 100%);
+		min-height: auto;
+		margin: 10vh auto;
+		padding: 2rem;
 		border: 1px solid var(--glass-border);
 		border-radius: var(--radius-xl);
-		backdrop-filter: blur(20px);
+		background: var(--glass-bg);
 	}
 
-	.auth-gate-title {
-		font-size: 1.5rem;
-		font-weight: 700;
-		color: var(--text-primary);
-		margin-bottom: 0.75rem;
-	}
-
-	.auth-gate-text {
-		font-size: 0.9rem;
+	.gate.card p {
+		margin: 0.75rem 0 1.2rem;
 		color: var(--text-secondary);
-		line-height: 1.6;
-		margin-bottom: 1.5rem;
 	}
 
-	.auth-gate-btn {
-		display: inline-flex;
-		align-items: center;
-		gap: 0.5rem;
-		padding: 0.65rem 1.75rem;
-		font-size: 0.9rem;
-		font-weight: 600;
-		color: var(--color-bg-primary);
-		background: var(--gradient-primary);
-		border-radius: var(--radius-full);
-		text-decoration: none;
-		transition:
-			transform 0.2s ease,
-			box-shadow 0.2s ease;
+	.gate.card a {
+		background: var(--accent-cyan);
+		color: #07111f;
 	}
 
-	.auth-gate-btn:hover {
-		transform: translateY(-1px);
-		box-shadow: 0 0 20px rgba(6, 182, 212, 0.3);
-	}
-
-	.spinner-lg {
-		width: 36px;
-		height: 36px;
-		border: 3px solid var(--glass-border);
+	.loader {
+		width: 42px;
+		height: 42px;
+		border: 3px solid rgba(6, 182, 212, 0.15);
 		border-top-color: var(--accent-cyan);
 		border-radius: 50%;
 		animation: spin 0.8s linear infinite;
-		margin-bottom: 1rem;
 	}
 
 	@keyframes spin {
@@ -923,39 +468,21 @@
 		}
 	}
 
-	@media (max-width: 640px) {
+	@media (max-width: 650px) {
 		.scanner {
-			/* env(safe-area-inset-bottom) adds clearance for iPhone notch/home-bar
-			   so the scan button never sits behind the iOS gesture handle. */
-			padding: 5rem 1.5rem calc(3rem + env(safe-area-inset-bottom, 0px));
+			padding-top: 4rem;
+		}
+
+		.steps {
+			grid-template-columns: repeat(2, 1fr);
 		}
 
 		.actions {
-			flex-direction: column;
+			flex-direction: column-reverse;
 		}
 
-		.step-line {
-			width: 30px;
-		}
-
-		.steps-labels {
-			gap: 2rem;
-		}
-
-		.auth-gate-card {
-			padding: 2rem 1.5rem;
-			margin: 0 1rem;
-		}
-
-		/* reduce paste textarea height on mobile so it does not eat above-the-fold
-		   space. 6 rows (~132px) is enough to see what was pasted. */
-		.paste-textarea {
-			min-height: 132px;
-		}
-
-		/* enlarge small action buttons to meet WCAG 2.5.5 44x44px touch target */
-		.paste-btn {
-			min-height: 44px;
+		.actions button {
+			width: 100%;
 		}
 	}
 </style>

--- a/tests/e2e/deterministic-scanner.spec.ts
+++ b/tests/e2e/deterministic-scanner.spec.ts
@@ -1,0 +1,36 @@
+import { expect, test } from '@playwright/test';
+
+const RESUME = `
+GABRIEL SAMPAIO DE SOUZA
+Desenvolvedor de Software | São Paulo, SP | gabedsam01@gmail.com | +55 (11) 93937-0117
+
+Perfil Profissional
+Desenvolvedor focado em soluções web e automações.
+
+Competências Técnicas
+TypeScript, Python, Golang, React, Next.js, Node.js, FastAPI, PostgreSQL, Docker
+
+Experiência Profissional
+MVP Builders — Desenvolvedor
+Mai/2026 – Presente
+• Desenvolveu aplicações web responsivas.
+• Automatizou 3 rotinas operacionais.
+Stefanini Brasil — Auxiliar de Escritório
+Mai/2023 – Abr/2024
+• Processou dados e estruturou relatórios.
+
+Formação Acadêmica
+Tecnologia em Análise e Desenvolvimento de Sistemas — Faculdade São Francisco de Assis — 2026 – 2030
+`;
+
+test('parses and scores a Portuguese resume without an LLM', async ({ page }) => {
+	await page.goto('/scanner');
+	await page.getByText('Or paste resume text instead').click();
+	await page.getByRole('textbox', { name: 'Paste resume text' }).fill(RESUME);
+	await page.getByRole('button', { name: 'Use this text' }).click();
+	await expect(page.getByText('Resume Parsed Successfully')).toBeVisible();
+	await expect(page.getByText('TypeScript', { exact: true }).first()).toBeVisible();
+	await page.getByRole('button', { name: /Scan Resume|Re-Scan/ }).click();
+	await expect(page.getByText('Gupy-like', { exact: true }).first()).toBeVisible({ timeout: 30_000 });
+	await expect(page.getByText(/Systems Passed/)).toBeVisible();
+});

--- a/tests/unit/integration/pipeline.test.ts
+++ b/tests/unit/integration/pipeline.test.ts
@@ -1,19 +1,10 @@
 /* eslint-disable no-console */
-// console.log statements in this file are intentional. they emit a
-// human-readable trace of scoring breakdowns when the integration suite
-// runs, which is invaluable when tuning the scorer or debugging a
-// regression. quieter alternatives (assert-only) would lose the
-// diagnostic signal that justifies the file existing.
-import { describe, it, expect } from 'vitest';
-import { scoreResume } from '$engine/scorer/engine';
+import { describe, expect, it } from 'vitest';
 import { parseJobDescription } from '$engine/job-parser/extractor';
+import { scoreResume } from '$engine/scorer/engine';
 import type { ScoringInput } from '$engine/scorer/types';
 
-// end-to-end pipeline test: simulates what the scanner page does
-// after parseResume() extracts data from a file
-
 describe('full pipeline: scoring input -> results', () => {
-	// simulates a well-structured software engineer resume
 	const goodResume: ScoringInput = {
 		resumeText: `
 			Software Engineer with 5 years of experience building scalable web applications.
@@ -44,8 +35,26 @@ describe('full pipeline: scoring input -> results', () => {
 			'Architected real-time data pipeline processing 500K events/day',
 			'Mentored 5 junior developers through structured onboarding program'
 		],
+		experienceEntries: [
+			{
+				title: 'Software Engineer',
+				company: 'Example',
+				start: '2019-01',
+				end: '2024-12',
+				isCurrent: false,
+				text: 'Software Engineer building web applications and APIs'
+			}
+		],
 		educationText:
 			'Bachelor of Science in Computer Science, University of Waterloo, 2019, GPA: 3.7/4.0',
+		educationEntries: [
+			{
+				degree: 'Bachelor of Science',
+				field: 'Computer Science',
+				institution: 'University of Waterloo',
+				text: 'Bachelor of Science in Computer Science, University of Waterloo, 2019'
+			}
+		],
 		hasMultipleColumns: false,
 		hasTables: false,
 		hasImages: false,
@@ -53,54 +62,38 @@ describe('full pipeline: scoring input -> results', () => {
 		wordCount: 500
 	};
 
-	it('scores a resume without JD (general mode)', () => {
+	it('scores a resume without a job description without fake keyword points', () => {
 		const results = scoreResume(goodResume);
-
-		// should return 6 results for 6 ATS profiles
-		expect(results).toHaveLength(6);
-
-		// every score should be between 0 and 100
-		for (const r of results) {
-			expect(r.overallScore).toBeGreaterThanOrEqual(0);
-			expect(r.overallScore).toBeLessThanOrEqual(100);
-			expect(r.breakdown).toBeDefined();
-			expect(r.system).toBeTruthy();
-			expect(r.vendor).toBeTruthy();
+		expect(results).toHaveLength(7);
+		expect(results.some((result) => result.system === 'Gupy-like')).toBe(true);
+		for (const result of results) {
+			expect(result.overallScore).toBeGreaterThanOrEqual(0);
+			expect(result.overallScore).toBeLessThanOrEqual(100);
+			expect(result.breakdown.keywordMatch.score).toBe(0);
 		}
-
-		// a good resume should average above 50
-		const avg = results.reduce((s, r) => s + r.overallScore, 0) / results.length;
-		expect(avg).toBeGreaterThan(50);
-
-		console.log('--- general mode scores ---');
-		for (const r of results) {
-			console.log(`  ${r.system} (${r.vendor}): ${r.overallScore} ${r.passesFilter ? '✓' : '✗'}`);
-		}
-		console.log(`  average: ${Math.round(avg)}`);
+		const average = results.reduce((sum, result) => sum + result.overallScore, 0) / results.length;
+		expect(average).toBeGreaterThan(50);
 	});
 
-	it('scores a resume with JD (targeted mode)', () => {
-		const jd =
-			'Looking for a Senior Software Engineer with 5+ years experience in JavaScript, TypeScript, React, Node.js, and AWS. Must have experience with microservices, CI/CD, and team leadership.';
-
-		const results = scoreResume({ ...goodResume, jobDescription: jd });
-
-		expect(results).toHaveLength(6);
-		for (const r of results) {
-			expect(r.overallScore).toBeGreaterThanOrEqual(0);
-			expect(r.overallScore).toBeLessThanOrEqual(100);
-			// with a matching JD, keyword scores should be higher
-			expect(r.breakdown.keywordMatch.matched.length).toBeGreaterThan(0);
+	it('scores a resume against a target job', () => {
+		const job = `
+			Senior Software Engineer
+			Requirements:
+			- 5+ years experience in JavaScript, TypeScript, React, Node.js, AWS and microservices
+			- Bachelor's degree in Computer Science
+			Preferred:
+			- Docker, Kubernetes, PostgreSQL and Redis
+		`;
+		const results = scoreResume({ ...goodResume, jobDescription: job });
+		expect(results).toHaveLength(7);
+		for (const result of results) {
+			expect(result.overallScore).toBeGreaterThanOrEqual(0);
+			expect(result.overallScore).toBeLessThanOrEqual(100);
+			expect(result.breakdown.keywordMatch.matched.length).toBeGreaterThan(0);
 		}
-
-		const avg = results.reduce((s, r) => s + r.overallScore, 0) / results.length;
-		console.log('--- targeted mode scores ---');
-		for (const r of results) {
-			console.log(
-				`  ${r.system}: ${r.overallScore} | keywords: ${r.breakdown.keywordMatch.matched.length} matched, ${r.breakdown.keywordMatch.missing.length} missing`
-			);
-		}
-		console.log(`  average: ${Math.round(avg)}`);
+		const gupy = results.find((result) => result.system === 'Gupy-like')!;
+		expect(gupy.breakdown.keywordMatch.score).toBeGreaterThan(60);
+		expect(gupy.breakdown.experience.score).toBeGreaterThan(60);
 	});
 
 	it('gives lower scores to a weak resume', () => {
@@ -116,115 +109,83 @@ describe('full pipeline: scoring input -> results', () => {
 			pageCount: 4,
 			wordCount: 15
 		};
-
-		const good = scoreResume(goodResume);
-		const bad = scoreResume(weak);
-
-		const goodAvg = good.reduce((s, r) => s + r.overallScore, 0) / good.length;
-		const badAvg = bad.reduce((s, r) => s + r.overallScore, 0) / bad.length;
-
-		expect(goodAvg).toBeGreaterThan(badAvg);
-
-		console.log('--- good vs weak ---');
-		console.log(`  good avg: ${Math.round(goodAvg)}`);
-		console.log(`  weak avg: ${Math.round(badAvg)}`);
-		console.log(`  difference: ${Math.round(goodAvg - badAvg)} points`);
+		const goodAverage = average(scoreResume(goodResume));
+		const weakAverage = average(scoreResume(weak));
+		expect(goodAverage).toBeGreaterThan(weakAverage);
 	});
 
 	it('produces deterministic results', () => {
-		const a = scoreResume(goodResume);
-		const b = scoreResume(goodResume);
-
-		for (let i = 0; i < a.length; i++) {
-			expect(a[i].overallScore).toBe(b[i].overallScore);
-			expect(a[i].passesFilter).toBe(b[i].passesFilter);
-			expect(a[i].breakdown.formatting.score).toBe(b[i].breakdown.formatting.score);
-			expect(a[i].breakdown.keywordMatch.score).toBe(b[i].breakdown.keywordMatch.score);
-		}
+		const first = scoreResume(goodResume);
+		const second = scoreResume(goodResume);
+		expect(first.map((result) => result.overallScore)).toEqual(
+			second.map((result) => result.overallScore)
+		);
 	});
 
-	it('produces different scores per ATS system', () => {
-		const results = scoreResume(goodResume);
-		const scores = results.map((r) => r.overallScore);
-		// not all systems should give the exact same score
-		const unique = new Set(scores);
-		expect(unique.size).toBeGreaterThan(1);
+	it('produces different scores per ATS profile', () => {
+		const scores = scoreResume(goodResume).map((result) => result.overallScore);
+		expect(new Set(scores).size).toBeGreaterThan(1);
 	});
 });
 
 describe('job description parser', () => {
-	it('extracts skills from a tech JD', () => {
-		const jd = `
-			Senior Software Engineer at Google
+	it('extracts English engineering requirements', () => {
+		const parsed = parseJobDescription(`
+			Senior Software Engineer
 			Requirements:
-			- 5+ years experience in JavaScript, TypeScript, React
-			- Experience with Node.js, AWS, Docker, Kubernetes
-			- Bachelor's degree in Computer Science or related field
+			- 5+ years experience in JavaScript, TypeScript, React, Node.js, AWS, Docker and Kubernetes
+			- Bachelor's degree in Computer Science
 			Preferred:
-			- Experience with GraphQL, Redis, PostgreSQL
-			- Agile/Scrum methodology
-		`;
-
-		const parsed = parseJobDescription(jd);
+			- Redis and PostgreSQL
+		`);
 		expect(parsed.extractedSkills.length).toBeGreaterThan(0);
 		expect(parsed.requiredSkills.length).toBeGreaterThan(0);
+		expect(parsed.preferredSkills).toEqual(expect.arrayContaining(['Redis', 'PostgreSQL']));
 		expect(parsed.experienceLevel).toBe('senior');
-		expect(parsed.educationRequirement).toContain('Bachelor');
+		expect(parsed.minimumExperienceYears).toBe(5);
+		expect(parsed.educationRequirement).toBe('bachelor');
 		expect(parsed.roleType).toBe('engineering');
-
-		console.log('--- parsed JD ---');
-		console.log(`  skills: ${parsed.extractedSkills.join(', ')}`);
-		console.log(`  required: ${parsed.requiredSkills.join(', ')}`);
-		console.log(`  preferred: ${parsed.preferredSkills.join(', ')}`);
-		console.log(`  level: ${parsed.experienceLevel}`);
-		console.log(`  education: ${parsed.educationRequirement}`);
-		console.log(`  role: ${parsed.roleType}`);
-		console.log(`  industry: ${parsed.industryContext}`);
+		expect(parsed.language).toBe('en');
 	});
 
-	it('extracts skills from a non-tech JD (nursing)', () => {
-		const jd = `
-			Registered Nurse - ICU
-			Requirements:
-			- Active RN license
-			- 3+ years ICU/Critical Care experience
-			- BLS and ACLS certification required
-			- Bachelor of Science in Nursing (BSN)
-			Preferred:
-			- CCRN certification
-			- Epic EMR experience
-		`;
-
-		const parsed = parseJobDescription(jd);
+	it('extracts Portuguese requirements and desired skills', () => {
+		const parsed = parseJobDescription(`
+			Desenvolvedor Backend Sênior
+			Requisitos obrigatórios:
+			- 4 anos de experiência com TypeScript, Node.js, PostgreSQL e APIs REST
+			- Graduação em Análise e Desenvolvimento de Sistemas
+			Diferenciais:
+			- Docker e Kubernetes
+		`);
+		expect(parsed.requiredSkills).toEqual(
+			expect.arrayContaining(['TypeScript', 'Node.js', 'PostgreSQL'])
+		);
+		expect(parsed.preferredSkills).toEqual(expect.arrayContaining(['Docker', 'Kubernetes']));
+		expect(parsed.minimumExperienceYears).toBe(4);
 		expect(parsed.experienceLevel).toBe('mid');
-		expect(parsed.roleType).toBe('healthcare');
-
-		console.log('--- nursing JD ---');
-		console.log(`  skills: ${parsed.extractedSkills.join(', ')}`);
-		console.log(`  level: ${parsed.experienceLevel}`);
-		console.log(`  role: ${parsed.roleType}`);
-		console.log(`  industry: ${parsed.industryContext}`);
+		expect(parsed.educationRequirement).toBe('bachelor');
+		expect(parsed.roleType).toBe('engineering');
+		expect(parsed.language).toBe('pt-BR');
 	});
 
-	it('extracts skills from a finance JD', () => {
-		const jd = `
+	it('extracts healthcare and finance contexts', () => {
+		const nursing = parseJobDescription(`
+			Registered Nurse - ICU
+			Requirements: 3+ years ICU experience and Bachelor of Science in Nursing
+		`);
+		expect(nursing.experienceLevel).toBe('mid');
+		expect(nursing.roleType).toBe('healthcare');
+
+		const finance = parseJobDescription(`
 			Senior Financial Analyst
-			Requirements:
-			- CPA or CFA preferred
-			- 5+ years in financial analysis or accounting
-			- Advanced Excel, PowerPoint, SAP
-			- MBA or Master's degree in Finance
-		`;
-
-		const parsed = parseJobDescription(jd);
-		expect(parsed.experienceLevel).toBe('senior');
-		expect(parsed.roleType).toBe('finance');
-		expect(parsed.educationRequirement).toContain('Master');
-
-		console.log('--- finance JD ---');
-		console.log(`  skills: ${parsed.extractedSkills.join(', ')}`);
-		console.log(`  level: ${parsed.experienceLevel}`);
-		console.log(`  role: ${parsed.roleType}`);
-		console.log(`  industry: ${parsed.industryContext}`);
+			Requirements: CPA, 5+ years in financial analysis, Excel, SAP and Master's degree
+		`);
+		expect(finance.experienceLevel).toBe('senior');
+		expect(finance.roleType).toBe('finance');
+		expect(finance.educationRequirement).toBe('master');
 	});
 });
+
+function average(results: ReturnType<typeof scoreResume>): number {
+	return results.reduce((sum, result) => sum + result.overallScore, 0) / results.length;
+}

--- a/tests/unit/parser/brazilian-resume.test.ts
+++ b/tests/unit/parser/brazilian-resume.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest';
+import { parseResumeText } from '$engine/parser';
+import { scoreResume } from '$engine/scorer/engine';
+import type { ScoringInput } from '$engine/scorer/types';
+
+const PORTUGUESE_RESUME = `
+GABRIEL SAMPAIO DE SOUZA
+Desenvolvedor de Software | TypeScript • Python • Golang
+São Paulo, SP — Brasil | WhatsApp: +55 (11) 93937-0117 | Email: gabedsam01@gmail.com | GitHub: github.com/gabedsam01 | LinkedIn: linkedin.com/in/gabrielsampaiodesouza
+
+🎯 Perfil Profissional
+Desenvolvedor de Software focado em soluções web, automações e integrações de sistemas.
+
+🛠️ Competências Técnicas
+• Linguagens: TypeScript, Python, Golang, JavaScript.
+• Front-end & Web: TSX, React, React Native, Next.js, HTML5, CSS3, Tailwind CSS.
+• Back-end & APIs: Node.js, Express, FastAPI, RESTful APIs, Microsserviços em Go.
+• Automação & Web Scraping: Python, Selenium, Playwright, BeautifulSoup.
+• Bancos de Dados & Ferramentas: PostgreSQL, MySQL, MongoDB, Git, GitHub, Docker, Postman.
+
+💼 Experiência Profissional
+MVP Builders — Desenvolvedor
+Mai/2026 – Presente (Remoto)
+• Desenvolveu aplicações web responsivas.
+• Construiu automações de processos e integrações via API.
+Stefanini Brasil — Auxiliar de Escritório
+Mai/2023 – Abr/2024
+• Processou e organizou alto volume de dados operacionais.
+Outras Experiências Profissionais
+• Grupo Pro Security — Auxiliar de Serviços Gerais (Ago/2025 – Mai/2026) — Padronizou rotinas operacionais.
+• Contax S.A. — Promotor de Vendas (Jun/2025 – Jul/2025) — Operou sistemas de cadastro.
+• MRS Logística / SENAI — Aprendiz / Auxiliar de Operação Ferroviária (Set/2024 – Jun/2025) — Executou rotinas técnicas.
+
+🎓 Formação Acadêmica
+• Tecnologia em Análise e Desenvolvimento de Sistemas (ADS) Faculdade São Francisco de Assis | Previsão de Conclusão: 2028 – 2030
+• Ensino Técnico em Transporte Ferroviário SENAI São Paulo | Concluído (Set/2024 – Jun/2025)
+
+🚀 Repositórios e Projetos Técnicos
+• Aplicações Web em TypeScript/TSX: interfaces integradas a APIs REST.
+• Automações e Scripts em Python/Golang: web scraping e processamento de dados.
+`;
+
+const ENGLISH_RESUME = `
+GABRIEL SAMPAIO DE SOUZA
+Software Developer | TypeScript • Python • Golang
+São Paulo, SP — Brazil | WhatsApp: +55 (11) 93937-0117 | Email: gabedsam01@gmail.com | GitHub: github.com/gabedsam01 | LinkedIn: linkedin.com/in/gabrielsampaiodesouza
+
+🎯 Professional Summary
+Software Developer specializing in web solutions, automation, and system integrations.
+
+🛠️ Technical Skills
+• Languages: TypeScript, Python, Golang, JavaScript.
+• Front-end & Web: TSX, React, React Native, Next.js, HTML5, CSS3, Tailwind CSS.
+• Back-end & APIs: Node.js, Express, FastAPI, RESTful APIs, Go Microservices.
+• Automation & Web Scraping: Selenium, Playwright, BeautifulSoup.
+• Databases & Tools: PostgreSQL, MySQL, MongoDB, Git, GitHub, Docker, Postman.
+
+💼 Professional Experience
+MVP Builders — Software Developer
+May 2026 – Present
+• Developed responsive web applications.
+• Built process automation and API integrations.
+Stefanini Brasil — Administrative Assistant
+May 2023 – Apr 2024
+• Processed high-volume operational datasets.
+Additional Experience
+• Grupo Pro Security — General Operations Assistant (Aug 2025 – May 2026) — Standardized operational routines.
+• Contax S.A. — Sales Representative (Jun 2025 – Jul 2025) — Operated registration systems.
+• MRS Logística / SENAI — Railway Operations Apprentice (Sep 2024 – Jun 2025) — Executed technical operations.
+
+🎓 Education
+• Associate Degree in Systems Analysis and Development Faculdade São Francisco de Assis | Expected Graduation: 2028 – 2030
+• Technical Degree in Railway Transportation SENAI São Paulo | Completed (Sep 2024 – Jun 2025)
+
+🚀 Projects & Technical Repositories
+• Web Applications (TypeScript / TSX): interfaces integrated with REST APIs.
+• Automation & Scripting (Python / Golang): web scraping and data processing.
+`;
+
+function assertCoreExtraction(text: string, locale: 'pt-BR' | 'en') {
+	const result = parseResumeText(text);
+	expect(result.success).toBe(true);
+	const resume = result.resume!;
+	expect(resume.metadata.language).toBe(locale);
+	expect(resume.contact.email).toBe('gabedsam01@gmail.com');
+	expect(resume.contact.phone?.replace(/\D/g, '')).toContain('11939370117');
+	expect(resume.sections.map((section) => section.type)).toEqual(expect.arrayContaining(['contact', 'summary', 'skills', 'experience', 'education', 'projects']));
+	expect(resume.experience.length).toBeGreaterThanOrEqual(5);
+	expect(resume.education.length).toBe(2);
+	expect(resume.skills).toEqual(expect.arrayContaining(['TypeScript', 'Python', 'Go', 'React', 'PostgreSQL', 'Docker']));
+	expect(resume.skills.some((skill) => skill.length > 45)).toBe(false);
+	return resume;
+}
+
+describe('Brazilian deterministic resume parser', () => {
+	it('parses the Portuguese reference resume', () => {
+		const resume = assertCoreExtraction(PORTUGUESE_RESUME, 'pt-BR');
+		expect(resume.experience.some((entry) => entry.company.includes('MVP Builders') && /Desenvolvedor/i.test(entry.title))).toBe(true);
+	});
+
+	it('parses the English reference resume', () => {
+		const resume = assertCoreExtraction(ENGLISH_RESUME, 'en');
+		expect(resume.experience.some((entry) => entry.company.includes('MVP Builders') && /Developer/i.test(entry.title))).toBe(true);
+	});
+
+	it('adds a Gupy-like profile and does not inflate keywords without a job', () => {
+		const resume = assertCoreExtraction(PORTUGUESE_RESUME, 'pt-BR');
+		const input: ScoringInput = {
+			resumeText: resume.rawText,
+			resumeSkills: resume.skills,
+			resumeSections: resume.sections.map((section) => section.type),
+			experienceBullets: resume.experience.flatMap((entry) => entry.bullets),
+			educationText: resume.education.map((entry) => entry.rawText).join('\n'),
+			hasMultipleColumns: false,
+			hasTables: false,
+			hasImages: false,
+			pageCount: 2,
+			wordCount: resume.metadata.wordCount,
+			locale: resume.metadata.language,
+			extractionQuality: resume.metadata.extractionQuality
+		};
+		const first = scoreResume(input);
+		const second = scoreResume(input);
+		expect(first).toHaveLength(7);
+		expect(first.find((score) => score.system === 'Gupy-like')).toBeDefined();
+		expect(first.every((score) => score.breakdown.keywordMatch.score === 0)).toBe(true);
+		expect(first.map((score) => score.overallScore)).toEqual(second.map((score) => score.overallScore));
+	});
+});

--- a/tests/unit/scorer/gupy-alignment.test.ts
+++ b/tests/unit/scorer/gupy-alignment.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import { totalNonOverlappingMonths } from '$engine/scorer/gupy-alignment';
+import { scoreAgainstProfile } from '$engine/scorer/engine';
+import { GUPY_PROFILE } from '$engine/scorer/profiles/gupy';
+import type { ScoringInput } from '$engine/scorer/types';
+
+const job = `
+Desenvolvedor Backend Sênior
+Requisitos obrigatórios:
+- 3 anos de experiência com TypeScript, Node.js, PostgreSQL e APIs REST
+- Graduação em tecnologia
+Diferenciais:
+- Docker e Kubernetes
+`;
+
+function input(name: string, email: string): ScoringInput {
+	return {
+		resumeText: `${name}\n${email}\nDesenvolvedor Backend\nTypeScript Node.js PostgreSQL Docker`,
+		resumeSkills: ['TypeScript', 'Node.js', 'PostgreSQL', 'Docker'],
+		resumeSections: ['contact', 'summary', 'skills', 'experience', 'education'],
+		experienceBullets: [
+			'Desenvolveu APIs REST em TypeScript e Node.js',
+			'Otimizou consultas PostgreSQL em 30%'
+		],
+		experienceEntries: [
+			{
+				title: 'Desenvolvedor Backend',
+				company: 'Empresa A',
+				start: '2022-01',
+				end: '2024-12',
+				isCurrent: false,
+				text: 'Desenvolvimento de APIs REST com TypeScript, Node.js e PostgreSQL'
+			},
+			{
+				title: 'Desenvolvedor',
+				company: 'Empresa B',
+				start: '2024-06',
+				end: null,
+				isCurrent: true,
+				text: 'Serviços backend e Docker'
+			}
+		],
+		educationText: 'Tecnologia em Análise e Desenvolvimento de Sistemas - Faculdade Exemplo',
+		educationEntries: [
+			{
+				degree: 'Tecnologia',
+				field: 'Análise e Desenvolvimento de Sistemas',
+				institution: 'Faculdade Exemplo',
+				text: 'Tecnologia em Análise e Desenvolvimento de Sistemas'
+			}
+		],
+		hasMultipleColumns: false,
+		hasTables: false,
+		hasImages: false,
+		pageCount: 1,
+		wordCount: 350,
+		jobDescription: job,
+		locale: 'pt-BR',
+		extractionQuality: 95
+	};
+}
+
+describe('Gupy-like deterministic alignment', () => {
+	it('weights required skills above preferred skills', () => {
+		const result = scoreAgainstProfile(input('CANDIDATO TESTE', 'teste@example.com'), GUPY_PROFILE);
+		expect(result.breakdown.keywordMatch.matched).toEqual(
+			expect.arrayContaining(['TypeScript', 'Node.js', 'PostgreSQL'])
+		);
+		expect(result.breakdown.keywordMatch.missing).toContain('REST APIs');
+		expect(result.breakdown.keywordMatch.synonymMatched).toContain('Docker');
+		expect(result.breakdown.keywordMatch.score).toBeGreaterThan(65);
+	});
+
+	it('does not double-count overlapping employment dates', () => {
+		const months = totalNonOverlappingMonths(input('CANDIDATO TESTE', 'teste@example.com').experienceEntries!);
+		const now = new Date();
+		const expected = now.getUTCFullYear() * 12 + now.getUTCMonth() - (2022 * 12) + 1;
+		expect(months).toBe(expected);
+	});
+
+	it('ignores candidate name and email in Gupy-like ordering', () => {
+		const first = scoreAgainstProfile(input('ALICE EXEMPLO', 'alice@example.com'), GUPY_PROFILE);
+		const second = scoreAgainstProfile(input('BRUNO EXEMPLO', 'bruno@example.com'), GUPY_PROFILE);
+		expect(first.overallScore).toBe(second.overallScore);
+		expect(first.breakdown.keywordMatch).toEqual(second.breakdown.keywordMatch);
+		expect(first.breakdown.experience.score).toBe(second.breakdown.experience.score);
+	});
+});


### PR DESCRIPTION
## Overview

This contribution turns the scanner’s default path into a fully deterministic, self-hostable pipeline and adds first-class support for Brazilian and English resumes.

## What changed

- removes mandatory LLM calls from the primary scoring flow
- adds a transparent `Gupy-like` profile based on public candidate guidance, without claiming to reproduce Gupy’s proprietary algorithm
- expands the scanner from 6 to 7 platform profiles
- adds PT-BR/EN parsing for contacts, sections, dates, experience, education and skills
- adds self-hosted Tesseract OCR (`por+eng`) with Poppler rendering and text-layer quality fallback
- improves PDF geometry reconstruction to reduce false multi-column/table/image detections
- fixes the automatic 100 keyword score when no job description is provided
- adds Portuguese action verbs, measurable-result patterns and Unicode-safe normalization
- adds extraction method and confidence indicators to the UI
- adds PT/EN interface localization
- adds regression tests, deterministic scoring tests, Playwright E2E coverage and Docker OCR validation
- documents architecture, limits and deployment behavior

## Gupy-like scoring

The Gupy-like profile evaluates structured skills, required/preferred requirements, minimum experience duration, role alignment, seniority and education. Personal contact data is excluded from ranking.

## Validation

The forked version has been deployed successfully in a live self-hosted environment and tested with Portuguese and English resume fixtures.

## Important disclaimer

`Gupy-like` is an explainable simulation built from public guidance. It is not affiliated with Gupy and does not reproduce any proprietary ranking algorithm.

## Source branch

`gabedsam01/ats-screener:main`