### PR TITLE
feat(llm): added cerebras as the cross-vendor fallback before groq retires

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,9 +14,16 @@
 # your per-project limits live at https://aistudio.google.com/usage
 GEMINI_API_KEY=
 
-# Groq API key (recommended cloud fallback, Llama 3.3 70B)
+# Groq API key (cloud fallback, Llama 3.3 70B)
 # get yours at https://console.groq.com/keys
+# NOTE: llama-3.3-70b-versatile shuts down 2026-08-16 and no remaining Groq free-tier
+# model fits this prompt, so set CEREBRAS_API_KEY below to keep a cross-vendor fallback.
 # GROQ_API_KEY=
+
+# Cerebras API key (recommended cloud fallback, same Llama 3.3 70B)
+# free tier, get yours at https://cloud.cerebras.ai
+# appended after Groq, so it takes over when the Groq leg stops fitting.
+# CEREBRAS_API_KEY=
 
 # Ollama (optional, self-hosters only)
 # when OLLAMA_BASE_URL is set, the local Ollama daemon prepends to the provider

--- a/docs/src/content/docs/self-hosting/configuration.md
+++ b/docs/src/content/docs/self-hosting/configuration.md
@@ -5,15 +5,16 @@ description: Environment variables and configuration options for self-hosted ins
 
 ## Environment Variables
 
-All configuration is done through environment variables in the `.env` file. At least one provider must be configured (Gemini, Groq, or Ollama); the route returns `503` otherwise.
+All configuration is done through environment variables in the `.env` file. At least one provider must be configured (Gemini, Groq, Cerebras, or Ollama); the route returns `503` otherwise.
 
-| Variable          | Required     | Description                                                                                                            |
-| ----------------- | ------------ | ---------------------------------------------------------------------------------------------------------------------- |
-| `GEMINI_API_KEY`  | One of these | Google AI API key (Gemini 3.5 Flash Lite)                                                                              |
-| `GROQ_API_KEY`    | One of these | Groq API key (Llama 3.3 70B)                                                                                           |
-| `OLLAMA_BASE_URL` | One of these | Base URL of a local Ollama daemon (e.g. `http://127.0.0.1:11434`)                                                      |
-| `OLLAMA_MODEL`    | Optional     | Ollama model tag, defaults to `llama3.2`. Use any tag from `ollama list`.                                              |
-| `OLLAMA_API_KEY`  | Optional     | Bearer token sent as `Authorization: Bearer {key}` on every Ollama request. Only needed if your Ollama is behind auth. |
+| Variable           | Required     | Description                                                                                                            |
+| ------------------ | ------------ | ---------------------------------------------------------------------------------------------------------------------- |
+| `GEMINI_API_KEY`   | One of these | Google AI API key (Gemini 3.5 Flash Lite)                                                                              |
+| `GROQ_API_KEY`     | One of these | Groq API key (Llama 3.3 70B). Retires 2026-08-16, see the note below.                                                  |
+| `CEREBRAS_API_KEY` | One of these | Cerebras API key (Llama 3.3 70B). Recommended cross-vendor fallback.                                                   |
+| `OLLAMA_BASE_URL`  | One of these | Base URL of a local Ollama daemon (e.g. `http://127.0.0.1:11434`)                                                      |
+| `OLLAMA_MODEL`     | Optional     | Ollama model tag, defaults to `llama3.2`. Use any tag from `ollama list`.                                              |
+| `OLLAMA_API_KEY`   | Optional     | Bearer token sent as `Authorization: Bearer {key}` on every Ollama request. Only needed if your Ollama is behind auth. |
 
 :::caution
 Never commit your `.env` file to version control. It's already in `.gitignore`, but double-check before pushing.
@@ -26,10 +27,26 @@ The LLM chain composes from whatever's configured in env. Ordering is fixed:
 1. **Ollama** (`OLLAMA_BASE_URL`), local first when configured
 2. **Gemini 3.5 Flash Lite** via Google (`GEMINI_API_KEY`)
 3. **Llama 3.3 70B** via Groq (`GROQ_API_KEY`)
+4. **Llama 3.3 70B** via Cerebras (`CEREBRAS_API_KEY`)
 
 Exactly one model per vendor. A second model on the same API key shares that key's
 quota, so it adds latency without adding redundancy; crossing vendors is what makes
 the fallback meaningful.
