### PR TITLE
fix(security): moved the gemini key out of the request url, sha-pinned pnpm action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      # no version input: action-setup reads the packageManager field in package.json
-      - uses: pnpm/action-setup@v6
+      # sha-pinned third-party action. no version input, it reads packageManager from package.json
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
       - uses: actions/setup-node@v7
         with:

--- a/scripts/test-gemma-json.mjs
+++ b/scripts/test-gemma-json.mjs
@@ -59,10 +59,10 @@ console.log('');
 async function test() {
 	const start = Date.now();
 	const res = await fetch(
-		`https://generativelanguage.googleapis.com/v1beta/models/gemma-3-27b-it:generateContent?key=${GEMINI_KEY}`,
+		`https://generativelanguage.googleapis.com/v1beta/models/gemma-3-27b-it:generateContent`,
 		{
 			method: 'POST',
-			headers: { 'Content-Type': 'application/json' },
+			headers: { 'Content-Type': 'application/json', 'x-goog-api-key': GEMINI_KEY },
 			body: JSON.stringify({
 				contents: [{ parts: [{ text: scoringPrompt }] }],
 				generationConfig: { temperature: 0.3, topP: 0.85, maxOutputTokens: 16384 }

--- a/scripts/test-providers.mjs
+++ b/scripts/test-providers.mjs
@@ -55,10 +55,10 @@ const PROVIDERS = [
 		name: 'gemma-3-27b (Google)',
 		key: GEMINI_KEY,
 		build: (prompt) => ({
-			url: `https://generativelanguage.googleapis.com/v1beta/models/gemma-3-27b-it:generateContent?key=${GEMINI_KEY}`,
+			url: `https://generativelanguage.googleapis.com/v1beta/models/gemma-3-27b-it:generateContent`,
 			opts: {
 				method: 'POST',
-				headers: { 'Content-Type': 'application/json' },
+				headers: { 'Content-Type': 'application/json', 'x-goog-api-key': GEMINI_KEY },
 				body: JSON.stringify({
 					contents: [{ parts: [{ text: prompt }] }],
 					generationConfig: { temperature: 0.3, topP: 0.85, maxOutputTokens: 16384 }
@@ -91,10 +91,10 @@ const PROVIDERS = [
 		name: 'gemini-2.5-flash (Google)',
 		key: GEMINI_KEY,
 		build: (prompt) => ({
-			url: `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=${GEMINI_KEY}`,
+			url: `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent`,
 			opts: {
 				method: 'POST',
-				headers: { 'Content-Type': 'application/json' },
+				headers: { 'Content-Type': 'application/json', 'x-goog-api-key': GEMINI_KEY },
 				body: JSON.stringify({
 					contents: [{ parts: [{ text: prompt }] }],
 					generationConfig: {

--- a/src/routes/api/analyze/providers.ts
+++ b/src/routes/api/analyze/providers.ts
@@ -58,10 +58,11 @@ export function buildGoogleProvider(
 		// while keeping the whole chain inside the route's maxDuration
 		timeoutMs: opts?.timeoutMs ?? 30_000,
 		buildRequest: (prompt, apiKey) => ({
-			url: `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${apiKey}`,
+			url: `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent`,
 			init: {
 				method: 'POST',
-				headers: { 'Content-Type': 'application/json' },
+				// key goes in the header, not ?key=, so it never lands in request logs
+				headers: { 'Content-Type': 'application/json', 'x-goog-api-key': apiKey },
 				body: JSON.stringify({
 					contents: [{ parts: [{ text: prompt }] }],
 					generationConfig: {


### PR DESCRIPTION
clears the two code scanning alerts the `extended` query suite surfaced after #21. one of them turned out to point at production, not at the file it flagged.

### the key was sitting in the url

codeql flagged `scripts/test-gemma-json.mjs`, but the same pattern was live in the scoring chain. `providers.ts` passed `GEMINI_API_KEY` as `?key=`, which puts the secret in the request line and therefore into vercel function logs and any intermediary proxy log. groq was already doing this correctly with an `Authorization` header, google was the odd one out.

moved to the `x-goog-api-key` header in `providers.ts` and both dev scripts.

6a89f0e only just repaired this chain, so this got verified rather than assumed:

- both auth forms return `200` with identical output against the live api, on the actual production model `gemini-3.5-flash-lite`, not the models the test script happens to use
- `POST /api/analyze` end to end returns `HTTP 200` with a full 6 platform result, `_provider: gemini-3.5-flash-lite`, `_fallback: false`

worth flagging: `scripts/test-providers.mjs` shows two pre-existing failures, both unrelated to this change and both against models the production chain does not use. `gemma-3-27b-it` now 404s as removed from `v1beta`, and `llama-3.3-70b-versatile` returns a tpm `Request too large`. noted, not fixed here.

### sha pinned the pnpm action

`actions/unpinned-tag` on `pnpm/action-setup@v6`. it is the only third party action in the workflow, which is exactly why the `actions/*` ones are not flagged, and a mutable tag can be repointed at new code. pinned to `0ebf471` with a `# v6.0.9` comment so dependabot still tracks it.

### on the remaining alert

`js/file-access-to-http` will likely survive this change. the dev script still reads `.env` and that data still reaches a `fetch`, just in a header now. that dataflow is the entire point of a script whose job is to call the api with the developer's own key, so if it stays open it gets dismissed as used-in-tests rather than contorting a local harness around it.

gate green: 468/468 tests, 0 type errors, 0 lint errors, docs 29 pages.
