### PR TITLE
chore(deps): tightened the typescript ignore to >=6.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,10 +33,10 @@ updates:
           - minor
           - patch
     ignore:
-      # typescript-eslint peers cap at <6.1.0, so ts 7 breaks pnpm lint outright
+      # typescript-eslint peers cap at <6.1.0, so 6.1 breaks pnpm lint, not just 7
       - dependency-name: typescript
         versions:
-          - '>=7'
+          - '>=6.1'
       # jsdom 30 wants node ^22.22.2 || ^24.15.0 and vercel builds on 24.13.x
       - dependency-name: jsdom
         versions:


### PR DESCRIPTION
follow up to #21. the ignore rule said `>=7`, on the reasoning that typescript 7 breaks lint. the real constraint is typescript-eslint's peer range `>=4.8.4 <6.1.0`, so 6.1 breaks it just as surely and dependabot would have proposed it happily.

typescript 6.0.3 itself was fine and merged in #23 after a full local gate on node 22 and 24. this only closes the 6.1 to 7 window the original rule left open.

config only, no dependency movement.