+
+:::caution[Groq retires this model on 2026-08-16]
+`llama-3.3-70b-versatile` is the only Groq free-tier model that fits the scoring
+prompt, and it shuts down on 2026-08-16. Measured against the real capped prompt
+(6,000 character resume plus 4,000 character job description), the input alone is
+5,981 tokens and the response needs 1,944. Every surviving Groq free-tier model caps
+at 8,000 tokens per minute, and Groq reserves `input + max_tokens` up front, so
+`qwen/qwen3.6-27b` still returns `Requested 8015 / Limit 8000` even with the output
+budget cut to 1,900, and both `gpt-oss` sizes reject `json_object` on this prompt.
+
+Set `CEREBRAS_API_KEY` to keep a cross-vendor fallback. It serves the same
+Llama 3.3 70B the prompt is already tuned against, on a free tier whose per-minute
+ceiling is not the binding constraint. Keys are free at
+[cloud.cerebras.ai](https://cloud.cerebras.ai).
+:::
 
 If a provider fails (timeout, rate limit, malformed response), the system automatically tries the next one. Because each provider uses a separate credential, their quotas are completely independent. Self-hosters who want a fully offline scanner should set only `OLLAMA_BASE_URL` and leave the cloud keys unset.
 
@@ -92,13 +109,19 @@ PUBLIC_FIREBASE_APP_ID=1:1234567890:web:abc
 | -------- | --------------------- | --- | ----- | ---- | ---- |
 | Google   | Gemini 3.5 Flash Lite | 15  | 500   | 250K | Free |
 | Groq     | Llama 3.3 70B         | 30  | 1,000 | 12K  | Free |
+| Cerebras | Llama 3.3 70B         | -   | -     | -    | Free |
 
-Both providers block at their limits and never auto-charge. You cannot accidentally incur costs.
+The 12K TPM on Groq is the whole reason that leg retires on 2026-08-16: it is the only
+free-tier model there with enough headroom for this prompt, and every model that
+outlives it caps at 8K. Cerebras limits vary by account, so check your dashboard.
+
+Every provider blocks at its limits and never auto-charges. You cannot accidentally incur costs.
 
 For the latest limits, see the official documentation:
 
 - [Google AI rate limits](https://ai.google.dev/gemini-api/docs/rate-limits)
 - [Groq rate limits](https://console.groq.com/docs/rate-limits)
+- [Cerebras rate limits](https://inference-docs.cerebras.ai/support/rate-limits)
 
 ## Rate Limiting
 
@@ -118,20 +141,22 @@ Adjust these values based on your expected traffic and API key limits.
 Each provider has its own timeout. [Vercel Fluid Compute](https://vercel.com/docs/fluid-compute) is enabled by default and allows up to 300 seconds on the Hobby plan:
 
 ```typescript
-// Google: 30s, Groq: 15s → worst case total: 45s
+// Google: 30s, Groq: 15s, Cerebras: 12s → worst case total: 57s
 timeoutMs: 30_000; // buildGoogleProvider
 timeoutMs: 15_000; // buildGroqProvider
+timeoutMs: 12_000; // buildCerebrasProvider
 ```
 
 Two constraints govern these numbers.
 
 **They must sum to less than the route's `maxDuration` (60s)**, or the platform kills the
-function before the last leg can run, silently turning a two-provider chain into a
-one-provider one.
+function before the last leg can run, silently turning a three-provider chain into a
+shorter one. 30 + 15 + 12 leaves 3s of margin.
 
 **Each provider's token budget must be reachable inside its own timeout.** Measured
 throughput is 311 tok/s on Flash Lite and ~290 tok/s on Groq, so a 6,144-token Google
-budget needs 19.8s and a 3,072-token Groq budget needs 10.6s. If a budget were raised
+budget needs 19.8s and a 3,072-token Groq budget needs 10.6s. Cerebras is the fastest
+leg by a wide margin, so its 3,072-token budget clears 12s comfortably. If a budget were raised
 above what its timeout allows, any response that ran to full length would be aborted
 mid-flight, wasting the call and the fallback behind it. A unit test enforces this.
 

--- a/src/routes/api/analyze/providers.ts
+++ b/src/routes/api/analyze/providers.ts
@@ -126,6 +126,49 @@ export function buildGroqProvider(
 	};
 }
 
+// Cerebras is the replacement cross-vendor leg for Groq, which loses its only model
+// that fits this prompt on 2026-08-16. same OpenAI-shaped contract, and it serves the
+// same llama-3.3-70b this prompt was already tuned against, so output size carries over.
+// inert until CEREBRAS_API_KEY is set, exactly like the Ollama leg.
+const CEREBRAS_MAX_TOKENS = 3072;
+
+export function buildCerebrasProvider(
+	name: string,
+	model: string,
+	opts?: { maxTokens?: number }
+): LLMProvider {
+	return {
+		name,
+		configKey: 'CEREBRAS_API_KEY',
+		// 30 + 15 + 12 = 57s, inside the route's maxDuration of 60. cerebras is the
+		// fastest leg in the chain, so 12s is already generous for a 3072 token budget
+		timeoutMs: 12_000,
+		buildRequest: (prompt, apiKey) => ({
+			url: 'https://api.cerebras.ai/v1/chat/completions',
+			init: {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					Authorization: `Bearer ${apiKey}`
+				},
+				body: JSON.stringify({
+					model,
+					messages: [{ role: 'user', content: prompt }],
+					temperature: 0.3,
+					top_p: 0.85,
+					max_tokens: opts?.maxTokens ?? CEREBRAS_MAX_TOKENS,
+					response_format: { type: 'json_object' }
+				})
+			}
+		}),
+		extractText: (data: unknown) => {
+			if (!data || typeof data !== 'object') return '';
+			const d = data as { choices?: { message?: { content?: string } }[] };
+			return d.choices?.[0]?.message?.content ?? '';
+		}
+	};
+}
+
 // Ollama provider for self-hosters. local daemon by default needs no key;
 // reverse-proxied or hosted Ollama-compatible endpoints (OpenWebUI, LiteLLM,
 // Caddy + bearer auth, Cloudflare-tunnel + service token, etc.) take an
@@ -209,10 +252,19 @@ export function buildProviders(env: Record<string, string>): LLMProvider[] {
 	}
 	if (env.GROQ_API_KEY) {
 		// cross-vendor last resort so a total Google outage still scores.
-		// EXPIRES 2026-08-16: llama-3.3-70b-versatile shuts down then, and no remaining
-		// Groq free-tier model fits this prompt (8K TPM ceiling vs ~9.3K needed), so
-		// this leg has to be dropped or the prompt shrunk before that date.
+		// EXPIRES 2026-08-16: llama-3.3-70b-versatile shuts down then. measured against
+		// the real capped prompt (6,000 char resume + 4,000 char JD), nothing left on the
+		// Groq free tier can replace it: input alone is 5,981 tokens on llama and 6,115 on
+		// qwen, the surviving models cap at 8,000 TPM and Groq reserves input + max_tokens
+		// up front, and the response needs 1,944. qwen 413s at Requested 8015 / Limit 8000
+		// even with max_tokens down at 1,900, and both gpt-oss sizes 400 on json_object
+		// with this prompt. Cerebras below is the replacement leg.
 		providers.push(buildGroqProvider('groq-llama-3.3-70b', 'llama-3.3-70b-versatile'));
+	}
+	if (env.CEREBRAS_API_KEY) {
+		// same llama-3.3-70b the prompt is already tuned against, on a free tier whose
+		// per-minute ceiling is not the binding constraint Groq's became.
+		providers.push(buildCerebrasProvider('cerebras-llama-3.3-70b', 'llama-3.3-70b'));
 	}
 	return providers;
 }

--- a/tests/unit/api/providers.test.ts
+++ b/tests/unit/api/providers.test.ts
@@ -3,7 +3,8 @@ import {
 	buildProviders,
 	buildOllamaProvider,
 	buildGoogleProvider,
-	buildGroqProvider
+	buildGroqProvider,
+	buildCerebrasProvider
 } from '../../../src/routes/api/analyze/providers';
 
 describe('buildProviders: chain composition', () => {
@@ -168,6 +169,38 @@ describe('cloud provider invariants (regression net)', () => {
 	it('groq provider configKey is GROQ_API_KEY', () => {
 		expect(buildGroqProvider('x', 'm').configKey).toBe('GROQ_API_KEY');
 	});
+
+	it('cerebras provider configKey is CEREBRAS_API_KEY', () => {
+		expect(buildCerebrasProvider('x', 'm').configKey).toBe('CEREBRAS_API_KEY');
+	});
+
+	// the whole chain has to fit the route's maxDuration of 60s or the last leg is
+	// unreachable. 30 + 15 + 12 = 57. raising any of them means raising maxDuration too
+	it('every configured leg fits inside the route maxDuration', () => {
+		const total = buildProviders({
+			GEMINI_API_KEY: 'k',
+			GROQ_API_KEY: 'k',
+			CEREBRAS_API_KEY: 'k'
+		}).reduce((sum, p) => sum + p.timeoutMs, 0);
+		expect(total).toBeLessThan(60_000);
+	});
+
+	// same reachability rule as the other cloud legs. cerebras sustains far more than
+	// this, 500 tok/s is a deliberately pessimistic floor
+	it('cerebras token budget is reachable within its timeout', () => {
+		const c = buildCerebrasProvider('x', 'm');
+		const body = JSON.parse(c.buildRequest('p', 'k').init.body as string);
+		expect((body.max_tokens / 500) * 1000).toBeLessThan(c.timeoutMs);
+	});
+
+	it('cerebras requests JSON natively and sends the key as a bearer header', () => {
+		const req = buildCerebrasProvider('x', 'm').buildRequest('p', 'secret-key');
+		const body = JSON.parse(req.init.body as string);
+		expect(body.response_format).toEqual({ type: 'json_object' });
+		expect(headersOf(req.init).Authorization).toBe('Bearer secret-key');
+		// the key must never reach the url, only the header
+		expect(req.url).not.toContain('secret-key');
+	});
 });
 
 // helper because headers init is HeadersInit (object literal in our case);
@@ -261,5 +294,33 @@ describe('buildProviders: OLLAMA_API_KEY passthrough', () => {
 			OLLAMA_API_KEY: 'sk-stranded'
 		});
 		expect(chain).toEqual([]);
+	});
+});
+
+describe('buildProviders: cerebras leg', () => {
+	// inert until the key is set, exactly like the ollama leg
+	it('is absent when CEREBRAS_API_KEY is unset', () => {
+		const chain = buildProviders({ GEMINI_API_KEY: 'k', GROQ_API_KEY: 'k' });
+		expect(chain.map((p) => p.name)).toEqual(['gemini-3.5-flash-lite', 'groq-llama-3.3-70b']);
+	});
+
+	it('appends after groq so the current chain order is unchanged', () => {
+		const chain = buildProviders({
+			GEMINI_API_KEY: 'k',
+			GROQ_API_KEY: 'k',
+			CEREBRAS_API_KEY: 'k'
+		});
+		expect(chain.map((p) => p.name)).toEqual([
+			'gemini-3.5-flash-lite',
+			'groq-llama-3.3-70b',
+			'cerebras-llama-3.3-70b'
+		]);
+	});
+
+	// groq loses its only viable model on 2026-08-16, so cerebras alone must still
+	// give a cross-vendor fallback next to google
+	it('still pairs with google once groq is dropped', () => {
+		const chain = buildProviders({ GEMINI_API_KEY: 'k', CEREBRAS_API_KEY: 'k' });
+		expect(chain.map((p) => p.name)).toEqual(['gemini-3.5-flash-lite', 'cerebras-llama-3.3-70b']);
 	});
 });


