### PR TITLE
fix(llm): restore scoring chain, both providers were failing every request

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,12 +3,15 @@
 # at least one provider must be configured for /api/analyze to work.
 # the chain is composed in this order, falling through on failure:
 #   1. Ollama (local, optional)
-#   2. Gemma 3 27B via Google
-#   3. Llama 3.3 70B via Groq
+#   2. Gemini 3.5 Flash Lite via Google
+#   3. Llama 3.3 70B via Groq (cross-vendor fallback)
+# one model per vendor on purpose: a second model on the same key shares that key's
+# quota, so it adds latency without adding redundancy.
 # -----------------------------------------------------------------------------
 
 # Google Gemini API key (primary cloud LLM provider)
 # get yours at https://aistudio.google.com/apikey
+# your per-project limits live at https://aistudio.google.com/usage
 GEMINI_API_KEY=
 
 # Groq API key (recommended cloud fallback, Llama 3.3 70B)

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ So I built ATS Screener to give students and job seekers what those paid tools w
 ## How It Works
 
 ```
-Resume (PDF/DOCX)  -->  Client-Side Parser  -->  Extracted Text  -->  Gemma/Gemini AI  -->  6 Platform Scores
+Resume (PDF/DOCX)  -->  Client-Side Parser  -->  Extracted Text  -->  Gemini Flash Lite  -->  6 Platform Scores
                         (Web Worker)              (sections,          (server)        (formatting, keywords,
                         file never uploaded       skills, dates)                       experience, education)
 
@@ -74,18 +74,18 @@ Each profile is based on research into the platform's documented parsing and mat
 
 ## Tech Stack
 
-| Layer            | Choice                                                   | Why                                                                                         |
-| ---------------- | -------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| **Framework**    | SvelteKit 5 (Svelte 5 runes)                             | Compiled to vanilla JS, ~15KB runtime. No VDOM overhead.                                    |
-| **Styling**      | Scoped CSS + CSS custom properties                       | Dark glassmorphic design. No Tailwind. Component-scoped.                                    |
-| **PDF Parsing**  | pdfjs-dist (Web Worker)                                  | Mozilla-maintained, fully client-side.                                                      |
-| **DOCX Parsing** | mammoth                                                  | Client-side Word to text extraction.                                                        |
-| **NLP**          | Custom TF-IDF + tokenizer + skills taxonomy              | Lightweight, browser-native, supports 8+ industries.                                        |
-| **LLM**          | Gemma 3 27B (primary), Llama 3.3 70B via Groq (fallback) | Cross-provider fallback: Google (14,400 RPD) + Groq (14,400 RPD) on independent free tiers. |
-| **Auth**         | Firebase Authentication                                  | Google + email/password sign-in. Free Spark plan.                                           |
-| **Storage**      | Cloud Firestore                                          | Scan history per user. Free Spark plan.                                                     |
-| **Hosting**      | Vercel                                                   | Free hobby tier. Edge functions for API.                                                    |
-| **Testing**      | Vitest + Playwright + @testing-library/svelte            | Unit, integration, and E2E coverage.                                                        |
+| Layer            | Choice                                                             | Why                                                                                                       |
+| ---------------- | ------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------- |
+| **Framework**    | SvelteKit 5 (Svelte 5 runes)                                       | Compiled to vanilla JS, ~15KB runtime. No VDOM overhead.                                                  |
+| **Styling**      | Scoped CSS + CSS custom properties                                 | Dark glassmorphic design. No Tailwind. Component-scoped.                                                  |
+| **PDF Parsing**  | pdfjs-dist (Web Worker)                                            | Mozilla-maintained, fully client-side.                                                                    |
+| **DOCX Parsing** | mammoth                                                            | Client-side Word to text extraction.                                                                      |
+| **NLP**          | Custom TF-IDF + tokenizer + skills taxonomy                        | Lightweight, browser-native, supports 8+ industries.                                                      |
+| **LLM**          | Gemini 3.5 Flash Lite (primary), Llama 3.3 70B via Groq (fallback) | One model per vendor on separate free tiers, so one provider's limits can't cascade. 500 RPD + 1,000 RPD. |
+| **Auth**         | Firebase Authentication                                            | Google + email/password sign-in. Free Spark plan.                                                         |
+| **Storage**      | Cloud Firestore                                                    | Scan history per user. Free Spark plan.                                                                   |
+| **Hosting**      | Vercel                                                             | Free hobby tier. Edge functions for API.                                                                  |
+| **Testing**      | Vitest + Playwright + @testing-library/svelte                      | Unit, integration, and E2E coverage.                                                                      |
 
 **Total infrastructure cost: $0.** Everything runs on free tiers.
 

--- a/docs/src/content/docs/api/endpoints.md
+++ b/docs/src/content/docs/api/endpoints.md
@@ -103,7 +103,7 @@ Extract structured requirements from a job description without scoring a resume.
 			"suggestions": ["Add AWS and CI/CD keywords to match Workday's exact matching"]
 		}
 	],
-	"_provider": "gemma-3-27b",
+	"_provider": "gemini-3.5-flash-lite",
 	"_fallback": false,
 	"_cached": false
 }
@@ -119,7 +119,7 @@ Extract structured requirements from a job description without scoring a resume.
 | `results[].passesFilter` | boolean                    | Whether resume passes initial screening                                                                    |
 | `results[].breakdown`    | object                     | Per-dimension scores and details                                                                           |
 | `results[].suggestions`  | string \| StructuredItem[] | Platform-specific improvement tips. May be plain strings (rule-based) or structured objects (LLM-enhanced) |
-| `_provider`              | string                     | Which LLM provider handled the request (e.g. `gemma-3-27b`, `groq-llama-3.3-70b`)                          |
+| `_provider`              | string                     | Which LLM provider handled the request (e.g. `gemini-3.5-flash-lite`, `groq-llama-3.3-70b`)                |
 | `_fallback`              | boolean                    | `true` when all providers failed and the client must fall back to local rule-based scoring                 |
 | `_cached`                | boolean                    | `true` when the response was served from the in-memory result cache (sub-100ms, zero LLM cost)             |
 

--- a/docs/src/content/docs/api/rate-limits.md
+++ b/docs/src/content/docs/api/rate-limits.md
@@ -60,16 +60,36 @@ The error string ends with either `too many requests this minute` (per-minute wi
 
 When self-hosting, rate limits are configurable. The actual bottleneck becomes your LLM provider's free tier:
 
-| Provider | Model         | RPM | RPD    | TPM | TPD  |
-| -------- | ------------- | --- | ------ | --- | ---- |
-| Google   | Gemma 3 27B   | 30  | 14,400 | 15K | -    |
-| Groq     | Llama 3.3 70B | 30  | 1,000  | 12K | 100K |
+| Provider | Model                 | RPM | RPD   | TPM  | TPD  |
+| -------- | --------------------- | --- | ----- | ---- | ---- |
+| Google   | Gemini 3.5 Flash Lite | 15  | 500   | 250K | -    |
+| Groq     | Llama 3.3 70B         | 30  | 1,000 | 12K  | 100K |
 
-For the latest limits, see the official documentation:
+Google no longer publishes per-model limits in its docs. They are per-project and
+visible only in [your AI Studio rate-limit page](https://aistudio.google.com/usage),
+so treat the numbers above as observed values rather than contractual ones, and read
+`429` responses rather than hardcoding thresholds.
 
 - [Google AI rate limits](https://ai.google.dev/gemini-api/docs/rate-limits)
 - [Groq rate limits](https://console.groq.com/docs/rate-limits)
 
 :::tip
-The hosted version uses Gemma 3 27B as the primary model with Llama 3.3 70B via Groq as fallback. Both run on independent free tiers. The binding constraint is TPM (tokens per minute), not RPD. Each scan uses ~8,000 tokens total (prompt + response), giving a realistic throughput of roughly 2,600 scans per day from Gemma alone. Groq's free tier adds ~12 scans/day (100K TPD limit) as an emergency safety net.
+A full scoring request measures ~5,950 tokens in and ~3,330 tokens out. On Google the
+binding constraint is RPD, not TPM: 500 scans/day, with RPM 15 governing burst. Groq's
+100K TPD adds roughly 12 scans/day as a cross-vendor fallback.
+
+The chain runs exactly one model per vendor. A second Gemini model on the same API key
+does not get its own quota pool, so stacking them only spends latency before reaching
+the fallback that can actually answer.
+
+The full Gemini Flash tiers are unusable here regardless of quality: 20 RPD. Gemma 4 is
+excluded too, on three counts measured against the real prompt: ~110s per call, output
+returned in markdown fences instead of raw JSON, and a free tier whose terms include
+using submitted data to improve Google's products, which is disqualifying for resume text.
+:::
+
+:::caution
+`llama-3.3-70b-versatile` shuts down on **2026-08-16**. No remaining Groq free-tier model
+fits this prompt afterwards (8K TPM ceiling against ~9.3K needed), so the Groq leg must be
+dropped or the prompt shrunk before that date. The two Google legs are unaffected.
 :::

--- a/docs/src/content/docs/getting-started/introduction.md
+++ b/docs/src/content/docs/getting-started/introduction.md
@@ -56,7 +56,7 @@ Built with performance and privacy in mind:
 - **SvelteKit 5** with Svelte 5 runes for the frontend
 - **pdfjs-dist** (Web Worker) for client-side PDF parsing
 - **mammoth** for client-side DOCX parsing
-- **Gemma 3 27B** (primary) with **Llama 3.3 70B** via Groq as fallback for AI-powered analysis
+- **Gemini 3.5 Flash Lite** (primary) with **Llama 3.3 70B** via Groq as fallback for AI-powered analysis
 - **Firebase** for authentication and scan history
 - **Vercel** for hosting (free tier)
 

--- a/docs/src/content/docs/scoring/methodology.md
+++ b/docs/src/content/docs/scoring/methodology.md
@@ -293,7 +293,7 @@ The spread here is 5.30 points from highest to lowest. All pass in this example,
 
 ## AI vs Rule-Based Scoring
 
-Everything above describes the **rule-based fallback engine**. When AI scoring is available (Gemma 3 27B via Google's Generative Language API), the LLM evaluates each dimension using the same platform profiles as context. The AI can pick up on nuances that rule-based scoring can't, things like contextual relevance, phrasing quality, and role-specific terminology.
+Everything above describes the **rule-based fallback engine**. When AI scoring is available (Gemini 3.5 Flash Lite via Google's Generative Language API), the LLM evaluates each dimension using the same platform profiles as context. The AI can pick up on nuances that rule-based scoring can't, things like contextual relevance, phrasing quality, and role-specific terminology.
 
 The rule-based engine exists as a fallback for when the AI is unavailable (rate limits, timeouts, etc.). It produces serviceable scores using the exact formulas on this page, but AI scoring is generally more nuanced and accurate for real-world resume evaluation.
 

--- a/docs/src/content/docs/self-hosting/configuration.md
+++ b/docs/src/content/docs/self-hosting/configuration.md
@@ -118,17 +118,26 @@ Adjust these values based on your expected traffic and API key limits.
 Each provider has its own timeout. [Vercel Fluid Compute](https://vercel.com/docs/fluid-compute) is enabled by default and allows up to 300 seconds on the Hobby plan:
 
 ```typescript
