### PR TITLE
fix(llm): passed CEREBRAS_API_KEY through the analyze route

### DIFF
--- a/scripts/test-providers.mjs
+++ b/scripts/test-providers.mjs
@@ -64,8 +64,9 @@ async function callProvider(provider, prompt, timeoutMs) {
 	const secret = envVars[provider.configKey];
 	if (!secret) return { status: 'SKIP', ms: 0, detail: `no ${provider.configKey}` };
 
-	// default to the provider's own production timeout so this mirrors the real chain
-	const budget = timeoutMs ?? provider.timeoutMs;
+	// never exceed the provider's production timeout, or this reports OK for a call the
+	// real chain would have aborted and fallen through
+	const budget = Math.min(timeoutMs ?? provider.timeoutMs, provider.timeoutMs);
 	const { url, init } = provider.buildRequest(prompt, secret);
 	const t = performance.now();
 	try {
@@ -137,12 +138,12 @@ console.log('\n=== test 2: large prompt (~6K tokens, realistic resume) ===\n');
 console.log(
 	`  prompt size: ${BIG_PROMPT.length} chars (~${Math.round(BIG_PROMPT.length / 4)} tokens)\n`
 );
-for (const p of providers) log(p.name, await callProvider(p, BIG_PROMPT, 45000));
+for (const p of providers) log(p.name, await callProvider(p, BIG_PROMPT));
 
 console.log('\n=== test 3: fallback chain simulation ===\n');
 let resolved = false;
 for (const p of providers) {
-	const r = await callProvider(p, BIG_PROMPT, 45000);
+	const r = await callProvider(p, BIG_PROMPT);
 	if (r.status === 'OK') {
 		console.log(`  resolved: ${p.name} (${r.ms}ms)`);
 		resolved = true;

--- a/src/routes/api/analyze/+server.ts
+++ b/src/routes/api/analyze/+server.ts
@@ -5,7 +5,7 @@ import { buildFullScoringPrompt, buildJDAnalysisPrompt } from '$engine/llm/promp
 import { logger } from '$lib/log';
 import { hashPrompt, getCached, setCached } from './cache';
 import { checkRateLimit } from './rate-limiter';
-import { buildProviders } from './providers';
+import { buildProviders, PROVIDER_ENV_KEYS } from './providers';
 import { resolveAuthMode } from '$lib/server/auth/config';
 
 // tries each provider in sequence until one succeeds and returns valid JSON
@@ -100,9 +100,9 @@ function extractJSON(raw: string): unknown {
 	return null;
 }
 
-// must exceed the sum of every provider timeout in the chain (30 + 15 = 45s) or the
-// last leg gets killed by the platform before it can answer, which silently turns a
-// 2-provider chain into a 1-provider one
+// must exceed the sum of every provider timeout in the chain (30 + 15 + 12 = 57s) or
+// the last leg gets killed by the platform before it can answer, which silently turns
+// a 3-provider chain into a shorter one
 export const config = {
 	maxDuration: 60
 };
@@ -127,20 +127,18 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 	// buildProviders() and defaults to llama3.2 when unset; OLLAMA_API_KEY is
 	// optional and, when set, attaches Authorization: Bearer {key} for forks
 	// running Ollama behind a reverse-proxy or hosted Ollama-compatible API.
-	const keys: Record<string, string> = {
-		GEMINI_API_KEY: env.GEMINI_API_KEY ?? '',
-		GROQ_API_KEY: env.GROQ_API_KEY ?? '',
-		OLLAMA_BASE_URL: env.OLLAMA_BASE_URL ?? '',
-		OLLAMA_MODEL: env.OLLAMA_MODEL ?? '',
-		OLLAMA_API_KEY: env.OLLAMA_API_KEY ?? ''
-	};
+	// driven off PROVIDER_ENV_KEYS so adding a provider cannot leave its key behind here
+	const keys: Record<string, string> = Object.fromEntries(
+		PROVIDER_ENV_KEYS.map((k) => [k, env[k] ?? ''])
+	);
 
 	// at least one provider must be configured. cloud-hosted instances set
-	// GEMINI/GROQ; self-hosted forks can opt into Ollama-only by setting
+	// GEMINI/GROQ/CEREBRAS; self-hosted forks can opt into Ollama-only by setting
 	// OLLAMA_BASE_URL with no cloud keys.
 	const hasAnyProvider =
 		keys.GEMINI_API_KEY.length > 0 ||
 		keys.GROQ_API_KEY.length > 0 ||
+		keys.CEREBRAS_API_KEY.length > 0 ||
 		keys.OLLAMA_BASE_URL.length > 0;
 	if (!hasAnyProvider) {
 		return json({ error: 'no LLM providers configured', fallback: true }, { status: 503 });

--- a/src/routes/api/analyze/providers.ts
+++ b/src/routes/api/analyze/providers.ts
@@ -228,6 +228,17 @@ export function buildOllamaProvider(
 // intentional: when Ollama is configured we put it first so a self-hoster who
 // also has cloud keys still defaults to local. callers without any of the
 // three configured will see an empty array and the route returns 503.
+// every env var buildProviders reads. the route copies exactly these out of $env, so a
+// name missing here silently disables a whole leg no matter how the var is configured
+export const PROVIDER_ENV_KEYS = [
+	'GEMINI_API_KEY',
+	'GROQ_API_KEY',
+	'CEREBRAS_API_KEY',
+	'OLLAMA_BASE_URL',
+	'OLLAMA_MODEL',
+	'OLLAMA_API_KEY'
+] as const;
+
 export function buildProviders(env: Record<string, string>): LLMProvider[] {
 	const providers: LLMProvider[] = [];
 	if (env.OLLAMA_BASE_URL) {

--- a/tests/unit/api/providers.test.ts
+++ b/tests/unit/api/providers.test.ts
@@ -4,7 +4,8 @@ import {
 	buildOllamaProvider,
 	buildGoogleProvider,
 	buildGroqProvider,
-	buildCerebrasProvider
+	buildCerebrasProvider,
+	PROVIDER_ENV_KEYS
 } from '../../../src/routes/api/analyze/providers';
 
 describe('buildProviders: chain composition', () => {
@@ -322,5 +323,47 @@ describe('buildProviders: cerebras leg', () => {
 	it('still pairs with google once groq is dropped', () => {
 		const chain = buildProviders({ GEMINI_API_KEY: 'k', CEREBRAS_API_KEY: 'k' });
 		expect(chain.map((p) => p.name)).toEqual(['gemini-3.5-flash-lite', 'cerebras-llama-3.3-70b']);
+	});
+});
+
+describe('PROVIDER_ENV_KEYS covers every leg', () => {
+	// deliberately hardcoded and NOT derived from PROVIDER_ENV_KEYS. deriving it makes
+	// the assertion circular: dropping a name from the list would also drop it from the
+	// env, the leg would never build, and the test would pass while the route broke
+	const EVERY_PROVIDER_ENV: Record<string, string> = {
+		GEMINI_API_KEY: 'k',
+		GROQ_API_KEY: 'k',
+		CEREBRAS_API_KEY: 'k',
+		OLLAMA_BASE_URL: 'http://127.0.0.1:11434',
+		OLLAMA_MODEL: 'llama3.2',
+		OLLAMA_API_KEY: 'k'
+	};
+
+	// the bug this exists to stop: the route copies env into a plain object before
+	// calling buildProviders, so a configKey missing from that copy silently disables
+	// a whole provider no matter how the deployment sets the variable
+	it('contains the configKey of every provider the chain can produce', () => {
+		const chain = buildProviders(EVERY_PROVIDER_ENV);
+		expect(chain.length).toBeGreaterThan(0);
+		for (const p of chain) {
+			expect(PROVIDER_ENV_KEYS).toContain(p.configKey);
+		}
+	});
+
+	// guards the hardcoded env above from going stale when a provider is added
+	it('builds one leg per vendor from a fully populated env', () => {
+		expect(buildProviders(EVERY_PROVIDER_ENV).map((p) => p.name)).toEqual([
+			'ollama-llama3.2',
+			'gemini-3.5-flash-lite',
+			'groq-llama-3.3-70b',
+			'cerebras-llama-3.3-70b'
+		]);
+	});
+
+	// read inside buildProviders but not a configKey any provider keys on, so they
+	// would be silently dropped by the route without being listed
+	it('lists the ollama tuning vars that no provider keys on', () => {
+		expect(PROVIDER_ENV_KEYS).toContain('OLLAMA_MODEL');
+		expect(PROVIDER_ENV_KEYS).toContain('OLLAMA_API_KEY');
 	});
 });


### PR DESCRIPTION
a2f5680 added the cerebras leg to `buildProviders`, but the route builds its own `keys` object out of `$env` before calling it and that object never listed `CEREBRAS_API_KEY`. the leg could never activate in production no matter how the variable was set. the feature shipped dead.

caught by copilot on #31. the isolated `buildProviders` tests all passed because they pass their own env straight in, so nothing exercised the actual call site.

the same omission hit `hasAnyProvider`, which copilot did not flag: a self-hoster running cerebras alone would have been turned away with `503 no LLM providers configured` despite having a valid provider.

### fix

`keys` is now derived from a new exported `PROVIDER_ENV_KEYS`, the single list `buildProviders` reads and the route copies. adding a provider cannot leave its variable behind again.

| env | guard | chain |
|---|---|---|
| cerebras only | pass | `[cerebras]` |
| gemini + groq (today) | pass | `[gemini, groq]` |
| all three | pass | `[gemini, groq, cerebras]` |
| nothing | 503 | `[]` |

also corrected the `maxDuration` comment, which still described a 2-leg 45s chain.

### the first regression test was vacuous

worth calling out. the initial version built its env from `PROVIDER_ENV_KEYS`:

```js
const all = Object.fromEntries(PROVIDER_ENV_KEYS.map((k) => [k, 'set']));
```

so deleting a name removed it from the env too, the leg never built, the loop never checked it, and the suite passed. it proved nothing. deleting `CEREBRAS_API_KEY` from the list still showed `42 passed`.

the env is hardcoded independently now, and the same deletion fails:

```
× contains the configKey of every provider the chain can produce
  Tests  1 failed | 42 passed
```

a second test pins the full four-leg chain so that hardcoded env cannot silently go stale.

### also

clamped the dry-run script to each provider's own timeout. it accepted a caller value of `45000` that exceeds both cloud legs, so it could report `OK` for a call the real chain would have aborted and fallen through. same class of problem as #30 fixed.

477 tests. gate green on node 22 and 24.