### PR TITLE
fix(releases): inlined the changelog so the rss feed is not empty in production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1] - 2026-08-02
+
+### Fixed
+
+- **the `/releases.xml` rss feed served zero items in production.** the endpoint read `CHANGELOG.md` with `readFileSync(join(process.cwd(), ...))` at request time, wrapped in a `catch` that fell back to an empty string. that works locally, where `process.cwd()` is the repo root, but on vercel the changelog is never traced into the function bundle because `@vercel/nft` cannot statically resolve a `process.cwd()` path, so every request silently produced a valid but empty feed. the changelog is now inlined at build time via a vite `?raw` import, which puts it in the serverless bundle and removes the runtime filesystem read entirely. present since the feed was introduced in 0.3.0, and invisible because the failure path was a silent fallback rather than an error.
+
 ## [0.5.0] - 2026-08-02
 
 maintenance cycle. the dependency tree had drifted far enough to carry 137 advisories across the two manifests, dependabot had never been configured and its alerts were switched off, and there was no code scanning at all. this brings the tree current and adds the automation so it cannot drift back. no user-facing behaviour changes: the scoring engine, parsers, ATS profiles and UI are untouched.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ats-screener",
-	"version": "0.5.0",
+	"version": "0.5.1",
 	"private": true,
 	"license": "MIT",
 	"type": "module",

--- a/src/routes/releases.xml/+server.ts
+++ b/src/routes/releases.xml/+server.ts
@@ -1,5 +1,6 @@
-import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
+// ?raw inlines the changelog at build time. reading it from process.cwd() at runtime
+// silently yielded an empty feed on vercel, where nft cannot trace a dynamic path
+import changelogRaw from '../../../CHANGELOG.md?raw';
 import type { RequestHandler } from './$types';
 
 // rss 2.0 feed of releases parsed from CHANGELOG.md.
@@ -70,13 +71,7 @@ let cached: { xml: string; etag: string } | null = null;
 function buildFeed(origin: string): { xml: string; etag: string } {
 	if (cached) return cached;
 
-	let raw: string;
-	try {
-		raw = readFileSync(join(process.cwd(), 'CHANGELOG.md'), 'utf-8');
-	} catch {
-		raw = '';
-	}
-	const releases = parseChangelog(raw);
+	const releases = parseChangelog(changelogRaw);
 	const buildDate = new Date().toUTCString();
 
 	const items = releases


### PR DESCRIPTION
`/releases.xml` has been serving a valid but completely itemless feed in production. found it while verifying the 0.5.0 release actually reached the feed.

the endpoint read the changelog at request time:

\`\`\`ts
raw = readFileSync(join(process.cwd(), 'CHANGELOG.md'), 'utf-8');
\`\`\`

wrapped in a `catch` that falls back to `''`. `process.cwd()` is the repo root locally, which is exactly why this always looked correct in dev and in `pnpm preview`. on vercel the changelog is never traced into the function bundle, because `@vercel/nft` cannot statically resolve a `process.cwd()` path, so every request took the catch and emitted an empty feed. no error, no log, just nothing.

now imported with vite's `?raw`, so the changelog is inlined at build time and the runtime filesystem read is gone entirely.

verified:

- the changelog text is present in both `.svelte-kit/output/server/...` and `.vercel/output/functions/.../releases.xml/_server.ts.js`, which is the part that was previously missing
- the feed renders 7 items locally instead of 0

this predates the dependency work: it has been broken since the feed landed in 1b38c5c (v0.3.0), and the silent fallback is why nobody noticed. tagged `0.5.1` since v0.5.0 is already released.