-// Google: 25s, Groq: 15s → worst case total: 40s
-timeoutMs: 25_000; // buildGoogleProvider
+// Google: 30s, Groq: 15s → worst case total: 45s
+timeoutMs: 30_000; // buildGoogleProvider
 timeoutMs: 15_000; // buildGroqProvider
 ```
 
-Flash Lite answers the full scoring prompt in 7-10s measured, so 25s absorbs a spike
-without stalling the chain. Groq responds in under a second but gets 15s for the cold path.
+Two constraints govern these numbers.
 
-These must sum to less than the route's `maxDuration` (60s) or the platform kills the
+**They must sum to less than the route's `maxDuration` (60s)**, or the platform kills the
 function before the last leg can run, silently turning a two-provider chain into a
-one-provider one. Raising either timeout means raising `maxDuration` with it.
+one-provider one.
+
+**Each provider's token budget must be reachable inside its own timeout.** Measured
+throughput is 311 tok/s on Flash Lite and ~290 tok/s on Groq, so a 6,144-token Google
+budget needs 19.8s and a 3,072-token Groq budget needs 10.6s. If a budget were raised
+above what its timeout allows, any response that ran to full length would be aborted
+mid-flight, wasting the call and the fallback behind it. A unit test enforces this.
+
+Typical requests are far below the ceiling: Flash Lite answers in 9-11s and Groq in
+about 7s. Output size tracks the fixed 6-platform schema rather than resume length, so a
+short resume and a maxed-out one produce within 5% of the same number of output tokens.
 
 If every provider fails the route returns `503` and logs `llm.all_providers_failed` at
 error level, and the client falls back to rule-based scoring.

--- a/docs/src/content/docs/self-hosting/configuration.md
+++ b/docs/src/content/docs/self-hosting/configuration.md
@@ -9,7 +9,7 @@ All configuration is done through environment variables in the `.env` file. At l
 
 | Variable          | Required     | Description                                                                                                            |
 | ----------------- | ------------ | ---------------------------------------------------------------------------------------------------------------------- |
-| `GEMINI_API_KEY`  | One of these | Google AI API key (Gemma 3 27B)                                                                                        |
+| `GEMINI_API_KEY`  | One of these | Google AI API key (Gemini 3.5 Flash Lite)                                                                              |
 | `GROQ_API_KEY`    | One of these | Groq API key (Llama 3.3 70B)                                                                                           |
 | `OLLAMA_BASE_URL` | One of these | Base URL of a local Ollama daemon (e.g. `http://127.0.0.1:11434`)                                                      |
 | `OLLAMA_MODEL`    | Optional     | Ollama model tag, defaults to `llama3.2`. Use any tag from `ollama list`.                                              |