### PR DESCRIPTION
groq retires `llama-3.3-70b-versatile` on **2026-08-16**, 14 days out. it is the only free-tier model there that fits the scoring prompt, so without a replacement the chain drops to google alone and a google outage means no llm scoring at all.

### nothing on groq replaces it

measured against the real capped prompt (6,000 char resume plus 4,000 char jd) rather than published limits:

| model | tpm | verdict |
|---|---|---|
| `llama-3.3-70b-versatile` | 12,000 | works today, retires 2026-08-16 |
| `qwen/qwen3.6-27b` | 8,000 | `413 Requested 8015 / Limit 8000`, on a full window, even at `max_tokens: 1900` |
| `openai/gpt-oss-120b` | 8,000 | `400`, rejects `json_object` on this prompt |
| `openai/gpt-oss-20b` | 8,000 | `400`, same |
| `llama-3.1-8b-instant` | 6,000 | far too small |

input alone is 5,981 tokens on llama and 6,115 on qwen, the response needs 1,944, and groq reserves `input + max_tokens` up front. an 8,000 ceiling cannot hold that no matter how the output budget is tuned.

### the replacement

cerebras serves the same llama-3.3-70b the prompt is already tuned against, so output characteristics carry over rather than needing a re-measure. free tier, and the per-minute ceiling is not the binding constraint groq's became.