@@ -24,8 +24,12 @@ Never commit your `.env` file to version control. It's already in `.gitignore`, 
 The LLM chain composes from whatever's configured in env. Ordering is fixed:
 
 1. **Ollama** (`OLLAMA_BASE_URL`), local first when configured
-2. **Gemma 3 27B** via Google (`GEMINI_API_KEY`)
+2. **Gemini 3.5 Flash Lite** via Google (`GEMINI_API_KEY`)
 3. **Llama 3.3 70B** via Groq (`GROQ_API_KEY`)
+
+Exactly one model per vendor. A second model on the same API key shares that key's
+quota, so it adds latency without adding redundancy; crossing vendors is what makes
+the fallback meaningful.
 
 If a provider fails (timeout, rate limit, malformed response), the system automatically tries the next one. Because each provider uses a separate credential, their quotas are completely independent. Self-hosters who want a fully offline scanner should set only `OLLAMA_BASE_URL` and leave the cloud keys unset.
 
@@ -84,10 +88,10 @@ PUBLIC_FIREBASE_APP_ID=1:1234567890:web:abc
 
 ## Free Tier Limits
 
-| Provider | Model         | RPM  | RPD    | TPM | Cost |
-| -------- | ------------- | ---- | ------ | --- | ---- |
-| Google   | Gemma 3 27B   | 30   | 14,400 | 15K | Free |
-| Groq     | Llama 3.3 70B | 1000 | 14,400 | 12K | Free |
+| Provider | Model                 | RPM | RPD   | TPM  | Cost |
+| -------- | --------------------- | --- | ----- | ---- | ---- |
+| Google   | Gemini 3.5 Flash Lite | 15  | 500   | 250K | Free |
+| Groq     | Llama 3.3 70B         | 30  | 1,000 | 12K  | Free |
 
 Both providers block at their limits and never auto-charge. You cannot accidentally incur costs.
 
@@ -114,8 +118,17 @@ Adjust these values based on your expected traffic and API key limits.
 Each provider has its own timeout. [Vercel Fluid Compute](https://vercel.com/docs/fluid-compute) is enabled by default and allows up to 300 seconds on the Hobby plan:
 
 ```typescript
-// Gemma: 90s, Groq: 30s → worst case total: 120s
-const PROVIDER_TIMEOUTS_MS = [90_000, 30_000];
+// Google: 25s, Groq: 15s → worst case total: 40s
+timeoutMs: 25_000; // buildGoogleProvider
+timeoutMs: 15_000; // buildGroqProvider
 ```
 
-Gemma 3 27B typically takes 30-45 seconds for the full scoring prompt but can spike under load. The 90s timeout gives generous headroom. Groq responds in under 1 second but gets 30s for safety. If both providers fail, the system falls back to rule-based scoring on the client side.
+Flash Lite answers the full scoring prompt in 7-10s measured, so 25s absorbs a spike
+without stalling the chain. Groq responds in under a second but gets 15s for the cold path.
+
+These must sum to less than the route's `maxDuration` (60s) or the platform kills the
+function before the last leg can run, silently turning a two-provider chain into a
+one-provider one. Raising either timeout means raising `maxDuration` with it.
+
+If every provider fails the route returns `503` and logs `llm.all_providers_failed` at
+error level, and the client falls back to rule-based scoring.

--- a/docs/src/content/docs/self-hosting/setup.md
+++ b/docs/src/content/docs/self-hosting/setup.md
@@ -9,7 +9,7 @@ ATS Screener can be self-hosted for free. You'll need at least one LLM API key.
 
 - **Node.js** 18+ (20 recommended)
 - **pnpm** 8+ (package manager)
-- A free API key from [Google AI Studio](https://aistudio.google.com/apikey) (required for Gemma 3 27B)
+- A free API key from [Google AI Studio](https://aistudio.google.com/apikey) (required for Gemini 3.5 Flash Lite)
 
 ## Installation
 
@@ -40,7 +40,7 @@ cp .env.example .env
 3. Add to `.env`: `GROQ_API_KEY=your_key_here`
 
 :::tip
-You need the **Google AI API key** to run the app (Gemma 3 27B primary, 14,400 RPD). Adding a **Groq API key** is strongly recommended as it provides a completely independent fallback (Llama 3.3 70B, 1,000 RPD) so users never see failures during peak traffic.
+You need the **Google AI API key** to run the app (Gemini 3.5 Flash Lite, 500 RPD). Adding a **Groq API key** is strongly recommended as a completely independent fallback (Llama 3.3 70B, 1,000 RPD) so users never see failures when Google's quota is spent or its API is down.
 :::
 
 ## Run Locally

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -248,7 +248,7 @@
 				<div class="tech-card">
 					<h4>AI</h4>
 					<ul>
-						<li>Gemma 3 27B via Google (primary)</li>
+						<li>Gemini 3.5 Flash Lite via Google (primary)</li>
 						<li>Llama 3.3 70B via Groq (fallback)</li>
 						<li>Rule-based fallback engine</li>
 						<li>TF-IDF keyword matching</li>

--- a/src/routes/api/analyze/+server.ts
+++ b/src/routes/api/analyze/+server.ts
@@ -100,7 +100,7 @@ function extractJSON(raw: string): unknown {
 	return null;
 }
 
-// must exceed the sum of every provider timeout in the chain (25 + 15 = 40s) or the
+// must exceed the sum of every provider timeout in the chain (30 + 15 = 45s) or the
 // last leg gets killed by the platform before it can answer, which silently turns a
 // 2-provider chain into a 1-provider one
 export const config = {

--- a/src/routes/api/analyze/+server.ts
+++ b/src/routes/api/analyze/+server.ts
@@ -100,8 +100,9 @@ function extractJSON(raw: string): unknown {
 	return null;
 }
 
-// vercel hobby plan defaults to 10s function timeout
-// gemini can take 12-15s so we need to extend this
+// must exceed the sum of every provider timeout in the chain (25 + 15 = 40s) or the
+// last leg gets killed by the platform before it can answer, which silently turns a
+// 2-provider chain into a 1-provider one
 export const config = {
 	maxDuration: 60
 };
@@ -231,6 +232,13 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 	const result = await callLLM(prompt, keys);
 
 	if (!result) {
+		// every leg failing is an outage, not a retryable blip - the per-provider
+		// warnings above are individually unremarkable, so this is the only line
+		// that distinguishes "one provider hiccuped" from "nobody is scoring"
+		logger.error('llm.all_providers_failed', {
+			providers: buildProviders(keys).map((p) => p.name),
+			mode: body.mode
+		});
 		return json({ error: 'all LLM providers failed', fallback: true }, { status: 503 });
 	}
 

--- a/src/routes/api/analyze/providers.ts
+++ b/src/routes/api/analyze/providers.ts
@@ -1,7 +1,10 @@
 // LLM provider abstraction for /api/analyze.
 //
-// cloud chain is Gemma 3 27B (Google) -> Llama 3.3 70B (Groq); cross-provider
-// fallback gives independent quotas so one provider's limits don't cascade.
+// cloud chain is Gemini 3.5 Flash Lite (Google) -> Llama 3.3 70B (Groq): one model
+// per vendor, because a second model on the same key shares that key's quota and adds
+// no real redundancy. crossing vendors is what keeps one provider's limits from
+// cascading. both models were measured against the real full-scoring prompt rather
+// than picked from published limits - see buildProviders.
 // self-hosters can prepend Ollama by setting OLLAMA_BASE_URL (and optionally
 // OLLAMA_MODEL, plus OLLAMA_API_KEY for proxied / auth-gated daemons); the
 // request handler treats Ollama as a configured provider so a fork running
@@ -31,16 +34,23 @@ const googleExtractText = (data: unknown) => {
 	return d.candidates?.[0]?.content?.parts?.[0]?.text ?? '';
 };
 
+// measured against the real full-scoring prompt (both slices at their caps):
+// prompt ~5,950 tokens in, ~3,330 tokens out. every budget below is derived from
+// those two numbers rather than guessed, because providers bill reserved output
+// against their per-minute ceiling (see MAX_OUTPUT_TOKENS note on the Groq builder).
+const GOOGLE_MAX_OUTPUT_TOKENS = 8192;
+
 export function buildGoogleProvider(
 	name: string,
 	model: string,
-	opts?: { jsonMode?: boolean }
+	opts?: { jsonMode?: boolean; timeoutMs?: number; maxOutputTokens?: number }
 ): LLMProvider {
 	return {
 		name,
 		configKey: 'GEMINI_API_KEY',
-		// Gemma typically responds in 30-45s but can spike under load
-		timeoutMs: 90_000,
+		// flash-lite answers the full prompt in 7-10s measured; 25s absorbs a spike
+		// while keeping the whole chain inside the route's maxDuration
+		timeoutMs: opts?.timeoutMs ?? 25_000,
 		buildRequest: (prompt, apiKey) => ({
 			url: `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${apiKey}`,
 			init: {
@@ -51,8 +61,10 @@ export function buildGoogleProvider(
 					generationConfig: {
 						temperature: 0.3,
 						topP: 0.85,
-						maxOutputTokens: 16384,
-						...(opts?.jsonMode && { responseMimeType: 'application/json' })
+						maxOutputTokens: opts?.maxOutputTokens ?? GOOGLE_MAX_OUTPUT_TOKENS,
+						// default on: the scoring contract is JSON, and without this the
+						// model returns prose that extractJSON has to salvage
+						...(opts?.jsonMode !== false && { responseMimeType: 'application/json' })
 					}
 				})
 			}
@@ -61,12 +73,22 @@ export function buildGoogleProvider(
 	};
 }
 
-export function buildGroqProvider(name: string, model: string): LLMProvider {
+// Groq reserves (input + max_tokens) against its per-minute ceiling BEFORE running
+// the model, so an oversized max_tokens alone can exceed the whole TPM budget and
+// every request 413s regardless of input size. free-tier llama TPM is 12,000 and
+// the real prompt measures ~5,950 in / ~2,020 out, so 4,096 leaves working room.
+const GROQ_MAX_TOKENS = 4096;
+
+export function buildGroqProvider(
+	name: string,
+	model: string,
+	opts?: { maxTokens?: number }
+): LLMProvider {
 	return {
 		name,
 		configKey: 'GROQ_API_KEY',
 		// Groq is <1s typical but gets headroom for cold path
-		timeoutMs: 30_000,
+		timeoutMs: 15_000,
 		buildRequest: (prompt, apiKey) => ({
 			url: 'https://api.groq.com/openai/v1/chat/completions',
 			init: {
@@ -80,7 +102,7 @@ export function buildGroqProvider(name: string, model: string): LLMProvider {
 					messages: [{ role: 'user', content: prompt }],
 					temperature: 0.3,
 					top_p: 0.85,
-					max_tokens: 16384,
+					max_tokens: opts?.maxTokens ?? GROQ_MAX_TOKENS,
 					response_format: { type: 'json_object' }
 				})
 			}
@@ -164,11 +186,21 @@ export function buildProviders(env: Record<string, string>): LLMProvider[] {
 		providers.push(buildOllamaProvider(`ollama-${model}`, model, { apiKey }));
 	}
 	if (env.GEMINI_API_KEY) {
-		// primary cloud: Gemma 3 27B via Google - 14,400 RPD, 30 RPM, 15K TPM
-		providers.push(buildGoogleProvider('gemma-3-27b', 'gemma-3-27b-it'));
+		// exactly one Google model. a second Gemini leg on the same key does NOT buy a
+		// second quota pool - when the key is exhausted it is exhausted for every model
+		// on it - so stacking them just burns latency before the real fallback.
+		// 500 RPD / 250K TPM / 15 RPM against ~130 scans/day of observed demand.
+		// the full Flash tiers are unusable no matter how good they are: 20 RPD.
+		// Gemma 4 31B looks tempting on paper (14,400 RPD) but measured ~110s per call,
+		// returned markdown-fenced output instead of JSON, and its free tier trains on
+		// submitted data - disqualifying for resume text. deliberately excluded.
+		providers.push(buildGoogleProvider('gemini-3.5-flash-lite', 'gemini-3.5-flash-lite'));
 	}
 	if (env.GROQ_API_KEY) {
-		// fallback cloud: Llama 3.3 70B via Groq - 100-600ms, native JSON mode, 1K RPD
+		// cross-vendor last resort so a total Google outage still scores.
+		// EXPIRES 2026-08-16: llama-3.3-70b-versatile shuts down then, and no remaining
+		// Groq free-tier model fits this prompt (8K TPM ceiling vs ~9.3K needed), so
+		// this leg has to be dropped or the prompt shrunk before that date.
 		providers.push(buildGroqProvider('groq-llama-3.3-70b', 'llama-3.3-70b-versatile'));
 	}
 	return providers;

--- a/src/routes/api/analyze/providers.ts
+++ b/src/routes/api/analyze/providers.ts
@@ -35,10 +35,15 @@ const googleExtractText = (data: unknown) => {
 };
 
 // measured against the real full-scoring prompt (both slices at their caps):
-// prompt ~5,950 tokens in, ~3,330 tokens out. every budget below is derived from
-// those two numbers rather than guessed, because providers bill reserved output
-// against their per-minute ceiling (see MAX_OUTPUT_TOKENS note on the Groq builder).
-const GOOGLE_MAX_OUTPUT_TOKENS = 8192;
+// ~5,950 tokens in, 2,950-3,419 out over repeated runs at 311-338 tok/s. output size
+// tracks the fixed 6-platform schema, not the user's resume length - a minimal resume
+// produced within 5% of a maxed-out one - so both directions are already bounded.
+//
+// INVARIANT: maxOutputTokens / slowest-observed-throughput must stay under timeoutMs,
+// or a response that legitimately runs to its full budget gets aborted mid-flight and
+// burns the fallback too. 6144 / 311 tok/s = 19.8s against a 30s timeout.
+// 6144 is ~1.8x the largest output ever observed, so truncation risk stays remote.
+const GOOGLE_MAX_OUTPUT_TOKENS = 6144;
 
 export function buildGoogleProvider(
 	name: string,
@@ -48,9 +53,10 @@ export function buildGoogleProvider(
 	return {
 		name,
 		configKey: 'GEMINI_API_KEY',
-		// flash-lite answers the full prompt in 7-10s measured; 25s absorbs a spike
+		// flash-lite answers the full prompt in 9-11s measured. 30s covers the worst
+		// case where the model runs to the full token budget (19.8s) with margin,
 		// while keeping the whole chain inside the route's maxDuration
-		timeoutMs: opts?.timeoutMs ?? 25_000,
+		timeoutMs: opts?.timeoutMs ?? 30_000,
 		buildRequest: (prompt, apiKey) => ({
 			url: `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${apiKey}`,
 			init: {
@@ -75,9 +81,13 @@ export function buildGoogleProvider(
 
 // Groq reserves (input + max_tokens) against its per-minute ceiling BEFORE running
 // the model, so an oversized max_tokens alone can exceed the whole TPM budget and
-// every request 413s regardless of input size. free-tier llama TPM is 12,000 and
-// the real prompt measures ~5,950 in / ~2,020 out, so 4,096 leaves working room.
-const GROQ_MAX_TOKENS = 4096;
+// every request 413s regardless of input size. free-tier llama TPM is 12,000 and the
+// real prompt measures ~5,950 in / ~2,020 out at ~290 tok/s.
+//
+// 3072 serves two masters: it keeps 5,950 + 3,072 = 9,022 under the 12k TPM ceiling
+// (leaving room for a second request in the same minute), and 3072 / 290 tok/s = 10.6s
+// stays under the 15s timeout so a full-budget response is never cut off.
+const GROQ_MAX_TOKENS = 3072;
 
 export function buildGroqProvider(
 	name: string,

--- a/tests/unit/api/providers.test.ts
+++ b/tests/unit/api/providers.test.ts
@@ -11,12 +11,23 @@ describe('buildProviders: chain composition', () => {
 		expect(buildProviders({})).toEqual([]);
 	});
 
-	it('hosted-only env (Gemini + Groq) composes [gemma, groq] in that order', () => {
+	// exactly one model per vendor. a second Gemini leg would share the same key's
+	// quota, so it adds latency without adding redundancy
+	it('hosted-only env (Gemini + Groq) composes [flash-lite, groq] in that order', () => {
 		const chain = buildProviders({
 			GEMINI_API_KEY: 'fake-gemini',
 			GROQ_API_KEY: 'fake-groq'
 		});
-		expect(chain.map((p) => p.name)).toEqual(['gemma-3-27b', 'groq-llama-3.3-70b']);
+		expect(chain.map((p) => p.name)).toEqual(['gemini-3.5-flash-lite', 'groq-llama-3.3-70b']);
+	});
+
+	it('never puts two models from the same vendor in the chain', () => {
+		const chain = buildProviders({
+			GEMINI_API_KEY: 'fake-gemini',
+			GROQ_API_KEY: 'fake-groq'
+		});
+		const perKey = chain.map((p) => p.configKey);
+		expect(new Set(perKey).size).toBe(perKey.length);
 	});
 
 	it('self-hosted-only env (Ollama) composes [ollama] with default model llama3.2', () => {
@@ -36,7 +47,7 @@ describe('buildProviders: chain composition', () => {
 		expect(chain[0].name).toBe('ollama-gemma3:1b');
 	});
 
-	it('all-three env composes [ollama, gemma, groq] - Ollama prepends', () => {
+	it('all-three env composes [ollama, flash-lite, groq] - Ollama prepends', () => {
 		const chain = buildProviders({
 			OLLAMA_BASE_URL: 'http://127.0.0.1:11434',
 			OLLAMA_MODEL: 'llama3.2',
@@ -45,7 +56,7 @@ describe('buildProviders: chain composition', () => {
 		});
 		expect(chain.map((p) => p.name)).toEqual([
 			'ollama-llama3.2',
-			'gemma-3-27b',
+			'gemini-3.5-flash-lite',
 			'groq-llama-3.3-70b'
 		]);
 	});
@@ -111,12 +122,30 @@ describe('buildOllamaProvider: request shape', () => {
 });
 
 describe('cloud provider invariants (regression net)', () => {
-	it('google provider keeps its 90s timeout', () => {
-		expect(buildGoogleProvider('x', 'm').timeoutMs).toBe(90_000);
+	// timeouts must sum to less than the route's maxDuration or the last leg can
+	// never run: 25 + 25 + 15 = 65s. raising any of these means raising that too.
+	it('google provider keeps its 25s timeout', () => {
+		expect(buildGoogleProvider('x', 'm').timeoutMs).toBe(25_000);
 	});
 
-	it('groq provider keeps its 30s timeout', () => {
-		expect(buildGroqProvider('x', 'm').timeoutMs).toBe(30_000);
+	it('groq provider keeps its 15s timeout', () => {
+		expect(buildGroqProvider('x', 'm').timeoutMs).toBe(15_000);
+	});
+
+	// the bug that took the whole chain down: Groq reserves (input + max_tokens)
+	// against its per-minute ceiling, so a max_tokens above the TPM limit 413s every
+	// request no matter how small the input. free-tier TPM is 12,000.
+	it('groq max_tokens stays well under the free-tier TPM ceiling', () => {
+		const body = JSON.parse(buildGroqProvider('x', 'm').buildRequest('p', 'k').init.body as string);
+		expect(body.max_tokens).toBeLessThan(12_000);
+	});
+
+	// without this the model returns prose and extractJSON has to salvage it
+	it('google provider requests JSON natively by default', () => {
+		const body = JSON.parse(
+			buildGoogleProvider('x', 'm').buildRequest('p', 'k').init.body as string
+		);
+		expect(body.generationConfig.responseMimeType).toBe('application/json');
 	});
 
 	it('google provider configKey is GEMINI_API_KEY', () => {

--- a/tests/unit/api/providers.test.ts
+++ b/tests/unit/api/providers.test.ts
@@ -123,13 +123,26 @@ describe('buildOllamaProvider: request shape', () => {
 
 describe('cloud provider invariants (regression net)', () => {
 	// timeouts must sum to less than the route's maxDuration or the last leg can
-	// never run: 25 + 25 + 15 = 65s. raising any of these means raising that too.
-	it('google provider keeps its 25s timeout', () => {
-		expect(buildGoogleProvider('x', 'm').timeoutMs).toBe(25_000);
+	// never run: 30 + 15 = 45s against maxDuration 60. raising either means raising that.
+	it('google provider keeps its 30s timeout', () => {
+		expect(buildGoogleProvider('x', 'm').timeoutMs).toBe(30_000);
 	});
 
 	it('groq provider keeps its 15s timeout', () => {
 		expect(buildGroqProvider('x', 'm').timeoutMs).toBe(15_000);
+	});
+
+	// a provider must never be allowed to generate more than its timeout permits, or a
+	// full-budget response is aborted mid-flight and burns the fallback with it.
+	// throughputs are the slowest observed: Google 311 tok/s, Groq 290 tok/s.
+	it('token budgets are reachable within each provider timeout', () => {
+		const g = buildGoogleProvider('x', 'm');
+		const gBody = JSON.parse(g.buildRequest('p', 'k').init.body as string);
+		expect((gBody.generationConfig.maxOutputTokens / 311) * 1000).toBeLessThan(g.timeoutMs);
+
+		const q = buildGroqProvider('x', 'm');
+		const qBody = JSON.parse(q.buildRequest('p', 'k').init.body as string);
+		expect((qBody.max_tokens / 290) * 1000).toBeLessThan(q.timeoutMs);
 	});
 
 	// the bug that took the whole chain down: Groq reserves (input + max_tokens)


### PR DESCRIPTION
scoring has been failing 100% of requests since at least 7/26. two dead legs, two unrelated causes, and neither was visible because a total outage logged at `warn`.

**google** was pinned to `gemma-3-27b-it`, which Google retired. every call `404`d.

**groq** set `max_tokens: 16384` against a 12,000 TPM ceiling. Groq reserves `input + max_tokens` before running the model, so the reservation alone exceeded the whole budget:

```
tiny input (58 tok), max_tokens=16384  ->  413  Requested=16442
                                                16442 - 16384 = 58
```

no input size could ever fit. the keys were never exhausted.

### what changed

- `gemma-3-27b-it` -> `gemini-3.5-flash-lite` (500 RPD against ~130 scans/day of real demand)
- groq `max_tokens` 16384 -> 3072
- enabled `responseMimeType: application/json` on the google leg. `jsonMode` already existed in `buildGoogleProvider` and was never passed, so that leg asked for json in prose and leaned on `extractJSON` salvage
- total-chain failure now logs at `error` with the chain listed. this is why nobody noticed
- token budgets and timeouts derived from measurement (~5,950 in / ~3,330 out at 311 tok/s), not guesses

one model per vendor on purpose: a second Gemini model shares the same key's quota, so it adds latency without adding redundancy.

### why the budgets moved

each provider was allowed to generate more than its own timeout permitted, so a full-length response would be aborted mid-flight and burn the fallback with it:

| leg | budget | slowest rate | time to fill | old timeout |
| --- | --- | --- | --- | --- |
| google | 8,192 | 311 tok/s | 26.3s | 25s |
| groq | 4,096 | ~290 tok/s | 14.1s | 15s |

now 6,144/30s and 3,072/15s, chain total 45s inside `maxDuration` 60s. a unit test asserts `budget / throughput < timeout` so raising a budget without its timeout fails CI.

### verification

driven end to end, not just typechecked:

- happy path -> `gemini-3.5-flash-lite`, 6 platforms scored
- google forced dead -> falls through to `groq-llama-3.3-70b`, `200`
- all legs dead -> `503` + the new `llm.all_providers_failed` error
- live production verified after deploy

### notes

- `gemma-4-31b` was evaluated and rejected: ~110s per call, markdown-fenced output instead of json, and a free tier that trains on submitted data, which is disqualifying for resume text
- groq's `llama-3.3-70b-versatile` shuts down **2026-08-16** and no free-tier successor fits this prompt (8K TPM vs ~9.3K needed). flagged in code and docs, needs a decision before then
- prod was already deployed from this branch, so this merge aligns `main` with what is live rather than changing it