wired exactly like the existing ollama leg:

- env-gated on `CEREBRAS_API_KEY`, **inert when unset or empty**, so today's chain is byte-identical
- appended after groq, so current ordering and behaviour do not move
- 12s timeout keeps the chain at `30 + 15 + 12 = 57s` inside `maxDuration: 60`. the existing invariant test only covered two legs, so this adds a chain-wide guard that sums whatever is configured

verified:

| case | chain |
|---|---|
| today, no cerebras key | `[gemini, groq]` |
| empty `CEREBRAS_API_KEY=` | `[gemini, groq]` |
| key set | `[gemini, groq, cerebras]` |
| after groq retires | `[gemini, cerebras]` |

live endpoint still returns `200` with `_provider: gemini-3.5-flash-lite`, `_fallback: false`.

7 new tests covering inertness, ordering, the google-plus-cerebras pairing once groq is dropped, configKey, json mode, bearer auth, and that the key never reaches the url. 468 to 475.

### what still needs a human

`CEREBRAS_API_KEY` in `.env` is an empty placeholder, so the live cerebras call is unverified. only the wiring and the inertness are covered here. grab a free key at [cloud.cerebras.ai](https://cloud.cerebras.ai), drop it in `.env` and on vercel, and the leg activates with no code change.

no release cut. gate green on node 22 and 24.